### PR TITLE
Wait for `OnChainEvent::SendRawTransaction` before returning from `fundchannel` RPC call

### DIFF
--- a/lampo-common/src/model/open_channel.rs
+++ b/lampo-common/src/model/open_channel.rs
@@ -30,9 +30,9 @@ pub mod response {
 
     use serde::{Deserialize, Serialize};
 
-    use crate::bitcoin::OutPoint;
     use crate::error;
     use crate::types::NodeId;
+    use bitcoin::Transaction;
 
     #[derive(Serialize, Deserialize)]
     pub struct Channels {
@@ -46,7 +46,7 @@ pub mod response {
         pub public: bool,
         pub push_mst: u64,
         pub to_self_delay: u64,
-        pub tx: Option<OutPoint>,
+        pub tx: Option<Transaction>,
     }
 
     impl OpenChannel {

--- a/lampo-common/src/model/open_channel.rs
+++ b/lampo-common/src/model/open_channel.rs
@@ -30,9 +30,9 @@ pub mod response {
 
     use serde::{Deserialize, Serialize};
 
+    use crate::bitcoin::Transaction;
     use crate::error;
     use crate::types::NodeId;
-    use bitcoin::Transaction;
 
     #[derive(Serialize, Deserialize)]
     pub struct Channels {

--- a/lampod/src/jsonrpc/open_channel.rs
+++ b/lampod/src/jsonrpc/open_channel.rs
@@ -10,6 +10,9 @@ use crate::LampoDeamon;
 pub fn json_open_channel(ctx: &LampoDeamon, request: &json::Value) -> Result<json::Value, Error> {
     log::info!("call for `openchannel` with request {:?}", request);
     let request: request::OpenChannel = json::from_value(request.clone())?;
+
+    // LDK's `create_channel()` doesn't check if you are currently connected
+    // to the given peer so we need to check ourselves
     // FIXME: remove unwrap!
     if !ctx
         .peer_manager()

--- a/lampod/src/ln/channel_manager.rs
+++ b/lampod/src/ln/channel_manager.rs
@@ -428,6 +428,7 @@ impl ChannelEvents for LampoChannelManager {
             .map_err(|err| error::anyhow!("{:?}", err))?;
 
         // Wait for SendRawTransaction to be received so to get the funding transaction
+        // FIXME: we can loop forever here
         let tx: Option<Transaction> = loop {
             let events = self.handler().events();
             let event = events.recv_timeout(std::time::Duration::from_secs(30))?;

--- a/tests/tests/src/lampo_cln_tests.rs
+++ b/tests/tests/src/lampo_cln_tests.rs
@@ -78,7 +78,7 @@ pub fn fund_a_simple_channel_from_lampo() {
         Err(())
     });
 
-    let _: json::Value = lampo
+    let response: json::Value = lampo
         .call(
             "fundchannel",
             request::OpenChannel {
@@ -90,6 +90,8 @@ pub fn fund_a_simple_channel_from_lampo() {
             },
         )
         .unwrap();
+    assert!(response.get("tx").is_some());
+
     wait!(|| {
         while let Ok(event) = events.recv_timeout(Duration::from_millis(100)) {
             log::trace!("{:?}", event);


### PR DESCRIPTION
Fixes #174
## Changes:
- Modified `OpenChannel` response struct of `fundchannel` JSON-RPC call to include the funding transaction of type `bitcoin::Transaction` 
- Wait for the `OnChainEvent::SendRawTransaction` event before returning from the JSON-RPC call of `fundchannel`. The timeout is 30 seconds. 