### PR TITLE
fix: added the '..' to ignore the missing fields explicitly

### DIFF
--- a/lampod/src/actions/handler.rs
+++ b/lampod/src/actions/handler.rs
@@ -153,6 +153,7 @@ impl Handler for LampoHandler {
                 channel_id,
                 user_channel_id,
                 reason,
+                ..
             } => {
                 log::info!("channel `{user_channel_id}` closed with reason: `{reason}`");
                 Ok(())


### PR DESCRIPTION
This was the error I got while I was compiling lampo :

```
error[E0027]: pattern does not mention fields `counterparty_node_id`, `channel_capacity_sats`
   --> lampod/src/actions/handler.rs:152:13
    |
152 | /             ldk::Event::ChannelClosed {
153 | |                 channel_id,
154 | |                 user_channel_id,
155 | |                 reason,
156 | |             } => {
    | |_____________^ missing fields `counterparty_node_id`, `channel_capacity_sats`
    |
help: include the missing fields in the pattern
    |
155 |                 reason, counterparty_node_id, channel_capacity_sats } => {
    |                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
help: if you don't care about these missing fields, you can explicitly ignore them
    |
155 |                 reason, .. } => {
    |                       ~~~~~~
```