### PR TITLE
fix: crash caused when the port is already in use

### DIFF
--- a/lampod/src/ln/peer_manager.rs
+++ b/lampod/src/ln/peer_manager.rs
@@ -148,23 +148,42 @@ impl LampoPeerManager {
         };
         let peer_manager = peer_manager.clone();
         std::thread::spawn(move || {
-            async_run!(async move {
+            let result = async_run!(async move {
                 let bind_addr = format!("0.0.0.0:{}", listen_port);
                 log::info!(target: "lampo", "Litening for in-bound connection on {bind_addr}");
-                let listener = tokio::net::TcpListener::bind(bind_addr).await.unwrap();
+                let listener = match tokio::net::TcpListener::bind(bind_addr).await {
+                    Ok(listener) => listener,
+                    Err(e) => {
+                        return Err::<(), _>(error::anyhow!("Error binding to address: {}", e));
+                    }
+                };
+
                 loop {
                     let peer_manager = peer_manager.clone();
-                    let tcp_stream = listener.accept().await.unwrap().0;
-                    log::info!(target: "lampo", "Got new connection {}", tcp_stream.peer_addr().unwrap());
-                    let _ = tokio::spawn(async move {
-                        // Use LDK's supplied networking battery to facilitate inbound
-                        // connections.
-                        net::setup_inbound(peer_manager.clone(), tcp_stream.into_std().unwrap())
+                    let accept = listener.accept().await;
+                    let accept = accept
+                        .map_err(|err| error::anyhow!("Error accepting connection: {}", err))?;
+                    match accept {
+                        (tcp_stream, _) => {
+                            log::info!(target: "lampo", "Got new connection {}", tcp_stream.peer_addr().unwrap());
+                            let _ = tokio::spawn(async move {
+                                // Use LDK's supplied networking battery to facilitate inbound
+                                // connections.
+                                net::setup_inbound(
+                                    peer_manager.clone(),
+                                    tcp_stream.into_std().unwrap(),
+                                )
+                                .await;
+                            })
                             .await;
-                    })
-                    .await;
+                        }
+                    }
                 }
             });
+            if let Err(err) = &result {
+                log::error!("error while try to listen on inbound connection: `{err}`");
+            }
+            result
         });
         Ok(())
     }


### PR DESCRIPTION
This pull request fixes #172 , where the application crashes when the specified port is already in use. The crash is occuring cause we are using unwrap() while handling TcpListener::bind().
This commit fixes it by replacing unwrap() with match expressions for error handling.

