### PR TITLE
Updated `Makefile` to Use `cargo install` with `--locked` Flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,8 +17,8 @@ clean:
 
 install:
 	$(CC) build
-	$(CC) install --path ./lampo-cli
-	$(CC) install --path ./lampod-cli --debug
+	$(CC) install --locked --path ./lampo-cli 
+	$(CC) install --locked --path ./lampod-cli --debug
 	sudo cp target/debug/liblampo.so /usr/local/lib
 
 integration: default


### PR DESCRIPTION
## Changes
In the `Makefile`, the `cargo install` commands for `lampo-cli` and `lampod-cli` were modified to include the `--locked` flag. 

## Description
This change ensures that `cargo update` is not automatically executed during the installation process. 
The `--locked` flag locks dependencies to their current versions.

## Note
The line `sudo cp target/debug/liblampo.so /usr/local/lib` in the `Makefile` may not work as expected on macOS, as the shared library file extension is typically `.dylib` on this platform.

Fixes #117