### PR TITLE
tests: gossip sync across hops

### DIFF
--- a/tests/tests/src/lampo_cln_tests.rs
+++ b/tests/tests/src/lampo_cln_tests.rs
@@ -1302,3 +1302,109 @@ fn test_sync_gossip_from_network_cln() {
 
     async_run!(cln1.stop()).unwrap();
 }
+
+#[test]
+fn test_sync_gossip_from_network_cln_between_nodes() {
+    init();
+    let mut cln = async_run!(cln::Node::with_params(
+        "--developer --dev-bitcoind-poll=1 --dev-fast-gossip --dev-allow-localhost",
+        "regtest"
+    ))
+    .unwrap();
+    let btc = cln.btc();
+
+    let lampo_manager = LampoTesting::new(btc.clone()).unwrap();
+    let lampo = lampo_manager.lampod();
+    let info: response::GetInfo = lampo.call("getinfo", json::json!({})).unwrap();
+    let events = lampo.events();
+    let address = lampo_manager.fund_wallet(101).unwrap();
+    wait!(|| {
+        let Ok(Event::OnChain(OnChainEvent::NewBestBlock((_, height)))) =
+            events.recv_timeout(Duration::from_millis(100))
+        else {
+            return Err(());
+        };
+        if height.to_consensus_u32() == 101 {
+            return Ok(());
+        }
+        Err(())
+    });
+    let _: json::Value = lampo
+        .call(
+            "fundchannel",
+            request::OpenChannel {
+                node_id: cln.rpc().getinfo().unwrap().id,
+                port: Some(cln.port.into()),
+                amount: 1_500_000_000,
+                public: true,
+                addr: Some("127.0.0.1".to_owned()),
+            },
+        )
+        .unwrap();
+
+    // Get the transaction confirmed
+    let _ = btc.rpc().generate_to_address(6, &address).unwrap();
+    wait!(|| {
+        log::info!(target: "tests", "wait for confimetion");
+        let _ = btc.rpc().generate_to_address(1, &address).unwrap();
+        // Get the transaction confirmed
+        for _ in 0..100 {
+            let Ok(event) = events.recv_timeout(Duration::from_nanos(100)) else {
+                continue;
+            };
+            log::info!(target: "tests", "lampo event: {:?}", event);
+            match event {
+                Event::Lightning(LightningEvent::ChannelReady { .. }) => return Ok(()),
+                _ => continue,
+            };
+        }
+        Err(())
+    });
+
+    wait!(|| {
+        let channels = cln.rpc().listfunds().unwrap().channels;
+        if channels.is_empty() {
+            return Err(());
+        }
+
+        let mut channels = cln.rpc().listfunds().unwrap().channels;
+        let origin_size = channels.len();
+        channels.retain(|chan| chan.state == "CHANNELD_NORMAL");
+        if channels.len() == origin_size {
+            return Ok(());
+        }
+
+        let channels: response::Channels = lampo.call("channels", json::json!({})).unwrap();
+        if !channels.channels.first().unwrap().ready {
+            return Err(());
+        }
+        let address = cln.rpc().newaddr(None).unwrap();
+        fund_wallet(btc.clone(), &address.bech32.unwrap(), 1).unwrap();
+        crate::wait_cln_sync!(cln);
+        Err(())
+    });
+
+    let endnode_manager = LampoTesting::new(btc.clone()).unwrap();
+    let endnode = endnode_manager.lampod();
+
+    let _: json::Value = endnode
+        .call(
+            "connect",
+            Connect {
+                node_id: info.node_id,
+                addr: "127.0.0.1".to_owned(),
+                port: lampo_manager.port.into(),
+            },
+        )
+        .unwrap();
+    wait!(|| {
+        let channels: NetworkChannels = endnode.call("networkchannels", json::json!({})).unwrap();
+        log::warn!("{:?}", channels);
+        if channels.channels.len() > 0 {
+            return Ok(());
+        }
+        Err(())
+    });
+
+    async_run!(cln.stop()).unwrap();
+}


### PR DESCRIPTION
This is making sure that we can fetch gossip from cln, with the following configuration

`cln <-> ldk1 <-> ldk2`, in this case ldk2 should see the channel between `cln <-> ldk1`