### PR TITLE
fix(docs): include the raw image of the image

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <div align="center">
   <h1>Lampo SDK</h1>
 
-  <img src="https://github.com/saradurante/lampo.docs/blob/dc0dce971c3052f0e9dd668fdf0c7376b12fee7b/imgs/web/icon-512.png"  width="150" height="150" />
+  <img src="https://github.com/saradurante/lampo.docs/blob/dc0dce971c3052f0e9dd668fdf0c7376b12fee7b/imgs/web/icon-512.png?raw=true"  width="150" height="150" />
 
 
   <p>


### PR DESCRIPTION
This commit fixes the radicle web markdown by adding the raw keyword, to the link.

Link: https://radicle.zulipchat.com/#narrow/stream/369278-web/topic/.E2.9C.94.20loading.20image.20in.20the.20markdown.20with.20html
Suggeted-by: @sebastinez