### PR TITLE
feat(ffi): allow to create a deamon from a private key

### DIFF
--- a/lampo-common/src/conf.rs
+++ b/lampo-common/src/conf.rs
@@ -11,6 +11,7 @@ pub struct LampoConf {
     pub ldk_conf: UserConfig,
     pub port: u64,
     pub path: String,
+    pub private_key: Option<String>,
 }
 
 impl TryFrom<String> for LampoConf {
@@ -34,12 +35,16 @@ impl TryFrom<String> for LampoConf {
         let Some(port) = port.first() else {
             anyhow::bail!("this is a bug inside the configuration parser, the vector of values is empty!");
         };
+        let private_key = conf
+            .get_conf("dev-private-key")
+            .map(|confs| confs.first().cloned().unwrap());
         Ok(Self {
             inner: conf,
             path: value,
             network: Network::from_str(network)?,
             ldk_conf: UserConfig::default(),
             port: u64::from_str(port)?,
+            private_key,
         })
     }
 }

--- a/lampod/src/lib.rs
+++ b/lampod/src/lib.rs
@@ -284,6 +284,7 @@ mod tests {
             port: 19753,
             path: "/tmp".to_string(),
             inner: CLNConf::new("/tmp/".to_owned(), true),
+            private_key: None,
         };
         let wallet = LampoWalletManager::new(conf.network).unwrap();
         let mut lampo = LampoDeamon::new(conf, Arc::new(wallet));
@@ -318,6 +319,7 @@ mod tests {
             port: 19753,
             path: "/tmp".to_string(),
             inner: CLNConf::new("/tmp/".to_owned(), true),
+            private_key: None,
         };
         let wallet = LampoWalletManager::new(conf.network).unwrap();
         let mut lampo = LampoDeamon::new(conf, Arc::new(wallet));
@@ -348,6 +350,7 @@ mod tests {
                 port: 19753,
                 path: format!("/tmp/lampo-{i}"),
                 inner: CLNConf::new("/tmp/".to_owned(), true),
+                private_key: None,
             };
             let key = bitcoin::PrivateKey::new(key, conf.network);
             let wallet = LampoWalletManager::try_from(key).unwrap();


### PR DESCRIPTION
This will add the possibility to create a deamon from the private key in the C ffi binding.

P.S: Please note that this should be available in the near future under the `lnprototest` or `developer` feature only.