### PR TITLE
bitcoind: do not unwrap the result

### DIFF
--- a/lampo-bitcoind/src/lib.rs
+++ b/lampo-bitcoind/src/lib.rs
@@ -159,12 +159,7 @@ impl Backend for BitcoinCore {
     }
 
     fn minimum_mempool_fee(&self) -> error::Result<u32> {
-        let fee = self
-            .inner
-            .get_mempool_info()
-            .unwrap()
-            .mempool_min_fee
-            .to_sat() as u32;
+        let fee = self.inner.get_mempool_info()?.mempool_min_fee.to_sat() as u32;
         Ok(fee)
     }
 


### PR DESCRIPTION
This fixes one of the bug that I founds in one of my node run where we was unwrap a result.

This will improve the error handling, but the solution is to denay the unwrap, See [1] for more info.

The stacktrace that this unwrap will produce will be:

```
2023-08-17T10:25:48.730Z DEBUG bitcoincore_rpc JSON-RPC request: estimatesmartfee [10]
2023-08-17T10:26:06.375Z TRACE bitcoincore_rpc JSON-RPC response for estimatesmartfee: {"feerate":0.00001000,"blocks":10}
2023-08-17T10:26:06.375Z DEBUG bitcoincore_rpc JSON-RPC request: getmempoolinfo []
2023-08-17T10:26:22.223Z DEBUG bitcoincore_rpc JSON-RPC failed parsing reply of getmempoolinfo: JsonRpc(Transport(SocketError(Os { code: 11, kind: WouldBlock, message: "Resource temporarily unavailable" })))
thread '<unnamed>' panicked at 'called `Result::unwrap()` on an `Err` value: JsonRpc(Transport(SocketError(Os { code: 11, kind: WouldBlock, message: "Resource temporarily unavailable" })))', lampo-bitcoind/src/lib.rs:165:14
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

Fixes https://github.com/dart-lightning/lampo.rs/issues/97

[1] https://rust-lang.zulipchat.com/#narrow/stream/257328-clippy/topic/safety.20comment.20for.20.60unwrap_used.60
Signed-off-by: Vincenzo Palazzo <vincenzopalazzodev@gmail.com>