### PR TITLE
Fixes related to `address` inside conf.

### DIFF
--- a/lampod-cli/src/main.rs
+++ b/lampod-cli/src/main.rs
@@ -155,7 +155,7 @@ fn run(args: LampoCliArgs) -> error::Result<()> {
         std::process::exit(0);
     })?;
 
-    let workder = lampod.listen().unwrap();
+    let workder = lampod.listen()?;
     log::info!(target: "lampod-cli", "------------ Starting Server ------------");
     let _ = workder.join();
     let _ = jsorpc_worker.join().unwrap();

--- a/lampod/src/lib.rs
+++ b/lampod/src/lib.rs
@@ -271,7 +271,7 @@ impl LampoDeamon {
         log::info!(target: "lampo", "Stating onchaind");
         let _ = self.onchain_manager().backend.clone().listen();
         log::info!(target: "lampo", "Starting peer manager");
-        let _ = self.peer_manager().run();
+        let _ = self.peer_manager().run()?;
         log::info!(target: "lampo", "Starting channel manager");
         let _ = self.channel_manager().listen();
         Ok(std::thread::spawn(move || {

--- a/lampod/src/ln/peer_manager.rs
+++ b/lampod/src/ln/peer_manager.rs
@@ -132,13 +132,10 @@ impl LampoPeerManager {
             .clone()
             .ok_or(error::anyhow!("channel manager is None"))?;
         let alias = self.conf.alias.clone().unwrap_or_default();
-        let addr = if let Some(addr) = self.conf.announce_addr.clone() {
-            addr
-        } else {
-            log::warn!("Address not specified inside conf, node is not reachable");
+        let Some(addr) = self.conf.announce_addr.clone() else {
             return Ok(());
         };
-        std::thread::spawn(move || {
+        let result = std::thread::spawn(move || {
             let result = async_run!(async move {
                 let bind_addr = format!("{addr}:{listen_port}");
                 log::info!(target: "lampo", "Listening for in-bound connection on {bind_addr}");
@@ -204,6 +201,7 @@ impl LampoPeerManager {
             }
             result
         });
+        result.join().unwrap()?;
         Ok(())
     }
 

--- a/lampod/src/ln/peer_manager.rs
+++ b/lampod/src/ln/peer_manager.rs
@@ -132,11 +132,12 @@ impl LampoPeerManager {
             .clone()
             .ok_or(error::anyhow!("channel manager is None"))?;
         let alias = self.conf.alias.clone().unwrap_or_default();
-        let addr = self
-            .conf
-            .announce_addr
-            .clone()
-            .unwrap_or_else(|| "127.0.0.1".to_string());
+        let addr = if let Some(addr) = self.conf.announce_addr.clone() {
+            addr
+        } else {
+            log::warn!("Address not specified inside conf, node is not reachable");
+            return Ok(());
+        };
         std::thread::spawn(move || {
             let result = async_run!(async move {
                 let bind_addr = format!("{addr}:{listen_port}");


### PR DESCRIPTION
There are two things that are addressed here : 

1. Throw a warning that the node is not reachable if the `announce-addr` inside `conf` is not present.
2. Stop the node in case the `announce-addr` mentioned inside the `conf` is wrong or could not be binded.
Fixes #231 