### PR TITLE
common: add gossip level as a debug

### DIFF
--- a/lampo-common/src/utils/logger.rs
+++ b/lampo-common/src/utils/logger.rs
@@ -25,6 +25,7 @@ impl FromStr for LogLevel {
             "warn" => Ok(LogLevel::Warn),
             "error" => Ok(LogLevel::Error),
             "trace" => Ok(LogLevel::Trace),
+            "gossip" => Ok(LogLevel::Debug),
             _ => Err(format!("Unknown {} level", s)),
         }
     }


### PR DESCRIPTION
```
2024-08-29T13:14:46.182Z DEBUG   021e9677478fef6e0ff9a64a83f996c7eb31524dc4b7f8b99543224fad3c557885-lightningd: Will try reconnect in 44 seconds
thread 'main' panicked at /home/vincent/.cargo/git/checkouts/lampo.rs-b9f97ec6bc9274e3/c22063d/lampo-common/src/utils/logger.rs:65:53:
called `Result::unwrap()` on an `Err` value: "Unknown gossip level"
```