### PR TITLE
common: fix the compilation in logger

### DIFF
--- a/lampo-common/src/logger.rs
+++ b/lampo-common/src/logger.rs
@@ -53,7 +53,7 @@ impl Log for Logger {
                 writeln!(
                     stream,
                     "{} {}",
-                    DateTime::from(SystemTime::now())
+                    DateTime::<Utc>::from(SystemTime::now())
                         .to_rfc3339_opts(SecondsFormat::Millis, true)
                         .white(),
                     message,


### PR DESCRIPTION
error[E0283]: type annotations needed
  --> /home/vincent/.cargo/git/checkouts/lampo.rs-b9f97ec6bc9274e3/bc15e03/lampo-common/src/logger.rs:56:21
   |
56 |                     DateTime::from(SystemTime::now())
   |                     ^^^^^^^^ cannot infer type for struct `chrono::DateTime<_>`
   |
   = note: multiple `impl`s satisfying `chrono::DateTime<_>: From<SystemTime>` found in the `chrono` crate:
           - impl From<SystemTime> for chrono::DateTime<Local>;
           - impl From<SystemTime> for chrono::DateTime<Utc>;

   Compiling h2 v0.3.26