### PR TITLE
catch the error of rebrodicasting tx already inside the blockchain

### DIFF
--- a/lampo-common/src/backend.rs
+++ b/lampo-common/src/backend.rs
@@ -79,7 +79,7 @@ pub trait Backend {
     /// the listener through the handler.
     fn listen(self: Arc<Self>) -> error::Result<JoinHandle<()>>;
     /// Get the information of a transaction inside the blockchain.
-    fn get_transaction(&self, txid: &Txid) -> error::Result<TxResult>;
+    fn get_transaction(&self, txid: &Txid, wallet_tx: bool) -> error::Result<TxResult>;
     /// Process the transactions
     fn process_transactions(&self) -> error::Result<()>;
 }


### PR DESCRIPTION
I do not like commit 760541c1753cec93e9c6df105a5f4e733b8ad42b because it requires the -txindex option in Bitcoin Core.

An alternative solution is also discussed in the issue, suggesting that this is not a significant problem since we already lost the transaction with a unilateral close. I am considering taking some time to ensure that we can track the block syncing status. By doing this, we can address the problem in another way.