### PR TITLE
feat: improve configuration handling and implement default for LampoConf

### DIFF
--- a/lampo-bitcoind/src/lib.rs
+++ b/lampo-bitcoind/src/lib.rs
@@ -145,6 +145,10 @@ impl BitcoinCore {
 }
 
 impl Backend for BitcoinCore {
+    fn kind(&self) -> lampo_common::backend::BackendKind {
+        lampo_common::backend::BackendKind::Core
+    }
+
     fn brodcast_tx(&self, tx: &lampo_common::backend::Transaction) {
         // FIXME: check the result.
         let result: bitcoincore_rpc::Result<json::Value> = self.inner.call(

--- a/lampo-common/src/backend.rs
+++ b/lampo-common/src/backend.rs
@@ -25,8 +25,17 @@ pub enum TxResult {
     Discarded,
 }
 
+/// Backend kind supported by the lampo
+pub enum BackendKind {
+    Core,
+    Nakamoto,
+}
+
 /// Bakend Trait specification
 pub trait Backend {
+    /// Return the kind of backend
+    fn kind(&self) -> BackendKind;
+
     /// Fetch feerate give a number of blocks
     fn fee_rate_estimation(&self, blocks: u64) -> error::Result<u32>;
 

--- a/lampo-common/src/conf.rs
+++ b/lampo-common/src/conf.rs
@@ -7,11 +7,11 @@ pub use lightning::util::config::UserConfig;
 
 #[derive(Clone, Debug)]
 pub struct LampoConf {
-    pub inner: CLNConf,
+    pub inner: Option<CLNConf>,
     pub network: Network,
     pub ldk_conf: UserConfig,
     pub port: u64,
-    pub path: String,
+    pub root_path: String,
     /// The backend implementation
     pub node: String,
     pub core_url: Option<String>,
@@ -22,14 +22,23 @@ pub struct LampoConf {
 }
 
 impl LampoConf {
-    pub fn new(path: &str, network: Network, port: u64) -> Self {
+    // Create a new LampoConf with default values (This is used if the user doesn't specify a path)
+    pub fn default() -> Self {
+        // default path for the configuration file
+        // (use deprecated std::env::home_dir() to avoid a dependency on dirs)
+        #[allow(deprecated)]
+        let path = std::env::home_dir().expect("Impossible to get the home directory");
+        let path = path.to_str().unwrap();
+        let lampo_home = format!("{}/.lampo", path);
         Self {
-            inner: CLNConf::new(format!("{path}/lampo.conf"), true),
-            network,
+            inner: None,
+            // default network is testnet
+            network: Network::Testnet,
             ldk_conf: UserConfig::default(),
-            port,
-            path: path.to_string(),
-            node: "core".to_owned(),
+            // default port is 19735 for testnet
+            port: 19735,
+            root_path: lampo_home,
+            node: "nakamoto".to_owned(),
             core_url: None,
             core_user: None,
             core_pass: None,
@@ -37,13 +46,69 @@ impl LampoConf {
             channels_keys: None,
         }
     }
+
+    pub fn prepare_dirs(&self) -> Result<(), anyhow::Error> {
+        Self::prepare_directories(&self.root_path, Some(self.network))
+    }
+
+    pub fn prepare_directories(
+        root_path: &str,
+        network: Option<Network>,
+    ) -> Result<(), anyhow::Error> {
+        // make sure that the data-dir exist
+        if !std::path::Path::new(root_path).exists() {
+            log::info!("Creating root dir at `{}`", root_path);
+            std::fs::create_dir(root_path)?;
+        }
+
+        if let Some(network) = network {
+            let network_path = format!("{root_path}/{network}");
+            if !std::path::Path::new(&network_path).exists() {
+                log::info!("Creating network directory at `{network_path}`");
+                std::fs::create_dir(network_path)?;
+            }
+        }
+        Ok(())
+    }
+
+    pub fn new(
+        path: Option<String>,
+        network: Option<Network>,
+        port: Option<u64>,
+    ) -> Result<Self, anyhow::Error> {
+        let mut conf = Self::default();
+        conf.network = network.unwrap_or(conf.network);
+        conf.port = port.unwrap_or(conf.port);
+        conf.root_path = path.unwrap_or(conf.root_path);
+        Self::prepare_directories(&conf.root_path, Some(conf.network))?;
+
+        let path = format!("{}/{}", conf.root_path, conf.network);
+        // if the path doesn't exist, return an error
+        if std::fs::File::open(&path).is_ok() {
+            conf.inner = Some(CLNConf::new(path, false));
+        }
+
+        Ok(conf)
+    }
 }
 
 impl TryFrom<String> for LampoConf {
     type Error = anyhow::Error;
 
     fn try_from(value: String) -> Result<Self, Self::Error> {
+        Self::prepare_directories(&value, None)?;
+
         let path = format!("{value}/lampo.conf");
+        // Check for double slashes
+        let path = path.replace("//", "/");
+
+        // If lampo.conf doesn't exist, return the default configuration
+        if !std::path::Path::new(&path).exists() {
+            let mut conf = Self::default();
+            conf.root_path = value;
+            return Ok(conf);
+        }
+
         let mut conf = CLNConf::new(path, false);
         conf.parse()
             .map_err(|err| anyhow::anyhow!("{}", err.cause))?;
@@ -68,22 +133,26 @@ impl TryFrom<String> for LampoConf {
         // Strip the value of whitespace
         let node = node.to_trimmed();
 
-        let core_url = conf
-            .get_conf("core-url")
-            .map_err(|err| anyhow::anyhow!("{err}"))?;
-        // If the value isn't none, strip the value of whitespace
-        let core_url = core_url.map(|url| url.to_trimmed());
+        let mut core_url = None;
+        let mut core_user = None;
+        let mut core_pass = None;
+        if node == "core" {
+            core_url = conf
+                .get_conf("core-url")
+                .map_err(|err| anyhow::anyhow!("{err}"))?;
+            // If the value isn't none, strip the value of whitespace
+            core_url = core_url.map(|url| url.to_trimmed());
 
-        let core_user = conf
-            .get_conf("core-user")
-            .map_err(|err| anyhow::anyhow!("{err}"))?;
-        let core_user = core_user.map(|user| user.to_trimmed());
+            core_user = conf
+                .get_conf("core-user")
+                .map_err(|err| anyhow::anyhow!("{err}"))?;
+            core_user = core_user.map(|user| user.to_trimmed());
 
-        let core_pass = conf
-            .get_conf("core-pass")
-            .map_err(|err| anyhow::anyhow!("{err}"))?;
-        let core_pass = core_pass.map(|pass| pass.to_trimmed());
-
+            core_pass = conf
+                .get_conf("core-pass")
+                .map_err(|err| anyhow::anyhow!("{err}"))?;
+            core_pass = core_pass.map(|pass| pass.to_trimmed());
+        }
         // Dev options
         #[allow(unused_mut, unused_assignments)]
         let mut private_key: Option<String> = None;
@@ -102,8 +171,8 @@ impl TryFrom<String> for LampoConf {
         }
 
         Ok(Self {
-            inner: conf,
-            path: value,
+            inner: Some(conf),
+            root_path: value.clone(),
             network: Network::from_str(&network)?,
             ldk_conf: UserConfig::default(),
             port: u64::from_str(&port)?,
@@ -119,19 +188,23 @@ impl TryFrom<String> for LampoConf {
 
 impl LampoConf {
     pub fn path(&self) -> String {
-        self.path.clone()
+        format!("{}/{}", self.root_path, self.network)
     }
 
-    pub fn get_values(&self, key: &str) -> Vec<String> {
-        self.inner.get_confs(key)
+    pub fn get_values(&self, key: &str) -> Option<Vec<String>> {
+        match self.inner {
+            Some(ref conf) => Some(conf.get_confs(key)),
+            None => None,
+        }
     }
 
     pub fn get_value(&self, key: &str) -> Result<Option<String>, anyhow::Error> {
-        let Some(value) = self
+        let conf = self
             .inner
-            .get_conf(key)
-            .map_err(|err| anyhow::anyhow!("{err}"))?
-        else {
+            .as_ref()
+            .ok_or_else(|| anyhow::anyhow!("Lampo configuration was not loaded"))?;
+
+        let Some(value) = conf.get_conf(key).map_err(|err| anyhow::anyhow!("{err}"))? else {
             return Ok(None);
         };
         Ok(Some(value))

--- a/lampo-nakamoto/src/lib.rs
+++ b/lampo-nakamoto/src/lib.rs
@@ -41,6 +41,7 @@ impl Nakamoto {
         let url = match config.network.as_str() {
             "bitcoin" => "https://blockstream.info/api",
             "testnet" => "https://blockstream.info/testnet/api",
+            "signet" => "https://mempool.space/signet/api",
             _ => {
                 return Err(error::anyhow!(
                     "network {} not supported",
@@ -75,6 +76,10 @@ impl Nakamoto {
 
 #[allow(unused_variables)]
 impl Backend for Nakamoto {
+    fn kind(&self) -> lampo_common::backend::BackendKind {
+        lampo_common::backend::BackendKind::Nakamoto
+    }
+
     fn get_block<'a>(
         &'a self,
         header_hash: &'a nakamoto_common::block::BlockHash,

--- a/lampo-testing/src/lib.rs
+++ b/lampo-testing/src/lib.rs
@@ -76,10 +76,11 @@ impl LampoTesting {
         let port = port::random_free_port().unwrap();
 
         let mut lampo_conf = LampoConf::new(
-            dir.path().to_str().unwrap(),
-            lampo_common::bitcoin::Network::Regtest,
-            port.into(),
-        );
+            // FIXME: this is bad we should wrap this logic
+            Some(dir.path().to_string_lossy().to_string()),
+            Some(lampo_common::bitcoin::Network::Regtest),
+            Some(port.into()),
+        )?;
         let core_url = format!("127.0.0.1:{}", btc.port);
         lampo_conf.core_pass = Some(btc.pass.clone());
         lampo_conf.core_url = Some(core_url);

--- a/lampod-cli/src/main.rs
+++ b/lampod-cli/src/main.rs
@@ -47,13 +47,40 @@ fn main() -> error::Result<()> {
 
 /// Return the root directory.
 fn run(args: LampoCliArgs) -> error::Result<()> {
-    let path = args.conf;
-    let mut lampo_conf = LampoConf::try_from(path)?;
-    if args.network.is_some() {
-        lampo_conf.set_network(&args.network.unwrap())?;
-    }
+    let mnemonic = args.mnemonic.clone();
 
+    // After this point the configuration is ready!
+    let lampo_conf: LampoConf = args.try_into()?;
     log::debug!(target: "lampod-cli", "init wallet ..");
+
+    // Prepare the backend
+    let client = lampo_conf.node.clone();
+    log::debug!(target: "lampod-cli", "lampo running with `{client}` backend");
+    let client: Arc<dyn Backend> = match client.as_str() {
+        "nakamoto" => {
+            let mut conf = Config::default();
+            conf.network = Network::from_str(&lampo_conf.network.to_string()).unwrap();
+            Arc::new(Nakamoto::new(conf).unwrap())
+        }
+        "core" => Arc::new(BitcoinCore::new(
+            &lampo_conf
+                .core_url
+                .clone()
+                .ok_or(error::anyhow!("Miss the bitcoin url"))?,
+            &lampo_conf
+                .core_user
+                .clone()
+                .ok_or(error::anyhow!("Miss the bitcoin user for auth"))?,
+            &lampo_conf
+                .core_pass
+                .clone()
+                .ok_or(error::anyhow!("Miss the bitcoin password for auth"))?,
+            Arc::new(false),
+            Some(60),
+        )?),
+        _ => error::bail!("client {:?} not supported", client),
+    };
+
     let wallet = if let Some(ref private_key) = lampo_conf.private_key {
         #[cfg(debug_assertions)]
         {
@@ -64,8 +91,16 @@ fn run(args: LampoCliArgs) -> error::Result<()> {
         }
         #[cfg(not(debug_assertions))]
         unimplemented!()
-    } else if args.mnemonic.is_none() {
-        let (wallet, mnemonic) = CoreWalletManager::new(Arc::new(lampo_conf.clone()))?;
+    } else if mnemonic.is_none() {
+        let (wallet, mnemonic) = match client.kind() {
+            lampo_common::backend::BackendKind::Core => {
+                CoreWalletManager::new(Arc::new(lampo_conf.clone()))?
+            }
+            lampo_common::backend::BackendKind::Nakamoto => {
+                error::bail!("wallet is not implemented for nakamoto")
+            }
+        };
+
         radicle_term::success!("Wallet Generated, please store this works in a safe way");
         radicle_term::println(
             radicle_term::format::badge_primary("waller-keys"),
@@ -73,41 +108,32 @@ fn run(args: LampoCliArgs) -> error::Result<()> {
         );
         wallet
     } else {
-        // SAFETY: It is safe to unwrap the mnemonic because we check it
-        // before.
-        CoreWalletManager::restore(Arc::new(lampo_conf.clone()), &args.mnemonic.unwrap())?
+        match client.kind() {
+            lampo_common::backend::BackendKind::Core => {
+                // SAFETY: It is safe to unwrap the mnemonic because we check it
+                // before.
+                CoreWalletManager::restore(Arc::new(lampo_conf.clone()), &mnemonic.unwrap())?
+            }
+            lampo_common::backend::BackendKind::Nakamoto => {
+                error::bail!("wallet is not implemented for nakamoto")
+            }
+        }
     };
     log::debug!(target: "lampod-cli", "wallet created with success");
     let mut lampod = LampoDeamon::new(lampo_conf.clone(), Arc::new(wallet));
-    let client = args.client.unwrap_or(lampo_conf.node.clone());
-    let client: Arc<dyn Backend> = match client.as_str() {
-        "nakamoto" => {
-            let mut conf = Config::default();
-            conf.network = Network::from_str(&lampo_conf.network.to_string()).unwrap();
-            Arc::new(Nakamoto::new(conf).unwrap())
-        }
-        "core" => Arc::new(BitcoinCore::new(
-            &args
-                .bitcoind_url
-                .unwrap_or(lampo_conf.core_url.clone().unwrap()),
-            &args
-                .bitcoind_user
-                .unwrap_or(lampo_conf.core_user.clone().unwrap()),
-            &args
-                .bitcoind_pass
-                .unwrap_or(lampo_conf.core_pass.clone().unwrap()),
-            Arc::new(false),
-            Some(60),
-        )?),
-        _ => error::bail!("client {:?} not supported", client),
-    };
+
+    // Init the lampod
     lampod.init(client)?;
 
     let rpc_handler = Arc::new(CommandHandler::new(&lampo_conf)?);
     lampod.add_external_handler(rpc_handler.clone())?;
 
-    let mut _pid = filelock_rs::pid::Pid::new(lampo_conf.path, "lampod".to_owned())
-        .map_err(|_| error::anyhow!("impossible take a lock on the `lampod.pid` file, maybe there is another instance running?"))?;
+    log::debug!(target: "lampod-cli", "Lampo directory `{}`", lampo_conf.path());
+    let mut _pid = filelock_rs::pid::Pid::new(lampo_conf.path(), "lampod".to_owned())
+        .map_err(|err| {
+            log::error!("{err}");
+            error::anyhow!("impossible take a lock on the `lampod.pid` file, maybe there is another instance running?")
+        })?;
 
     let lampod = Arc::new(lampod);
     let (jsorpc_worker, handler) = run_jsonrpc(lampod.clone()).unwrap();

--- a/lampod/src/lib.rs
+++ b/lampod/src/lib.rs
@@ -319,8 +319,8 @@ mod tests {
             ldk_conf: UserConfig::default(),
             network: bitcoin::Network::Testnet,
             port: 19753,
-            path: "/tmp".to_string(),
-            inner: CLNConf::new("/tmp/".to_owned(), true),
+            root_path: "/tmp".to_string(),
+            inner: Some(CLNConf::new("/tmp/".to_owned(), true)),
             private_key: None,
             channels_keys: None,
             node: String::from("nakamoto"),
@@ -359,8 +359,8 @@ mod tests {
             ldk_conf: UserConfig::default(),
             network: bitcoin::Network::Testnet,
             port: 19753,
-            path: "/tmp".to_string(),
-            inner: CLNConf::new("/tmp/".to_owned(), true),
+            root_path: "/tmp".to_string(),
+            inner: Some(CLNConf::new("/tmp/".to_owned(), true)),
             private_key: None,
             channels_keys: None,
             node: String::from("nakamoto"),
@@ -368,6 +368,7 @@ mod tests {
             core_url: None,
             core_user: None,
         };
+        conf.prepare_dirs().unwrap();
         let (wallet, _) = BDKWalletManager::new(conf.clone().into()).unwrap();
         let mut lampo = LampoDeamon::new(conf, Arc::new(wallet));
 
@@ -396,8 +397,8 @@ mod tests {
                 ldk_conf: UserConfig::default(),
                 network: bitcoin::Network::Testnet,
                 port: 19753,
-                path: format!("/tmp/lampo-{i}"),
-                inner: CLNConf::new("/tmp/".to_owned(), true),
+                root_path: format!("/tmp/lampo-{i}"),
+                inner: Some(CLNConf::new("/tmp/".to_owned(), true)),
                 private_key: None,
                 channels_keys: None,
 
@@ -406,6 +407,7 @@ mod tests {
                 core_url: None,
                 core_user: None,
             };
+            conf.prepare_dirs().unwrap();
             let key = bitcoin::PrivateKey::new(key, conf.network);
             let wallet = BDKWalletManager::try_from((key, None)).unwrap();
 
@@ -443,8 +445,8 @@ mod tests {
                 ldk_conf: UserConfig::default(),
                 network: bitcoin::Network::Testnet,
                 port: 19753,
-                path: format!("/tmp/lampo-{i}"),
-                inner: CLNConf::new("/tmp/".to_owned(), true),
+                root_path: format!("/tmp/lampo-{i}"),
+                inner: Some(CLNConf::new("/tmp/".to_owned(), true)),
                 private_key: None,
                 channels_keys: None,
 

--- a/lampod/src/ln/channe_manager.rs
+++ b/lampod/src/ln/channe_manager.rs
@@ -314,7 +314,7 @@ impl LampoChannelManager {
     pub fn is_restarting(&self) -> error::Result<bool> {
         Ok(Path::exists(Path::new(&format!(
             "{}/manager",
-            self.conf.path
+            self.conf.path()
         ))))
     }
 
@@ -336,7 +336,7 @@ impl LampoChannelManager {
             self.conf.ldk_conf,
             monitors,
         );
-        let mut channel_manager_file = File::open(format!("{}/manager", self.conf.path))?;
+        let mut channel_manager_file = File::open(format!("{}/manager", self.conf.path()))?;
         let (_, channel_manager) =
             <(BlockHash, LampoChannel)>::read(&mut channel_manager_file, read_args)
                 .map_err(|err| error::anyhow!("{err}"))?;


### PR DESCRIPTION
In this commit, we've made the following enhancements to Lampo:

1. Renamed the command parameter in lampod-cli from config to data-dir for improved clarity and alignment with the updates made.
2. Modified the logic to override the configuration file. Now, the configuration file will only be overridden when values from the command parameters are set.
3. Modified the LampoConf struct to make the inner field optional. This change allows us to handle cases where the user doesn't specify a configuration file in the command line. When the inner field is not provided, Lampo will use default configuration settings.

Pushing this to the finish line from https://github.com/vincenzopalazzo/lampo.rs/pull/141

Pushing as another PR just to run the CI