### PR TITLE
feat : close channel command

### DIFF
--- a/lampo-common/src/event/ln.rs
+++ b/lampo-common/src/event/ln.rs
@@ -41,7 +41,7 @@ pub enum LightningEvent {
     CloseChannelEvent {
         channel_id: String,
         message: String,
-        counterparty_node_id: String,
-        funding_utxo: String,
+        counterparty_node_id: Option<String>,
+        funding_utxo: Option<String>,
     },
 }

--- a/lampo-common/src/event/ln.rs
+++ b/lampo-common/src/event/ln.rs
@@ -38,4 +38,10 @@ pub enum LightningEvent {
         state: ChannelState,
         message: String,
     },
+    CloseChannelEvent {
+        channel_id: String,
+        message: String,
+        counterparty_node_id: String,
+        funding_utxo: String,
+    },
 }

--- a/lampo-common/src/model.rs
+++ b/lampo-common/src/model.rs
@@ -1,3 +1,4 @@
+mod close_channel;
 mod connect;
 mod getinfo;
 mod invoice;
@@ -10,6 +11,7 @@ pub use connect::Connect;
 pub use getinfo::GetInfo;
 
 pub mod request {
+    pub use crate::model::close_channel::request::*;
     pub use crate::model::connect::Connect;
     pub use crate::model::getinfo::GetInfo;
     pub use crate::model::invoice::request::*;
@@ -21,6 +23,7 @@ pub mod request {
 }
 
 pub mod response {
+    pub use crate::model::close_channel::response::*;
     pub use crate::model::connect::Connect;
     pub use crate::model::getinfo::GetInfo;
     pub use crate::model::invoice::response::*;

--- a/lampo-common/src/model/close_channel.rs
+++ b/lampo-common/src/model/close_channel.rs
@@ -10,20 +10,26 @@ pub mod request {
 
     #[derive(Clone, Serialize, Deserialize)]
     pub struct CloseChannel {
-        pub counterpart_node_id: String,
+        pub node_id: String,
         // Hex of the channel
-        pub channel_id: String,
+        pub channel_id: Option<String>,
     }
 
     impl CloseChannel {
         pub fn counterpart_node_id(&self) -> error::Result<PublicKey> {
-            let node_id = PublicKey::from_str(&self.counterpart_node_id)?;
+            let node_id = PublicKey::from_str(&self.node_id)?;
             Ok(node_id)
         }
 
         // Returns ChannelId in byte format from hex of channelid
         pub fn channel_id(&self) -> error::Result<ChannelId> {
-            let result = self.decode_hex(&self.channel_id)?;
+            let id = if let Some(id) = &self.channel_id {
+                id
+            } else {
+                error::bail!("No node_id provided");
+            };
+            let result = self.decode_hex(&id)?;
+            // FIXME: We can do better here
             let mut result_array: [u8; 32] = [0; 32];
             for i in 0..32 {
                 result_array[i] = result[i]

--- a/lampo-common/src/model/close_channel.rs
+++ b/lampo-common/src/model/close_channel.rs
@@ -37,6 +37,11 @@ pub mod request {
             Ok(ChannelId::from_bytes(result_array))
         }
 
+        /// This converts hex to bytes array.
+        /// Stolen from https://stackoverflow.com/a/52992629
+        /// It takes two values every in each iteration from the hex
+        /// then convert the formed hexdecimal digit to u8, collects it in a vector
+        /// and return it (redix = 16 for hexadecimal)
         fn decode_hex(&self, s: &str) -> Result<Vec<u8>, ParseIntError> {
             (0..s.len())
                 .step_by(2)

--- a/lampo-common/src/model/close_channel.rs
+++ b/lampo-common/src/model/close_channel.rs
@@ -23,17 +23,13 @@ pub mod request {
 
         // Returns ChannelId in byte format from hex of channelid
         pub fn channel_id(&self) -> error::Result<ChannelId> {
-            let id = if let Some(id) = &self.channel_id {
-                id
-            } else {
-                error::bail!("No node_id provided");
-            };
+            let id = self
+                .channel_id
+                .as_ref()
+                .ok_or(error::anyhow!("`channel_id` not found"))?;
             let result = self.decode_hex(&id)?;
-            // FIXME: We can do better here
             let mut result_array: [u8; 32] = [0; 32];
-            for i in 0..32 {
-                result_array[i] = result[i]
-            }
+            result_array.copy_from_slice(&result);
             Ok(ChannelId::from_bytes(result_array))
         }
 
@@ -58,7 +54,7 @@ pub mod response {
     pub struct CloseChannel {
         pub channel_id: String,
         pub message: String,
-        pub counterparty_node_id: String,
+        pub peer_id: String,
         pub funding_utxo: String,
     }
 }

--- a/lampo-common/src/model/close_channel.rs
+++ b/lampo-common/src/model/close_channel.rs
@@ -1,0 +1,53 @@
+pub mod request {
+    use std::num::ParseIntError;
+    use std::str::FromStr;
+
+    use bitcoin::secp256k1::PublicKey;
+    use serde::{Deserialize, Serialize};
+
+    use crate::error;
+    use crate::types::*;
+
+    #[derive(Clone, Serialize, Deserialize)]
+    pub struct CloseChannel {
+        pub counterpart_node_id: String,
+        // Hex of the channel
+        pub channel_id: String,
+    }
+
+    impl CloseChannel {
+        pub fn counterpart_node_id(&self) -> error::Result<PublicKey> {
+            let node_id = PublicKey::from_str(&self.counterpart_node_id)?;
+            Ok(node_id)
+        }
+
+        // Returns ChannelId in byte format from hex of channelid
+        pub fn channel_id(&self) -> error::Result<ChannelId> {
+            let result = self.decode_hex(&self.channel_id)?;
+            let mut result_array: [u8; 32] = [0; 32];
+            for i in 0..32 {
+                result_array[i] = result[i]
+            }
+            Ok(ChannelId::from_bytes(result_array))
+        }
+
+        fn decode_hex(&self, s: &str) -> Result<Vec<u8>, ParseIntError> {
+            (0..s.len())
+                .step_by(2)
+                .map(|i| u8::from_str_radix(&s[i..i + 2], 16))
+                .collect()
+        }
+    }
+}
+
+pub mod response {
+    use serde::{Deserialize, Serialize};
+
+    #[derive(Serialize, Deserialize, Debug)]
+    pub struct CloseChannel {
+        pub channel_id: String,
+        pub message: String,
+        pub counterparty_node_id: String,
+        pub funding_utxo: String,
+    }
+}

--- a/lampo-common/src/model/open_channel.rs
+++ b/lampo-common/src/model/open_channel.rs
@@ -34,7 +34,7 @@ pub mod response {
     use crate::error;
     use crate::types::NodeId;
 
-    #[derive(Serialize, Deserialize)]
+    #[derive(Serialize, Deserialize, Clone)]
     pub struct Channels {
         pub channels: Vec<Channel>,
     }
@@ -58,6 +58,8 @@ pub mod response {
 
     #[derive(Clone, Serialize, Deserialize, Debug)]
     pub struct Channel {
+        // Channel_id needs to be string as it currently does not derive Serialize
+        pub channel_id: String,
         pub short_channel_id: Option<u64>,
         pub peer_id: String,
         pub peer_alias: Option<String>,

--- a/lampo-testing/src/lib.rs
+++ b/lampo-testing/src/lib.rs
@@ -15,6 +15,7 @@ use clightning_testing::prelude::*;
 use lampo_common::json;
 use lampo_common::model::response;
 use lampo_common::model::response::NewAddress;
+use lampod::jsonrpc::channels::json_close_channel;
 use lampod::jsonrpc::offchain::json_keysend;
 use tempfile::TempDir;
 
@@ -117,6 +118,7 @@ impl LampoTesting {
 
         server.add_rpc("pay", json_pay).unwrap();
         server.add_rpc("keysend", json_keysend).unwrap();
+        server.add_rpc("close", json_close_channel).unwrap();
         let handler = server.handler();
         let rpc_handler = Arc::new(CommandHandler::new(&lampo_conf)?);
         rpc_handler.set_handler(handler);

--- a/lampod-cli/src/main.rs
+++ b/lampod-cli/src/main.rs
@@ -8,6 +8,7 @@ use std::str::FromStr;
 use std::sync::Arc;
 use std::thread::JoinHandle;
 
+use lampod::jsonrpc::channels::json_close_channel;
 use lampod::jsonrpc::channels::json_list_channels;
 
 use lampo_bitcoind::BitcoinCore;
@@ -171,6 +172,7 @@ fn run_jsonrpc(
     server.add_rpc("pay", json_pay).unwrap();
     server.add_rpc("keysend", json_keysend).unwrap();
     server.add_rpc("fees", json_estimate_fees).unwrap();
+    server.add_rpc("close", json_close_channel).unwrap();
     let handler = server.handler();
     Ok((server.spawn(), handler))
 }

--- a/lampod/src/actions/handler.rs
+++ b/lampod/src/actions/handler.rs
@@ -150,13 +150,26 @@ impl Handler for LampoHandler {
                     channel_type,
                 }));
                 Ok(())
-            }
+            },
             ldk::events::Event::ChannelClosed {
                 channel_id,
                 user_channel_id,
                 reason,
+                counterparty_node_id,
+                channel_funding_txo,
                 ..
             } => {
+                let node_id = if let Some(id) = counterparty_node_id {
+                    id.to_string()
+                } else {
+                    "Node_id not found".to_string()
+                };
+                let txo = if let Some(txo) = channel_funding_txo {
+                    txo.to_string()
+                } else {
+                    "Outpoint not found".to_string()
+                };
+                self.emit(Event::Lightning(LightningEvent::CloseChannelEvent { channel_id: channel_id.to_string(), message: reason.to_string(), counterparty_node_id : node_id, funding_utxo : txo}));
                 log::info!("channel `{user_channel_id}` closed with reason: `{reason}`");
                 Ok(())
             }

--- a/lampod/src/actions/handler.rs
+++ b/lampod/src/actions/handler.rs
@@ -159,16 +159,8 @@ impl Handler for LampoHandler {
                 channel_funding_txo,
                 ..
             } => {
-                let node_id = if let Some(id) = counterparty_node_id {
-                    id.to_string()
-                } else {
-                    "Node_id not found".to_string()
-                };
-                let txo = if let Some(txo) = channel_funding_txo {
-                    txo.to_string()
-                } else {
-                    "Outpoint not found".to_string()
-                };
+                let node_id = counterparty_node_id.map(|id| id.to_string());
+                let txo = channel_funding_txo.map(|txo| txo.to_string());
                 self.emit(Event::Lightning(LightningEvent::CloseChannelEvent { channel_id: channel_id.to_string(), message: reason.to_string(), counterparty_node_id : node_id, funding_utxo : txo}));
                 log::info!("channel `{user_channel_id}` closed with reason: `{reason}`");
                 Ok(())

--- a/lampod/src/jsonrpc/channels.rs
+++ b/lampod/src/jsonrpc/channels.rs
@@ -1,5 +1,9 @@
 use lampo_common::json;
+use lampo_common::model::request;
 use lampo_jsonrpc::errors::Error;
+use lampo_jsonrpc::errors::RpcError;
+
+use crate::ln::events::ChannelEvents;
 
 use crate::LampoDeamon;
 
@@ -7,4 +11,19 @@ pub fn json_list_channels(ctx: &LampoDeamon, request: &json::Value) -> Result<js
     log::info!("call for `list_channels` with request {:?}", request);
     let resp = ctx.channel_manager().list_channel();
     Ok(json::to_value(resp)?)
+}
+
+pub fn json_close_channel(ctx: &LampoDeamon, request: &json::Value) -> Result<json::Value, Error> {
+    log::info!("call for `closechannel` with request {:?}", request);
+    let request: request::CloseChannel = json::from_value(request.clone())?;
+    let res = ctx.channel_manager().close_channel(request);
+    let resp = match res {
+        Ok(resp) => Ok(resp),
+        Err(err) => Err(Error::Rpc(RpcError {
+            code: -1,
+            message: format!("{err}"),
+            data: None,
+        })),
+    };
+    Ok(json::to_value(resp?)?)
 }

--- a/lampod/src/jsonrpc/channels.rs
+++ b/lampod/src/jsonrpc/channels.rs
@@ -1,7 +1,10 @@
+use lampo_common::event::ln::LightningEvent;
+use lampo_common::event::Event;
 use lampo_common::json;
 use lampo_common::model::request;
 use lampo_jsonrpc::errors::Error;
 use lampo_jsonrpc::errors::RpcError;
+use lampo_common::handler::Handler;
 
 use crate::ln::events::ChannelEvents;
 
@@ -16,9 +19,33 @@ pub fn json_list_channels(ctx: &LampoDeamon, request: &json::Value) -> Result<js
 pub fn json_close_channel(ctx: &LampoDeamon, request: &json::Value) -> Result<json::Value, Error> {
     log::info!("call for `closechannel` with request {:?}", request);
     let request: request::CloseChannel = json::from_value(request.clone())?;
+    let events = ctx.handler().events();
     let res = ctx.channel_manager().close_channel(request);
+    let (message, channel_id, node_id, funding_utxo) = loop {
+        let event = events.recv_timeout(std::time::Duration::from_secs(30)).map_err(|err| {
+            Error::Rpc(RpcError {
+                code: -1,
+                message: format!("{err}"),
+                data: None,
+            })
+        })?;
+        if let Event::Lightning(LightningEvent::CloseChannelEvent {
+            message,
+            channel_id,
+            counterparty_node_id,
+            funding_utxo,
+        }) = event
+        {
+            break (message, channel_id, counterparty_node_id, funding_utxo);
+        }
+        };
     let resp = match res {
-        Ok(resp) => Ok(resp),
+        Ok(_) => Ok(json::json!({
+            "message" : message,
+            "channel_id" : channel_id,
+            "counterparty_node_id" : node_id,
+            "funding_utxo" : funding_utxo,
+        })),
         Err(err) => Err(Error::Rpc(RpcError {
             code: -1,
             message: format!("{err}"),

--- a/lampod/src/ln/channel_manager.rs
+++ b/lampod/src/ln/channel_manager.rs
@@ -10,7 +10,6 @@ use lampo_common::bitcoin::absolute::Height;
 use lampo_common::bitcoin::{BlockHash, Transaction};
 use lampo_common::conf::{LampoConf, UserConfig};
 use lampo_common::error;
-use lampo_common::event::ln::LightningEvent;
 use lampo_common::event::onchain::OnChainEvent;
 use lampo_common::event::Event;
 use lampo_common::handler::Handler;
@@ -32,7 +31,7 @@ use lampo_common::ldk::util::config::{ChannelHandshakeConfig, ChannelHandshakeLi
 use lampo_common::ldk::util::persist::read_channel_monitors;
 use lampo_common::ldk::util::ser::ReadableArgs;
 use lampo_common::model::request;
-use lampo_common::model::response::{self, Channel, Channels, CloseChannel};
+use lampo_common::model::response::{self, Channel, Channels};
 
 use crate::actions::handler::LampoHandler;
 use crate::chain::{LampoChainManager, WalletManager};
@@ -450,10 +449,7 @@ impl ChannelEvents for LampoChannelManager {
         })
     }
 
-    fn close_channel(
-        &self,
-        channel: request::CloseChannel,
-    ) -> error::Result<()> {
+    fn close_channel(&self, channel: request::CloseChannel) -> error::Result<()> {
         let channel_id = channel.channel_id()?;
         let node_id = channel.counterpart_node_id()?;
 

--- a/lampod/src/ln/channel_manager.rs
+++ b/lampod/src/ln/channel_manager.rs
@@ -453,32 +453,14 @@ impl ChannelEvents for LampoChannelManager {
     fn close_channel(
         &self,
         channel: request::CloseChannel,
-    ) -> error::Result<response::CloseChannel> {
+    ) -> error::Result<()> {
         let channel_id = channel.channel_id()?;
         let node_id = channel.counterpart_node_id()?;
 
         self.manager()
             .close_channel(&channel_id, &node_id)
             .map_err(|err| error::anyhow!("{:?}", err))?;
-        let events = self.handler().events();
-        let (message, channel_id, node_id, funding_utxo) = loop {
-            let event = events.recv_timeout(std::time::Duration::from_secs(30))?;
-            if let Event::Lightning(LightningEvent::CloseChannelEvent {
-                message,
-                channel_id,
-                counterparty_node_id,
-                funding_utxo,
-            }) = event
-            {
-                break (message, channel_id, counterparty_node_id, funding_utxo);
-            }
-        };
-        Ok(CloseChannel {
-            channel_id,
-            message,
-            counterparty_node_id: node_id,
-            funding_utxo,
-        })
+        Ok(())
     }
     fn change_state_channel(&self, _: ChangeStateChannelEvent) -> error::Result<()> {
         unimplemented!()

--- a/lampod/src/ln/events.rs
+++ b/lampod/src/ln/events.rs
@@ -31,10 +31,7 @@ pub trait ChannelEvents {
     ) -> error::Result<response::OpenChannel>;
 
     /// Close a channel
-    fn close_channel(
-        &self,
-        channel: request::CloseChannel,
-    ) -> error::Result<()>;
+    fn close_channel(&self, channel: request::CloseChannel) -> error::Result<()>;
 
     fn change_state_channel(&self, event: ChangeStateChannelEvent) -> error::Result<()>;
 }

--- a/lampod/src/ln/events.rs
+++ b/lampod/src/ln/events.rs
@@ -31,7 +31,10 @@ pub trait ChannelEvents {
     ) -> error::Result<response::OpenChannel>;
 
     /// Close a channel
-    fn close_channel(&self) -> error::Result<()>;
+    fn close_channel(
+        &self,
+        channel: request::CloseChannel,
+    ) -> error::Result<response::CloseChannel>;
 
     fn change_state_channel(&self, event: ChangeStateChannelEvent) -> error::Result<()>;
 }

--- a/lampod/src/ln/events.rs
+++ b/lampod/src/ln/events.rs
@@ -34,7 +34,7 @@ pub trait ChannelEvents {
     fn close_channel(
         &self,
         channel: request::CloseChannel,
-    ) -> error::Result<response::CloseChannel>;
+    ) -> error::Result<()>;
 
     fn change_state_channel(&self, event: ChangeStateChannelEvent) -> error::Result<()>;
 }


### PR DESCRIPTION
Adds the ability to close channels from the lampo node.

## Changes done :
	- Adds close_channel function inside lampod/src/ln/channel_manager.rs
	- Adds request/response inside model/close_channel.rs
	- Adds `close` command inside main.rs

## Some minor changes :
	- Adds `channel_id` inside channels response.


Fixes #195 
