### PR TITLE
core-wallet: do not reimport a descriptors

### DIFF
--- a/tests/tests/src/lib.rs
+++ b/tests/tests/src/lib.rs
@@ -12,8 +12,7 @@ fn init() {
     // ignore error
     INIT.call_once(|| {
         use lampo_common::logger;
-        use lampo_common::logger::Level;
 
-        logger::init(Level::Trace).expect("initializing logger for the first time");
+        logger::init("trace", None).expect("initializing logger for the first time");
     });
 }


### PR DESCRIPTION
If the wallet is already created we should just reload it and then we should not import multiple time the same descriptor because we can lost coins on the way.

Fixes https://github.com/vincenzopalazzo/lampo.rs/issues/143