### PR TITLE
fix : unwrap on `Err` inside node_id

### DIFF
--- a/lampo-common/src/model/connect.rs
+++ b/lampo-common/src/model/connect.rs
@@ -15,8 +15,8 @@ pub struct Connect {
 }
 
 impl Connect {
-    pub fn node_id(&self) -> NodeId {
-        NodeId::from_str(&self.node_id).unwrap()
+    pub fn node_id(&self) -> error::Result<NodeId> {
+        Ok(NodeId::from_str(&self.node_id)?)
     }
 
     pub fn addr(&self) -> error::Result<SocketAddr> {


### PR DESCRIPTION
The application crashes when we try to connect with wrong node id. This commit will fix it.

Co-Developed-by: Vincenzo Palazzo <vincenzopalazzodev@gmail.com