### PR TITLE
fix : add network type inside `getinfo`

### DIFF
--- a/lampo-common/src/model/getinfo.rs
+++ b/lampo-common/src/model/getinfo.rs
@@ -5,4 +5,5 @@ pub struct GetInfo {
     pub node_id: String,
     pub peers: usize,
     pub channels: usize,
+    pub chain: String,
 }

--- a/lampod/src/ln/channel_manager.rs
+++ b/lampod/src/ln/channel_manager.rs
@@ -74,7 +74,6 @@ pub type LampoRouter = DefaultRouter<
 >;
 
 pub struct LampoChannelManager {
-    conf: LampoConf,
     monitor: Option<Arc<LampoChainMonitor>>,
     onchain: Arc<LampoChainManager>,
     wallet_manager: Arc<dyn WalletManager>,
@@ -84,6 +83,7 @@ pub struct LampoChannelManager {
     handler: RefCell<Option<Arc<LampoHandler>>>,
     router: Option<Arc<LampoRouter>>,
 
+    pub(crate) conf: LampoConf,
     pub(crate) channeld: Option<Arc<LampoChannel>>,
     pub(crate) logger: Arc<LampoLogger>,
 }

--- a/lampod/src/ln/inventory_manager.rs
+++ b/lampod/src/ln/inventory_manager.rs
@@ -32,10 +32,12 @@ impl InventoryHandler for LampoInventoryManager {
 
         match event {
             InventoryCommand::GetNodeInfo(chan) => {
+                let chain = self.channel_manager.conf.network.to_string();
                 let getinfo = GetInfo {
                     node_id: self.channel_manager.manager().get_our_node_id().to_string(),
                     peers: self.peer_manager.manager().list_peers().len(),
                     channels: self.channel_manager.manager().list_channels().len(),
+                    chain,
                 };
                 let getinfo = json::to_value(getinfo)?;
                 chan.send(getinfo)?;


### PR DESCRIPTION
We simply get the network from `conf` inside the `CoreWalletManager`. Thus, adding a function inside `CoreWalletManager` to return the chain of network the wallet is built upon.

fixes #183 