### PR TITLE
fix(lampod-cli): fixes the args handling precedence

### DIFF
--- a/lampo-bitcoind/src/lib.rs
+++ b/lampo-bitcoind/src/lib.rs
@@ -63,6 +63,7 @@ impl BitcoinCore {
         // FIXME: the bitcoincore_rpc do not support the https protocol.
         use bitcoincore_rpc::Auth;
 
+        log::debug!(target: "lampo-bitcoind", "Connecting to bitcoin backend at `{url}`");
         let client = Client::new(url, Auth::UserPass(user.to_owned(), pass.to_owned()))?;
         // FIXME: grab some information from the blockchain, eg. Network
         Ok(Self {


### PR DESCRIPTION
This is fixing a bug that was funding by tarek and the lampo configuration was not able handle correctly the args conf with the file conf.

Alternative version of https://github.com/vincenzopalazzo/lampo.rs/pull/149 but it is still not completed

Fixes https://github.com/vincenzopalazzo/lampo.rs/issues/3

Co-Developed: Tarek <tareknaser360@gmail.com>