### PR TITLE
lampod: fixing panicing of the background task

### DIFF
--- a/lampod/src/lib.rs
+++ b/lampod/src/lib.rs
@@ -257,6 +257,13 @@ impl LampoDaemon {
             }
         };
 
+        log::info!(target: "lampo", "Stating onchaind");
+        let _ = self.onchain_manager().backend.clone().listen();
+        log::info!(target: "lampo", "Starting peer manager");
+        let _ = self.peer_manager().run();
+        log::info!(target: "lampo", "Starting channel manager");
+        let _ = self.channel_manager().listen();
+
         let background_processor = BackgroundProcessor::start(
             self.persister.clone(),
             event_handler,
@@ -268,12 +275,6 @@ impl LampoDaemon {
             Some(self.channel_manager().scorer()),
         );
 
-        log::info!(target: "lampo", "Stating onchaind");
-        let _ = self.onchain_manager().backend.clone().listen();
-        log::info!(target: "lampo", "Starting peer manager");
-        let _ = self.peer_manager().run();
-        log::info!(target: "lampo", "Starting channel manager");
-        let _ = self.channel_manager().listen();
         Ok(std::thread::spawn(move || {
             let _ = background_processor.join();
             Ok(())

--- a/lampod/src/utils/logger.rs
+++ b/lampod/src/utils/logger.rs
@@ -22,7 +22,7 @@ impl FromStr for LogLevel {
         match s {
             "debug" => Ok(LogLevel::Debug),
             "info" => Ok(LogLevel::Info),
-            "warning" => Ok(LogLevel::Warn),
+            "warn" => Ok(LogLevel::Warn),
             "error" => Ok(LogLevel::Error),
             "trace" => Ok(LogLevel::Trace),
             _ => Err(format!("Unknown {} level", s)),


### PR DESCRIPTION
ldk was generating a warning log, and we were implementing a wrong match on the string `warning` so the background process was panicking and we were not able to receive the ldk events sometimes.

Fixes: https://github.com/vincenzopalazzo/lampo.rs/issues/218