### PR TITLE
Add Lampo Python Client (`pylampo-client`)

### DIFF
--- a/tools/pylampo-client/client.py
+++ b/tools/pylampo-client/client.py
@@ -1,0 +1,53 @@
+import json
+import socket
+import os
+
+
+class LampoClient:
+    """
+    A simple Lampo client that communicates via a Unix socket.
+    """
+
+    def __init__(self, socket_path: str = None):
+        """
+        Initializes the LampoClient instance.
+
+        Args:
+          socket_path: (Optional) The path to the Lampo socket.
+                      Defaults to '<home_dir>/.lampo/regtest/lampod.socket'.
+        """
+        if socket_path:
+            self.socket_path = socket_path
+        else:
+            home_dir = os.environ["HOME"]
+            self.socket_path = f"{home_dir}/.lampo/regtest/lampod.socket"
+
+    def call(self, method: str, params: dict = None) -> dict:
+        """
+        Calls a method on the Lampo client over the Unix socket.
+
+        Args:
+          method: The name of the Lampo method to call.
+          params: (Optional) A dictionary of parameters to pass to the method.
+
+        Returns:
+          The response from the Lampo client as a dictionary.
+
+        Raises:
+          Exception: If there is an error communicating with the Lampo client.
+        """
+
+        request = {
+            "method": method,
+            "params": params if params else {},
+            "id": "",
+            "jsonrpc": "2.0",
+        }
+        try:
+            with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as sock:
+                sock.connect(self.socket_path)
+                sock.sendall(json.dumps(request).encode())
+                response = sock.recv(1024).decode()
+                return json.loads(response)
+        except Exception as e:
+            raise Exception(f"Error communicating with Lampo client: {e}")

--- a/tools/pylampo-client/client.py
+++ b/tools/pylampo-client/client.py
@@ -1,6 +1,5 @@
 import json
 import socket
-import os
 
 
 class LampoClient:
@@ -8,19 +7,15 @@ class LampoClient:
     A simple Lampo client that communicates via a Unix socket.
     """
 
-    def __init__(self, socket_path: str = None):
+    def __init__(self, socket_path: str):
         """
         Initializes the LampoClient instance.
 
         Args:
-          socket_path: (Optional) The path to the Lampo socket.
-                      Defaults to '<home_dir>/.lampo/regtest/lampod.socket'.
+          socket_path: The path to the Lampo socket.
         """
-        if socket_path:
-            self.socket_path = socket_path
-        else:
-            home_dir = os.environ["HOME"]
-            self.socket_path = f"{home_dir}/.lampo/regtest/lampod.socket"
+
+        self.socket_path = socket_path
 
     def call(self, method: str, params: dict = None) -> dict:
         """
@@ -40,7 +35,7 @@ class LampoClient:
         request = {
             "method": method,
             "params": params if params else {},
-            "id": "",
+            "id": "pylampo-client/1",
             "jsonrpc": "2.0",
         }
         try:

--- a/tools/pylampo-client/client.py
+++ b/tools/pylampo-client/client.py
@@ -42,7 +42,14 @@ class LampoClient:
             with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as sock:
                 sock.connect(self.socket_path)
                 sock.sendall(json.dumps(request).encode())
-                response = sock.recv(1024).decode()
+
+                response = ""
+                while True:
+                    data = sock.recv(1024)
+                    if not data:
+                        break
+                    response += data.decode()
+
                 return json.loads(response)
         except Exception as e:
             raise Exception(f"Error communicating with Lampo client: {e}")

--- a/tools/pylampo-client/pyproject.toml
+++ b/tools/pylampo-client/pyproject.toml
@@ -5,7 +5,7 @@ description = "A simple Lampo client that communicates via a Unix socket"
 authors = ["Tarek <tareknaser360@gmail.com>"]
 
 [tool.poetry.dependencies]
-python = "^3.8"
+python = "^3.7"
 
 
 [build-system]

--- a/tools/pylampo-client/pyproject.toml
+++ b/tools/pylampo-client/pyproject.toml
@@ -1,0 +1,13 @@
+[tool.poetry]
+name = "pylampo-client"
+version = "0.0.1"
+description = "A simple Lampo client that communicates via a Unix socket"
+authors = ["Tarek <tareknaser360@gmail.com>"]
+
+[tool.poetry.dependencies]
+python = "^3.8"
+
+
+[build-system]
+requires = ["poetry-core"]
+build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
## Description
This pull request implements `pylampo-client`, a Python client for interacting with Lampo through a Unix socket. It uses Poetry for dependency management.

- Defaults to using `<home_dir>/.lampo/regtest/lampod.socket` for the socket path.

**Related issues**: #132, #139
This client should be used in lnprototest integration testing (See https://github.com/vincenzopalazzo/lampo.rs/issues/139#issuecomment-2004988074) 
## Example Usage
```python
from pylampo_client import LampoClient


client = LampoClient()

# Prepare parameters for the "fundchannel" method
params = {
    "node_id": "<node_id>",
    "amount": 100000,
    "public": True,
    "addr": "<address>",
    "port": 19735
}

# Call the "fundchannel" method 
response = client.call("fundchannel", params)
print(response)
```


