### PR TITLE
Improve Error Handling in CLI Parsing

### DIFF
--- a/lampo-cli/src/args.rs
+++ b/lampo-cli/src/args.rs
@@ -92,9 +92,15 @@ pub fn parse_args() -> Result<LampoCliArgs, lexopt::Error> {
 
     log::debug!("args parser are {:?} {:?}", method, args);
     Ok(LampoCliArgs {
-        socket: socket.expect("Socket path need to be specified"),
-        method: method
-            .expect("Too few params, a method need to be specified. Try run `lampo-cli --help`"),
+        socket: socket.ok_or_else(|| lexopt::Error::MissingValue {
+            option: Some("Socket path need to be specified".to_owned()),
+        })?,
+        method: method.ok_or_else(|| lexopt::Error::MissingValue {
+            option: Some(
+                "Too few params, a method need to be specified. Try run `lampo-cli --hel"
+                    .to_owned(),
+            ),
+        })?,
         args,
     })
 }

--- a/lampod-cli/src/args.rs
+++ b/lampod-cli/src/args.rs
@@ -89,7 +89,9 @@ pub fn parse_args() -> Result<LampoCliArgs, lexopt::Error> {
     }
 
     Ok(LampoCliArgs {
-        conf: config.expect("Configuration option need to be specified"),
+        conf: config.ok_or_else(|| lexopt::Error::MissingValue {
+            option: Some("config is not specified".to_owned()),
+        })?,
         network,
         client,
         mnemonic,


### PR DESCRIPTION
This pull request addresses a common issue in the `lampo-cli` and `lampod-cli`.
Improved error handling during command-line argument parsing to enhance the user experience and prevent unnecessary panics.