### PR TITLE
fix : adds the `log_level` and `log_file` inside `conf.rs`

### DIFF
--- a/lampo-common/src/conf.rs
+++ b/lampo-common/src/conf.rs
@@ -19,6 +19,8 @@ pub struct LampoConf {
     pub core_pass: Option<String>,
     pub private_key: Option<String>,
     pub channels_keys: Option<String>,
+    pub log_file: Option<String>,
+    pub log_level: String,
 }
 
 impl LampoConf {
@@ -44,6 +46,8 @@ impl LampoConf {
             core_pass: None,
             private_key: None,
             channels_keys: None,
+            log_level: "info".to_string(),
+            log_file: None,
         }
     }
 
@@ -202,7 +206,12 @@ impl TryFrom<String> for LampoConf {
 
         let network = Network::from_str(&network)?;
         let root_path = Self::normalize_root_dir(&value, network);
-
+        let log_level = conf.get_conf("log-level");
+        let level = match log_level {
+            Ok(Some(level)) => level,
+            _ => "info".to_string(),
+        };
+        let log_file = conf.get_conf("log-file").unwrap_or_else(|_| None);
         Ok(Self {
             inner: Some(conf),
             root_path,
@@ -215,6 +224,8 @@ impl TryFrom<String> for LampoConf {
             core_pass,
             private_key,
             channels_keys,
+            log_file,
+            log_level: level,
         })
     }
 }

--- a/lampod-cli/src/args.rs
+++ b/lampod-cli/src/args.rs
@@ -41,7 +41,7 @@ pub struct LampoCliArgs {
     pub network: Option<String>,
     pub client: Option<String>,
     pub mnemonic: Option<String>,
-    pub log_level: String,
+    pub log_level: Option<String>,
     pub log_file: Option<String>,
     pub bitcoind_url: Option<String>,
     pub bitcoind_user: Option<String>,
@@ -90,7 +90,12 @@ impl TryInto<LampoConf> for LampoCliArgs {
         if self.bitcoind_pass.is_some() {
             conf.core_pass = self.bitcoind_pass;
         }
-
+        if self.log_file.is_some() {
+            conf.log_file = self.log_file;
+        }
+        if self.log_level.is_some() {
+            conf.log_level = self.log_level.unwrap();
+        }
         Ok(conf)
     }
 }
@@ -166,7 +171,7 @@ pub fn parse_args() -> Result<LampoCliArgs, lexopt::Error> {
         bitcoind_user,
         // Default log level is info if it is not specified
         // in the command line
-        log_level: level.unwrap_or("info".to_owned()),
+        log_level: level,
     })
 }
 

--- a/lampod-cli/src/main.rs
+++ b/lampod-cli/src/main.rs
@@ -40,14 +40,8 @@ use lampod::LampoDeamon;
 use crate::args::LampoCliArgs;
 
 fn main() -> error::Result<()> {
+    log::debug!("Started!");
     let args = args::parse_args()?;
-    logger::init(
-        &args.log_level,
-        args.log_file
-            .as_ref()
-            .and_then(|path| Some(PathBuf::from_str(&path).unwrap())),
-    )
-    .expect("unable to init the logger for the first time");
     run(args)?;
     Ok(())
 }
@@ -59,6 +53,15 @@ fn run(args: LampoCliArgs) -> error::Result<()> {
     // After this point the configuration is ready!
     let lampo_conf: LampoConf = args.try_into()?;
     log::debug!(target: "lampod-cli", "init wallet ..");
+    // init the logger here
+    logger::init(
+        &lampo_conf.log_level,
+        lampo_conf
+            .log_file
+            .as_ref()
+            .and_then(|path| Some(PathBuf::from_str(&path).unwrap())),
+    )
+    .expect("unable to init the logger for the first time");
 
     // Prepare the backend
     let client = lampo_conf.node.clone();


### PR DESCRIPTION
## For now
For now the `log_level` is of type `String` (defauting to info) rather than the `Option<String>`. Thus, we will be not able to override the values from the conf as there will always be some value inside the arg.

## Proposed changes
If we set the args of `log-level` to be `Option<String>` and then if we provide `Some` value of the arg we can then just override with the `conf` value. But if we don't put any value in the arg we can get the value from the `conf` file if present. If not present we can just default it to `Info`.

## Changes made
- adds the `log_file` and `log_level` inside the `conf.rs`
- changes the `log-level` to be an `Option<>` and overrides if we provide the `log-level` in arguments.
- changes the location of init of `logger`.

fix #161 