### PR TITLE
feat(getinfo) : specify address inside getinfo

### DIFF
--- a/lampo-common/src/model.rs
+++ b/lampo-common/src/model.rs
@@ -13,7 +13,7 @@ pub use getinfo::GetInfo;
 pub mod request {
     pub use crate::model::close_channel::request::*;
     pub use crate::model::connect::Connect;
-    pub use crate::model::getinfo::GetInfo;
+    pub use crate::model::getinfo::*;
     pub use crate::model::invoice::request::*;
     pub use crate::model::keysend::request::*;
     pub use crate::model::new_addr::request::*;
@@ -25,7 +25,7 @@ pub mod request {
 pub mod response {
     pub use crate::model::close_channel::response::*;
     pub use crate::model::connect::Connect;
-    pub use crate::model::getinfo::GetInfo;
+    pub use crate::model::getinfo::*;
     pub use crate::model::invoice::response::*;
     pub use crate::model::keysend::response::*;
     pub use crate::model::new_addr::response::*;

--- a/lampo-common/src/model/getinfo.rs
+++ b/lampo-common/src/model/getinfo.rs
@@ -9,4 +9,11 @@ pub struct GetInfo {
     pub alias: String,
     pub blockheight: u32,
     pub lampo_dir: String,
+    pub address: Vec<NetworkInfo>,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct NetworkInfo {
+    pub address: String,
+    pub port: u64,
 }

--- a/lampod/src/ln/inventory_manager.rs
+++ b/lampod/src/ln/inventory_manager.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 
 use lampo_common::error;
 use lampo_common::json;
+use lampo_common::model::response::NetworkInfo;
 
 use super::{LampoChannelManager, LampoPeerManager};
 use crate::actions::InventoryHandler;
@@ -39,6 +40,18 @@ impl InventoryHandler for LampoInventoryManager {
                 let (_, height) = self.channel_manager.onchain.backend.get_best_block()?;
                 let blockheight = height.unwrap_or_default();
                 let lampo_dir = self.channel_manager.conf.root_path.to_string();
+                // We provide a vector here as there may be other types of address in future like tor and ipv6.
+                let mut address_vec = Vec::new();
+                let address = self.channel_manager.conf.announce_addr.clone();
+                if let Some(addr) = address {
+                    let port = self.channel_manager.conf.port.clone();
+                    // For now we don't iterate as there is only one type of address.
+                    let address_info = NetworkInfo {
+                        address: addr,
+                        port,
+                    };
+                    address_vec.push(address_info);
+                }
                 let getinfo = GetInfo {
                     node_id: self.channel_manager.manager().get_our_node_id().to_string(),
                     peers: self.peer_manager.manager().list_peers().len(),
@@ -47,6 +60,7 @@ impl InventoryHandler for LampoInventoryManager {
                     alias,
                     blockheight,
                     lampo_dir,
+                    address: address_vec,
                 };
                 let getinfo = json::to_value(getinfo)?;
                 chan.send(getinfo)?;


### PR DESCRIPTION
This commit adds the address inside `getinfo` command. Changelog:
- Adds `NetworkInfo` response inside lampo_common::model
  This is done taking in mind the future work that we do on lampo. 

Sample output for `getinfo` :

```
[doom@archlinux ~]$ lampo-cli --network regtest getinfo
{
  "node_id": "02cc3f4c11351843d755569204a69c48cb4233b788392a13d3cf67bb412b14c90f",
  "peers": 0,
  "channels": 0,
  "chain": "regtest",
  "alias": "doom",
  "blockheight": 105,
  "lampo_dir": "/home/doom/.lampo",
  "address": [
    {
      "address": "127.0.0.1",
      "port": 39736
    }
  ]
}

```