### PR TITLE
jsonrpc: add the possibility to fetch the network graph info

### DIFF
--- a/lampo-common/src/model.rs
+++ b/lampo-common/src/model.rs
@@ -3,6 +3,7 @@ mod connect;
 mod getinfo;
 mod invoice;
 mod keysend;
+mod network;
 mod new_addr;
 mod on_chain;
 mod open_channel;
@@ -16,6 +17,7 @@ pub mod request {
     pub use crate::model::getinfo::*;
     pub use crate::model::invoice::request::*;
     pub use crate::model::keysend::request::*;
+    pub use crate::model::network::request::*;
     pub use crate::model::new_addr::request::*;
     #[allow(unused_imports)]
     pub use crate::model::on_chain::request::*;
@@ -28,6 +30,7 @@ pub mod response {
     pub use crate::model::getinfo::*;
     pub use crate::model::invoice::response::*;
     pub use crate::model::keysend::response::*;
+    pub use crate::model::network::response::*;
     pub use crate::model::new_addr::response::*;
     pub use crate::model::on_chain::response::*;
     pub use crate::model::open_channel::response::*;

--- a/lampo-common/src/model/network.rs
+++ b/lampo-common/src/model/network.rs
@@ -1,0 +1,26 @@
+pub mod request {}
+
+pub mod response {
+    use lightning::routing::gossip::ChannelInfo;
+    use serde::{Deserialize, Serialize};
+
+    #[derive(Serialize, Deserialize, Debug, Clone)]
+    pub struct NetworkChannels {
+        pub channels: Vec<NetworkChannel>,
+    }
+
+    #[derive(Clone, Serialize, Deserialize, Debug)]
+    pub struct NetworkChannel {
+        pub node_one: String,
+        pub node_two: String,
+    }
+
+    impl From<ChannelInfo> for NetworkChannel {
+        fn from(value: ChannelInfo) -> Self {
+            Self {
+                node_one: value.node_one.to_string(),
+                node_two: value.node_two.to_string(),
+            }
+        }
+    }
+}

--- a/lampo-testing/src/lib.rs
+++ b/lampo-testing/src/lib.rs
@@ -16,6 +16,7 @@ use lampo_common::json;
 use lampo_common::model::response;
 use lampo_common::model::response::NewAddress;
 use lampod::jsonrpc::channels::json_close_channel;
+use lampod::jsonrpc::inventory::json_network_channels;
 use lampod::jsonrpc::offchain::json_keysend;
 use tempfile::TempDir;
 
@@ -122,6 +123,9 @@ impl LampoTesting {
         server.add_rpc("pay", json_pay).unwrap();
         server.add_rpc("keysend", json_keysend).unwrap();
         server.add_rpc("close", json_close_channel).unwrap();
+        server
+            .add_rpc("networkchannels", json_network_channels)
+            .unwrap();
         let handler = server.handler();
         let rpc_handler = Arc::new(CommandHandler::new(&lampo_conf)?);
         rpc_handler.set_handler(handler);

--- a/lampod/src/jsonrpc/channels.rs
+++ b/lampod/src/jsonrpc/channels.rs
@@ -14,7 +14,7 @@ use crate::LampoDaemon;
 
 pub fn json_list_channels(ctx: &LampoDaemon, request: &json::Value) -> Result<json::Value, Error> {
     log::info!("call for `list_channels` with request {:?}", request);
-    let resp = ctx.channel_manager().list_channel();
+    let resp = ctx.channel_manager().list_channels();
     Ok(json::to_value(resp)?)
 }
 

--- a/lampod/src/jsonrpc/inventory.rs
+++ b/lampod/src/jsonrpc/inventory.rs
@@ -1,5 +1,6 @@
 //! Inventory method implementation
 use lampo_common::json;
+use lampo_common::model::response::{NetworkChannel, NetworkChannels};
 use lampo_jsonrpc::errors::Error;
 
 use crate::LampoDaemon;
@@ -8,4 +9,21 @@ pub fn get_info(ctx: &LampoDaemon, request: &json::Value) -> Result<json::Value,
     log::info!("calling `getinfo` with request `{:?}`", request);
     let result = ctx.call("getinfo", request.clone())?;
     Ok(result)
+}
+
+// FIXME: check the request
+pub fn json_network_channels(ctx: &LampoDaemon, _: &json::Value) -> Result<json::Value, Error> {
+    let network_graph = ctx.channel_manager().graph();
+    let network_graph = network_graph.read_only();
+    let channels = network_graph.channels().unordered_keys();
+    let mut network_channels = Vec::new();
+    for short_id in channels {
+        let Some(channel) = network_graph.channel(*short_id) else {
+            continue;
+        };
+        network_channels.push(NetworkChannel::from(channel.clone()));
+    }
+    Ok(json::to_value(NetworkChannels {
+        channels: network_channels,
+    })?)
 }

--- a/lampod/src/ln/channel_manager.rs
+++ b/lampod/src/ln/channel_manager.rs
@@ -21,7 +21,7 @@ use lampo_common::ldk::ln::channelmanager::{
     ChainParameters, ChannelManager, ChannelManagerReadArgs,
 };
 use lampo_common::ldk::persister::fs_store::FilesystemStore;
-use lampo_common::ldk::routing::gossip::NetworkGraph;
+use lampo_common::ldk::routing::gossip::{NetworkGraph, ReadOnlyNetworkGraph};
 use lampo_common::ldk::routing::router::DefaultRouter;
 use lampo_common::ldk::routing::scoring::{
     ProbabilisticScorer, ProbabilisticScoringDecayParameters, ProbabilisticScoringFeeParameters,
@@ -192,7 +192,7 @@ impl LampoChannelManager {
         self.channeld.clone().unwrap()
     }
 
-    pub fn list_channel(&self) -> Channels {
+    pub fn list_channels(&self) -> Channels {
         let channels: Vec<Channel> = self
             .manager()
             .list_channels()


### PR DESCRIPTION
This is going to reproduce https://github.com/vincenzopalazzo/lampo.rs/issues/256

Fixes https://github.com/vincenzopalazzo/lampo.rs/issues/256

To run the test consider running `nix develop --command bash -c 'make integration ARGS="-- --test-threads 1 test_sync_gossip_from_network_cln" TEST_LOG_LEVEL=info'` without wasting time in building the test environment.