### PR TITLE
fix : fixes error caused by bad input request

### DIFF
--- a/lampo-common/src/model/connect.rs
+++ b/lampo-common/src/model/connect.rs
@@ -19,9 +19,13 @@ impl Connect {
         NodeId::from_str(&self.node_id).unwrap()
     }
 
-    pub fn addr(&self) -> SocketAddr {
+    pub fn addr(&self) -> error::Result<SocketAddr> {
         let addr = format!("{}:{}", self.addr, self.port);
-        SocketAddr::from_str(&addr).unwrap()
+        let result = SocketAddr::from_str(&addr);
+        match result {
+            Ok(res) => Ok(res),
+            Err(e) => Err(e.into()),
+        }
     }
 }
 

--- a/lampod/src/jsonrpc/peer_control.rs
+++ b/lampod/src/jsonrpc/peer_control.rs
@@ -9,13 +9,26 @@ use crate::{ln::events::PeerEvents, LampoDeamon};
 pub fn json_connect(ctx: &LampoDeamon, request: &json::Value) -> Result<json::Value, Error> {
     log::info!("call for `connect` with request `{:?}`", request);
     let input: Connect = json::from_value(request.clone())?;
-
-    ctx.rt
-        .block_on(ctx.peer_manager().connect(input.node_id(), input.addr()))
-        .map_err(|err| RpcError {
-            code: -1,
-            message: format!("{err}"),
-            data: None,
-        })?;
-    Ok(request.clone())
+    let host = input.addr();
+    let result = match host {
+        Err(err) => {
+            let rpc_error = Error::Rpc(RpcError {
+                code: -1,
+                message: format!("{err}"),
+                data: None,
+            });
+            Err(rpc_error)
+        }
+        Ok(host_value) => {
+            ctx.rt
+                .block_on(ctx.peer_manager().connect(input.node_id(), host_value))
+                .map_err(|err| RpcError {
+                    code: -1,
+                    message: format!("{err}"),
+                    data: None,
+                })?;
+            Ok(request.clone())
+        }
+    };
+    result
 }

--- a/lampod/src/lib.rs
+++ b/lampod/src/lib.rs
@@ -348,7 +348,7 @@ mod tests {
             lampo.rt,
             lampo
                 .peer_manager()
-                .connect(connect.node_id(), connect.addr())
+                .connect(connect.node_id(), connect.addr().unwrap())
         );
         assert!(result.is_ok(), "{:?}", result);
     }


### PR DESCRIPTION
## Current state
For now when we call the `connect` method with bad address like "127.0.0". This will cause the crash as the unwrap [here](https://github.com/vincenzopalazzo/lampo.rs/blob/d76ce7647743e444f0ce410b3f749280b9980718/lampod/src/jsonrpc/peer_control.rs#L14) will be called with bad input.

For now :
```
harshit@harshit:~$ lampo-cli --socket /home/harshit/.lampo/testnet/lampod.socket connect --node_id 02b438e989282bb726f575ef356b45163aa37dc074fde9951f122774f3407485f8 --addr 127.0.1 --port 19735
✗ Malformed RPC response
```
Output is  :

```
2023-12-18T21:11:44.273Z TRACE jsonrpc request Request { method: "connect", params: Object {"addr": String("127.0.1"), "port": Number(19735), "node_id": String("02b438e989282bb726f575ef356b45163aa37dc074fde9951f122774f3407485f8")}, id: Some(Str("0")), jsonrpc: "2.0" }. [lampo-jsonrpc/src/lib.rs:237]
2023-12-18T21:11:44.273Z INFO lampod::jsonrpc::peer_control call for `connect` with request `Object {"addr": String("127.0.1"), "port": Number(19735), "node_id": String("02b438e989282bb726f575ef356b45163aa37dc074fde9951f122774f3407485f8")}`. [lampod/src/jsonrpc/peer_control.rs:10]
thread '<unnamed>' panicked at 'called `Result::unwrap()` on an `Err` value: AddrParseError(Socket)', lampo-common/src/model/connect.rs:24:37
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```
as stated in #153 

## Changes made in this PR
- Changed the addr method to return a result instead of `SocketAddr`.
- In `peer_control.rs` if the `input.addr()` method returns an error we simply return that error as an `rpc error`. (Should there be something to change here?)
- In `lampod/src/lib.rs` changed `connect.addr()` -> `connect.addr().unwrap()` for successful completion of the test.


## Output after this PR

```
harshit@harshit:~$ lampo-cli --socket /home/harshit/.lampo/testnet/lampod.socket connect --node_id 02b438e989282bb726f575ef356b45163aa37dc074fde9951f122774f3407485f8 --addr 127.0.1 --port 19735
{
  "code": -1,
  "message": "invalid socket address syntax",
  "data": null
}
```

```
2023-12-18T21:31:06.356Z INFO lampod::jsonrpc::peer_control call for `connect` with request `Object {"port": Number(19735), "node_id": String("02b438e989282bb726f575ef356b45163aa37dc074fde9951f122774f3407485f8"), "addr": String("127.0.1")}`. [lampod/src/jsonrpc/peer_control.rs:10]
2023-12-18T21:31:06.356Z TRACE jsonrpc send response: `Response { result: None, error: Some(RpcError { code: -1, message: "invalid socket address syntax", data: None }), id: Str("0"), jsonrpc: "2.0" }`. [lampo-jsonrpc/src/lib.rs:257]
```

Potential fix #133 