### PR TITLE
cli: ask as an input the bip 39

### DIFF
--- a/lampod-cli/Cargo.toml
+++ b/lampod-cli/Cargo.toml
@@ -10,7 +10,6 @@ lampo-common = { path = "../lampo-common" }
 lampo-bitcoind = { path = "../lampo-bitcoind" }
 lampo-jsonrpc = { path = "../lampo-jsonrpc" }
 lampo-core-wallet = { path = "../lampo-core-wallet" }
-
 tokio = { version = "1.22.0", features = ["rt"] }
 lexopt = { version = "0.3" }
 filelock-rs = "0.1.0-beta.2"

--- a/lampod-cli/src/args.rs
+++ b/lampod-cli/src/args.rs
@@ -40,7 +40,7 @@ pub struct LampoCliArgs {
     pub data_dir: Option<String>,
     pub network: Option<String>,
     pub client: Option<String>,
-    pub mnemonic: Option<String>,
+    pub restore_wallet: bool,
     pub log_level: Option<String>,
     pub log_file: Option<String>,
     pub bitcoind_url: Option<String>,
@@ -110,7 +110,7 @@ pub fn parse_args() -> Result<LampoCliArgs, lexopt::Error> {
     let mut bitcoind_url: Option<String> = None;
     let mut bitcoind_user: Option<String> = None;
     let mut bitcoind_pass: Option<String> = None;
-    let mut mnemonic: Option<String> = None;
+    let mut restore_wallet = false;
 
     let mut parser = lexopt::Parser::from_env();
     while let Some(arg) = parser.next()? {
@@ -148,8 +148,7 @@ pub fn parse_args() -> Result<LampoCliArgs, lexopt::Error> {
                 bitcoind_pass = Some(var);
             }
             Long("restore-wallet") => {
-                let var: String = parser.value()?.parse()?;
-                mnemonic = Some(var);
+                restore_wallet = true;
             }
             Long("help") => {
                 let _ = print_help();
@@ -163,7 +162,7 @@ pub fn parse_args() -> Result<LampoCliArgs, lexopt::Error> {
         data_dir,
         network,
         client,
-        mnemonic,
+        restore_wallet,
         log_file,
         bitcoind_url,
         bitcoind_pass,

--- a/lampod-cli/src/main.rs
+++ b/lampod-cli/src/main.rs
@@ -8,8 +8,7 @@ use std::str::FromStr;
 use std::sync::Arc;
 use std::thread::JoinHandle;
 
-use lampod::jsonrpc::channels::json_close_channel;
-use lampod::jsonrpc::channels::json_list_channels;
+use radicle_term as term;
 
 use lampo_bitcoind::BitcoinCore;
 use lampo_common::backend::Backend;
@@ -20,7 +19,8 @@ use lampo_core_wallet::CoreWalletManager;
 use lampo_jsonrpc::Handler;
 use lampo_jsonrpc::JSONRPCv2;
 use lampod::chain::WalletManager;
-
+use lampod::jsonrpc::channels::json_close_channel;
+use lampod::jsonrpc::channels::json_list_channels;
 use lampod::jsonrpc::inventory::get_info;
 use lampod::jsonrpc::offchain::json_decode_invoice;
 use lampod::jsonrpc::offchain::json_invoice;
@@ -32,7 +32,6 @@ use lampod::jsonrpc::onchain::json_funds;
 use lampod::jsonrpc::onchain::json_new_addr;
 use lampod::jsonrpc::open_channel::json_open_channel;
 use lampod::jsonrpc::peer_control::json_connect;
-
 use lampod::jsonrpc::CommandHandler;
 use lampod::LampoDeamon;
 
@@ -47,7 +46,16 @@ fn main() -> error::Result<()> {
 
 /// Return the root directory.
 fn run(args: LampoCliArgs) -> error::Result<()> {
-    let mnemonic = args.mnemonic.clone();
+    let mnemonic = if args.restore_wallet {
+        let inputs: String = term::input(
+            "BIP 39 Mnemonic",
+            None,
+            Some("To restore the wallet, lampo needs a BIP39 mnemonic with words separated by spaces."),
+        )?;
+        Some(inputs)
+    } else {
+        None
+    };
 
     // After this point the configuration is ready!
     let mut lampo_conf: LampoConf = args.try_into()?;


### PR DESCRIPTION
Before this commit the mnemonic was passed by
command line option and it was a privacy leak because the information was stored inside the terminal history.

With this commit, we ask the seeds as input each time that lampo is run with `--restore-wallet` option.

In the future, this option will be required only the first time of initialization of the wallet.

Fixes: https://github.com/vincenzopalazzo/lampo.rs/issues/211

oversees https://github.com/vincenzopalazzo/lampo.rs/pull/213