### PR TITLE
feat : adds `announce-addr`

### DIFF
--- a/lampo-common/src/conf.rs
+++ b/lampo-common/src/conf.rs
@@ -22,6 +22,7 @@ pub struct LampoConf {
     pub log_file: Option<String>,
     pub log_level: String,
     pub alias: Option<String>,
+    pub announce_addr: Option<String>,
 }
 
 impl LampoConf {
@@ -50,6 +51,7 @@ impl LampoConf {
             log_level: "info".to_string(),
             log_file: None,
             alias: None,
+            announce_addr: None,
         }
     }
 
@@ -216,6 +218,7 @@ impl TryFrom<String> for LampoConf {
         };
         let log_file = conf.get_conf("log-file").unwrap_or_else(|_| None);
         let alias = conf.get_conf("alias").unwrap_or(None);
+        let announce_addr = conf.get_conf("announce-addr").unwrap_or_else(|_| None);
 
         Ok(Self {
             inner: Some(conf),
@@ -232,6 +235,7 @@ impl TryFrom<String> for LampoConf {
             log_file,
             log_level: level,
             alias,
+            announce_addr,
         })
     }
 }

--- a/lampod/src/ln/peer_manager.rs
+++ b/lampod/src/ln/peer_manager.rs
@@ -132,10 +132,15 @@ impl LampoPeerManager {
             .clone()
             .ok_or(error::anyhow!("channel manager is None"))?;
         let alias = self.conf.alias.clone().unwrap_or_default();
+        let addr = self
+            .conf
+            .announce_addr
+            .clone()
+            .unwrap_or_else(|| "127.0.0.1".to_string());
         std::thread::spawn(move || {
             let result = async_run!(async move {
-                let bind_addr = format!("0.0.0.0:{}", listen_port);
-                log::info!(target: "lampo", "Litening for in-bound connection on {bind_addr}");
+                let bind_addr = format!("{addr}:{listen_port}");
+                log::info!(target: "lampo", "Listening for in-bound connection on {bind_addr}");
                 let listener = match tokio::net::TcpListener::bind(bind_addr.clone()).await {
                     Ok(listener) => listener,
                     Err(e) => {


### PR DESCRIPTION
This commits adds the ability to announce the IP address where the lampo node can listen for inbound connections.