### PR TITLE
Remove Unnecessary `#[cfg(debug_assertions)]` Statements

### DIFF
--- a/lampo-c-ffi/src/lib.rs
+++ b/lampo-c-ffi/src/lib.rs
@@ -100,6 +100,7 @@ fn init_logger() {
 #[no_mangle]
 #[allow(unused_variables)]
 #[allow(unused_assignments)]
+#[cfg(debug_assertions)]
 pub extern "C" fn new_lampod(conf_path: *const libc::c_char) -> *mut LampoDeamon {
     use lampo_common::bitcoin;
     use lampo_common::conf::LampoConf;


### PR DESCRIPTION
## Changes
Some of the `#[cfg(debug_assertions)]` statements were removed. 

## Description
These statements were conditional compilation attributes applied to several functions and a `TryFrom` implementation. These functions were used in various parts of the code. This removal ensures a smoother build process and resolves the encountered problem.

Fixes #121 