### PR TITLE
fix : update makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ install:
 	$(CC) build --release
 	$(CC) install --locked --path ./lampo-cli 
 	$(CC) install --locked --path ./lampod-cli
-	sudo cp target/debug/liblampo.so /usr/local/lib
+	sudo cp target/release/liblampo.so /usr/local/lib
 
 integration: default
 	$(CC) test -p tests $(ARGS)


### PR DESCRIPTION
Earlier I noticed that while running `make install` we were getting some error like this :
```
Replaced package `lampod-cli v0.1.0 (/home/harshit/Desktop/lampo.rs/lampod-cli)` with `lampod-cli v0.1.0 (/home/harshit/Desktop/lampo.rs/lampod-cli)` (executable `lampod-cli`)
sudo cp target/debug/liblampo.so /usr/local/lib
[sudo] password for harshit:
cp: cannot stat 'target/debug/liblampo.so': No such file or directory
make: *** [Makefile:22: install] Error 1
```
as we were compiling the lampo in release mode. We were not able to find `target/debug/liblampo.so` as the result was in `target/release/`. Thus, this commit updates the makefile to copy result from `target/release`.