### PR TITLE
lampod: fixing the decode bolt12 offer

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Community Support
+    url: https://discord.gg/j2QNJHxh8J
+    about: Please ask and answer questions here.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,0 @@
-blank_issues_enabled: false
-contact_links:
-  - name: Community Support
-    url: https://discord.gg/j2QNJHxh8J
-    about: Please ask and answer questions here.

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ default: fmt
 
 fmt:
 	$(CC) fmt --all
-	$(CC) clippy --workspace
+	# $(CC) clippy --workspace
 
 check:
 	$(CC) test --all -- --show-output

--- a/flake.nix
+++ b/flake.nix
@@ -78,7 +78,7 @@
 
         devShell = pkgs.mkShell {
           nativeBuildInputs = with pkgs; [ pkg-config ];
-          buildInputs = with pkgs; [ gnumake rustc cargo rustfmt openssl openssl.dev ] ++ cln-env-shell;
+          buildInputs = with pkgs; [ gnumake rustup openssl openssl.dev ] ++ cln-env-shell;
           shellHook = ''
             export HOST_CC=gcc
             export RUST_BACKTRACE=1

--- a/lampo-common/src/model/invoice.rs
+++ b/lampo-common/src/model/invoice.rs
@@ -62,8 +62,8 @@ pub mod response {
 
     #[derive(Serialize, Deserialize)]
     pub struct InvoiceInfo {
-        pub expiry_time: u64,
-        pub description: String,
+        pub expiry_time: Option<u64>,
+        pub description: Option<String>,
         pub routes: Vec<String>,
         pub hints: Vec<String>,
         pub network: String,

--- a/lampo-common/src/model/invoice.rs
+++ b/lampo-common/src/model/invoice.rs
@@ -16,10 +16,9 @@ pub mod request {
         pub description: Option<String>,
     }
 
-    #[derive(Serialize, Deserialize)]
+    #[derive(Debug, Serialize, Deserialize)]
     pub struct DecodeInvoice {
         pub invoice_str: String,
-        pub amount: Option<u64>,
     }
 
     #[derive(Serialize, Deserialize)]
@@ -60,8 +59,9 @@ pub mod response {
         }
     }
 
-    #[derive(Serialize, Deserialize)]
+    #[derive(Debug, Serialize, Deserialize)]
     pub struct InvoiceInfo {
+        pub issuer_id: Option<String>,
         pub expiry_time: Option<u64>,
         pub description: Option<String>,
         pub routes: Vec<String>,

--- a/lampo-jsonrpc/src/lib.rs
+++ b/lampo-jsonrpc/src/lib.rs
@@ -206,6 +206,9 @@ impl<T: Send + Sync + 'static> JSONRPCv2<T> {
             self.sources.poll(&mut events, Timeout::Never)?;
             for mut event in events.drain(..) {
                 match &event.key {
+                    // FIXME: this is just for the moment because
+                    // we are moving to https://github.com/vincenzopalazzo/lampo.rs/pull/246
+                    #[allow(clippy::never_loop)]
                     RPCEvent::Accept => loop {
                         let accept = self.socket.accept();
                         if let Err(err) = accept {

--- a/lampod/src/jsonrpc/offchain.rs
+++ b/lampod/src/jsonrpc/offchain.rs
@@ -68,6 +68,7 @@ pub fn json_decode_invoice(ctx: &LampoDaemon, request: &json::Value) -> Result<j
         .decode::<ldk::invoice::Bolt11Invoice>(&request.invoice_str)
     {
         InvoiceInfo {
+            issuer_id: invoice.payee_pub_key().map(|id| id.to_string()),
             amount_msa: invoice.amount_milli_satoshis(),
             network: invoice.network().to_string(),
             description: match invoice.description() {
@@ -94,6 +95,7 @@ pub fn json_decode_invoice(ctx: &LampoDaemon, request: &json::Value) -> Result<j
             .unwrap_or(&Network::Bitcoin.to_string())
             .clone();
         InvoiceInfo {
+            issuer_id: offer.issuer().map(|id| id.to_string()),
             amount_msa: offer.amount().map(|a| {
                 if let Amount::Bitcoin { amount_msats } = a {
                     amount_msats.clone()

--- a/lampod/src/ln/offchain_manager.rs
+++ b/lampod/src/ln/offchain_manager.rs
@@ -87,6 +87,13 @@ impl OffchainManager {
         Ok(invoice)
     }
 
+    pub fn decode<T: FromStr>(&self, invoice_str: &str) -> error::Result<T> {
+        let invoice = invoice_str
+            .parse::<T>()
+            .map_err(|_| error::anyhow!("Impossible decode the invoice `{invoice_str}`"))?;
+        Ok(invoice)
+    }
+
     pub fn pay_offer(&self, offer_str: &str, amount_msat: Option<u64>) -> error::Result<()> {
         // check if it is an invoice or an offer
         let offer_hash = Sha256::hash(offer_str.as_bytes());

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,1 +1,4 @@
-1.72
+[toolchain]
+channel = "stable"
+components = [ "rustfmt" ]
+profile = "minimal"

--- a/tests/tests/src/lampo_cln_tests.rs
+++ b/tests/tests/src/lampo_cln_tests.rs
@@ -632,7 +632,10 @@ pub fn decode_invoice_from_cln() {
             }),
         )
         .unwrap();
-    assert_eq!(decode.description, "need to be decoded by lampo");
+    assert_eq!(
+        decode.description,
+        Some("need to be decoded by lampo".to_owned())
+    );
     async_run!(cln.stop()).unwrap();
 }
 


### PR DESCRIPTION
Fixing the following error

➜  ~ lampo-cli --network testnet decode --invoice_str lno1qgsyxjtl6luzd9t3pr62xr7eemp6awnejusgf6gw45q75vcfqqqqqqqgqgn3qzs6danxvetjypnx7u3qwfjhqmmjwss8g6r9yp5hxum4v5tzzqctdp4pvw4zhwsre6ach2mh0ravy52nvjvpg80s5smddzp494px7c {
  "code": -1,
  "message": "Invalid bech32: invalid checksum",
  "data": null
}