### PR TITLE
lampod-cli: redirect logs on file

### DIFF
--- a/lampo-c-ffi/src/lib.rs
+++ b/lampo-c-ffi/src/lib.rs
@@ -3,10 +3,10 @@
 use std::cell::Cell;
 use std::sync::Arc;
 use std::sync::Mutex;
-use std::sync::Once;
 
 use lampo_bitcoind::BitcoinCore;
 use lampo_common::backend::Backend;
+use std::sync::Once;
 
 pub use lampod::LampoDeamon;
 
@@ -84,7 +84,7 @@ fn init_logger() {
         // ignore error
         INIT.call_once(|| {
             use lampo_common::logger;
-            logger::init(logger::Level::Debug).expect("Unable to init the logger");
+            logger::init("trace", None).expect("Unable to init the logger");
         });
     }
 

--- a/lampo-cli/src/main.rs
+++ b/lampo-cli/src/main.rs
@@ -4,17 +4,14 @@ use std::process::exit;
 
 use radicle_term as term;
 
+use lampo_client::errors::Error;
 use lampo_client::UnixClient;
 use lampo_common::error;
 use lampo_common::json;
-use lampo_common::logger;
 
 use crate::args::LampoCliArgs;
 
 fn main() -> error::Result<()> {
-    use lampo_client::errors::Error;
-
-    logger::init(log::Level::Info).unwrap();
     let args = match args::parse_args() {
         Ok(args) => args,
         Err(err) => {

--- a/lampo-common/src/logger.rs
+++ b/lampo-common/src/logger.rs
@@ -1,14 +1,21 @@
 //! Logging module.
 ///
 /// Credit to https://github.com/vincenzopalazzo/nakamoto/blob/master/node/src/logger.rs
-use std::{io, time::SystemTime};
+use std::io;
+use std::path::PathBuf;
+use std::str::FromStr;
+use std::time::SystemTime;
+// FIXME: this is not async we should modify it
+use std::fs::File;
 
 use chrono::prelude::*;
 use colored::*;
+
 pub use log::{Level, Log, Metadata, Record, SetLoggerError};
 
 struct Logger {
     level: Level,
+    file: Option<File>,
 }
 
 impl Log for Logger {
@@ -20,8 +27,8 @@ impl Log for Logger {
         if self.enabled(record.metadata()) {
             let target = record.target();
 
-            if record.level() == Level::Error {
-                write(record, target, io::stderr());
+            if let Some(ref file) = self.file {
+                write(record, target, file);
             } else {
                 write(record, target, io::stdout());
             }
@@ -60,10 +67,16 @@ impl Log for Logger {
 }
 
 /// Initialize a new logger.
-pub fn init(level: Level) -> Result<(), SetLoggerError> {
-    let logger = Logger { level };
+pub fn init(level: &str, file: Option<PathBuf>) -> anyhow::Result<()> {
+    let file = if let Some(path) = file {
+        Some(File::open(path)?)
+    } else {
+        None
+    };
+    let level = Level::from_str(level).map_err(|err| anyhow::anyhow!("{err}"))?;
+    let logger = Logger { level, file };
 
-    log::set_boxed_logger(Box::new(logger))?;
+    log::set_boxed_logger(Box::new(logger)).map_err(|err| anyhow::anyhow!("{err}"))?;
     log::set_max_level(level.to_level_filter());
 
     Ok(())

--- a/lampod-cli/src/args.rs
+++ b/lampod-cli/src/args.rs
@@ -24,6 +24,9 @@ Options
     -d | --data-dir    Override the default path of the config field
     -n | --network     Set the network for lampo
     -h | --help        Print help
+
+    --log-file         Redirect the lampo logs on the file
+    --log-level        Set the log level, by default is `info`
     --client           Set the default lampo bitcoin backend
 "#,
 };
@@ -34,6 +37,8 @@ pub struct LampoCliArgs {
     pub network: Option<String>,
     pub client: Option<String>,
     pub mnemonic: Option<String>,
+    pub log_level: String,
+    pub log_file: Option<String>,
     pub bitcoind_url: Option<String>,
     pub bitcoind_user: Option<String>,
     pub bitcoind_pass: Option<String>,
@@ -90,6 +95,8 @@ pub fn parse_args() -> Result<LampoCliArgs, lexopt::Error> {
     use lexopt::prelude::*;
 
     let mut data_dir: Option<String> = None;
+    let mut log_file: Option<String> = None;
+    let mut level: Option<String> = None;
     let mut network: Option<String> = None;
     let mut client: Option<String> = None;
     let mut bitcoind_url: Option<String> = None;
@@ -103,6 +110,14 @@ pub fn parse_args() -> Result<LampoCliArgs, lexopt::Error> {
             Short('d') | Long("data-dir") => {
                 let val: String = parser.value()?.parse()?;
                 data_dir = Some(val);
+            }
+            Long("log-file") => {
+                let val: String = parser.value()?.parse()?;
+                log_file = Some(val);
+            }
+            Long("log-level") => {
+                let val: String = parser.value()?.parse()?;
+                level = Some(val);
             }
             Short('n') | Long("network") => {
                 let val: String = parser.value()?.parse()?;
@@ -141,9 +156,13 @@ pub fn parse_args() -> Result<LampoCliArgs, lexopt::Error> {
         network,
         client,
         mnemonic,
+        log_file,
         bitcoind_url,
         bitcoind_pass,
         bitcoind_user,
+        // Default log level is info if it is not specified
+        // in the command line
+        log_level: level.unwrap_or("info".to_owned()),
     })
 }
 

--- a/lampod-cli/src/main.rs
+++ b/lampod-cli/src/main.rs
@@ -3,6 +3,7 @@ mod args;
 
 use std::env;
 use std::io;
+use std::path::PathBuf;
 use std::str::FromStr;
 use std::sync::Arc;
 use std::thread::JoinHandle;
@@ -39,8 +40,14 @@ use lampod::LampoDeamon;
 use crate::args::LampoCliArgs;
 
 fn main() -> error::Result<()> {
-    logger::init(log::Level::Trace).expect("unable to init the logger for the first time");
     let args = args::parse_args()?;
+    logger::init(
+        &args.log_level,
+        args.log_file
+            .as_ref()
+            .and_then(|path| Some(PathBuf::from_str(&path).unwrap())),
+    )
+    .expect("unable to init the logger for the first time");
     run(args)?;
     Ok(())
 }


### PR DESCRIPTION
This commit adds the possibility to redirect the logs on a file that is specified on the command line

Fixes https://github.com/vincenzopalazzo/lampo.rs/issues/89

It is missing how to demonize the main application