### PR TITLE
Fixes stuff inside bolt12 decode

### DIFF
--- a/lampo-common/src/model/invoice.rs
+++ b/lampo-common/src/model/invoice.rs
@@ -89,12 +89,16 @@ pub mod response {
                 .map(|chain| chain.to_string())
                 .collect::<Vec<String>>();
 
-            // Reference: https://github.com/lightning/bolts/blob/master/12-offer-encoding.md
+            // Reference: https://github.com/lightning/bolts/blob/master/12-offer-encoding.md#requirements-for-offers
+            // if the chain for the invoice is not solely bitcoin:
+            // MUST specify offer_chains the offer is valid for.
+            // otherwise:
+            // SHOULD omit offer_chains, implying that bitcoin is only chain.
             let network = offer
                 .chains()
                 .first()
-                .map(|hash| Network::from_chain_hash(*hash))
-                .unwrap_or(Some(Network::Bitcoin));
+                .and_then(|hash| Network::from_chain_hash(*hash))
+                .or(Some(Network::Bitcoin));
 
             let paths = offer
                 .paths()

--- a/lampo-testing/src/lib.rs
+++ b/lampo-testing/src/lib.rs
@@ -116,9 +116,7 @@ impl LampoTesting {
         server.add_rpc("funds", json_funds).unwrap();
         server.add_rpc("invoice", json_invoice).unwrap();
         server.add_rpc("offer", json_offer).unwrap();
-        server
-            .add_rpc("decode_invoice", json_decode_invoice)
-            .unwrap();
+        server.add_rpc("decode", json_decode_invoice).unwrap();
 
         server.add_rpc("pay", json_pay).unwrap();
         server.add_rpc("keysend", json_keysend).unwrap();

--- a/lampod/src/jsonrpc/offchain.rs
+++ b/lampod/src/jsonrpc/offchain.rs
@@ -89,11 +89,7 @@ pub fn json_decode_invoice(ctx: &LampoDaemon, request: &json::Value) -> Result<j
         let bolt12_invoice: Bolt12InvoiceInfo = offer.into();
         return Ok(json::to_value(&bolt12_invoice)?);
     } else {
-        Err(Error::Rpc(RpcError {
-            code: -1,
-            message: "Not able to decode invoice".to_string(),
-            data: None,
-        }))
+        Err(crate::rpc_error!("Not able to decode invoice"))
     }
 }
 

--- a/tests/tests/src/lampo_cln_tests.rs
+++ b/tests/tests/src/lampo_cln_tests.rs
@@ -9,7 +9,7 @@ use lampo_common::handler::Handler;
 use lampo_common::json;
 use lampo_common::model::request;
 use lampo_common::model::response;
-use lampo_common::model::response::InvoiceInfo;
+use lampo_common::model::response::Bolt11InvoiceInfo;
 use lampo_common::model::response::NetworkChannels;
 use lampo_common::model::response::Offer;
 use lampo_common::model::Connect;
@@ -625,9 +625,9 @@ pub fn decode_invoice_from_cln() {
             None,
         )
         .unwrap();
-    let decode: InvoiceInfo = lampo
+    let decode: Bolt11InvoiceInfo = lampo
         .call(
-            "decode_invoice",
+            "decode",
             json::json!({
                 "invoice_str": invoce.bolt11,
             }),

--- a/tests/tests/src/lampo_tests.rs
+++ b/tests/tests/src/lampo_tests.rs
@@ -509,3 +509,28 @@ pub fn decode_offer() -> error::Result<()> {
     log::info!(target: &node2.info.node_id, "decode offer `{:?}`", decode);
     Ok(())
 }
+
+#[test]
+pub fn decode_offer_hex() -> error::Result<()> {
+    init();
+    let btc = async_run!(btc::BtcNode::tmp("regtest"))?;
+    let btc = Arc::new(btc);
+    let node1 = Arc::new(LampoTesting::new(btc.clone())?);
+
+    // For now I am hardcoding this offer as generating an `offer` from test is broken at this point.
+    let decode: response::Bolt12InvoiceInfo = node1.lampod().call(
+        "decode",
+        request::DecodeInvoice {
+            invoice_str: "lno1qgsyxjtl6luzd9t3pr62xr7eemp6awnejusgf6gw45q75vcfqqqqqqqsespexwyy4tcadvgg89l9aljus6709kx235hhqrk6n8dey98uyuftzdqzrtkahuum7m56dxlnx8r6tffy54004l7kvs7pylmxx7xs4n54986qyqeeuhhunayntt50snmdkq4t7fzsgghpl69v9csgparek8kv7dlp5uqr8ymp5s4z9upmwr2s8xu020d45t5phqc8nljrq8gzsjmurzevawjz6j6rc95xwfvnhgfx6v4c3jha7jwynecrz3y092nn25ek4yl7xp9yu9ry9zqagt0ktn4wwvqg52v9ss9ls22sqyqqestzp2l6decpn87pq96udsvx".to_string(),
+        },
+    )?;
+
+    assert_eq!(
+        decode.offer_id,
+        "34460869549e37748ceaabdcff6284a98266c18052ab2a7e9eb5a1af0a5e5b7d"
+    );
+    // Checks if all the character inside the offer_id is hex.
+    let res = decode.offer_id.chars().all(|c| c.is_ascii_hexdigit());
+    assert!(res);
+    Ok(())
+}

--- a/tests/tests/src/lampo_tests.rs
+++ b/tests/tests/src/lampo_tests.rs
@@ -498,14 +498,14 @@ pub fn decode_offer() -> error::Result<()> {
 
     log::info!(target: &node2.info.node_id, "offer generated `{:?}`", offer);
 
-    let decode: response::InvoiceInfo = node2.lampod().call(
+    let decode: response::Bolt12InvoiceInfo = node2.lampod().call(
         "decode",
         request::DecodeInvoice {
             invoice_str: offer.bolt12,
         },
     )?;
 
-    assert_eq!(decode.issuer_id, Some(node2.info.node_id.clone()));
+    assert_eq!(decode.issuer_id.clone(), Some(node2.info.node_id.clone()));
     log::info!(target: &node2.info.node_id, "decode offer `{:?}`", decode);
     Ok(())
 }


### PR DESCRIPTION
Decoding bolt12 now:

```
[harshit:~] lampo-cli --network regtest decode --invoice_str lno1qgsyxjtl6luzd9t3pr62xr7eemp6awnejusgf6gw45q75vcfqqqqqqqsespexwyy4tcadvgg89l9aljus6709kx235hhqrk6n8dey98uyuftzdqzrtkahuum7m56dxlnx8r6tffy54004l7kvs7pylmxx7xs4n54986qyqeeuhhunayntt50snmdkq4t7fzsgghpl69v9csgparek8kv7dlp5uqr8ymp5s4z9upmwr2s8xu020d45t5phqc8nljrq8gzsjmurzevawjz6j6rc95xwfvnhgfx6v4c3jha7jwynecrz3y092nn25ek4yl7xp9yu9ry9zqagt0ktn4wwvqg52v9ss9ls22sqyqqestzp2l6decpn87pq96udsvx
{
  "issuer": "No issuer id provided",
  "offer_id": "[52, 70, 8, 105, 84, 158, 55, 116, 140, 234, 171, 220, 255, 98, 132, 169, 130, 102, 193, 128, 82, 171, 42, 126, 158, 181, 161, 175, 10, 94, 91, 125]",
  "offer_chains": [
    "43497fd7f826957108f4a30fd9cec3aeba79972084e90ead01ea330900000000"
  ],
  "description": "Description not provided",
  "offer_paths": [
    {
      "blinded_hops": [
        "0339e5efc9f4935ae8f84f6db02abf2450422e1fe8ac2e2080f479b1eccf37e1a7",
        "031448f2aa7355336a93fe304a4e14642881d42df65ceae73008a2985840bf8295"
      ],
      "blinding_points": "021aeddbf39bf6e9a69bf331c7a5a524a55efaffd6643c127f66378d0ace9529f4"
    }
  ],
  "network": "testnet"
}
```

If the bolt11/bolt12 is invalid:
```
[harshit:~] lampo-cli --network regtest decode --invoice_str lno1qgsyxjtl6luzd9t3pr62xr7eemp6awnejusgf6gw45q75vcfqqqqqqqsespexwyy4tcadvgg89l9aljus6709kx235hhqrk6n8dey98uyuftzdqzrtkahuum7m56dxlnx8r6tffy54004l7kvs7pylmxx7xs4n54986qyqeeuhhunayntt50snmdkq4t7fzsgghpl69v9csgparek8kv7dlp5uqr8ymp5s4z9upmwr2s8xu020d45t5phqc8nljrq8gzsjmurzevawjz6j6rc95xwfvnhgfx6v4c3jha7jwynecrz3y092nn25ek4yl7xp9yu9ry9zqagt0ktn4wwvqg52v9ss9ls22sqyqqestzp2l6decpn87pq96uds
{
  "code": -1,
  "message": "Not able to decode invoice",
  "data": null
}
```

UPDATE:

Running `lampo-cli --network regtest decode --invoice_str lno1qgsyxjtl6luzd9t3pr62xr7eemp6awnejusgf6gw45q75vcfqqqqqqqsespexwyy4tcadvgg89l9aljus6709kx235hhqrk6n8dey98uyuftzdqzrtkahuum7m56dxlnx8r6tffy54004l7kvs7pylmxx7xs4n54986qyqeeuhhunayntt50snmdkq4t7fzsgghpl69v9csgparek8kv7dlp5uqr8ymp5s4z9upmwr2s8xu020d45t5phqc8nljrq8gzsjmurzevawjz6j6rc95xwfvnhgfx6v4c3jha7jwynecrz3y092nn25ek4yl7xp9yu9ry9zqagt0ktn4wwvqg52v9ss9ls22sqyqqestzp2l6decpn87pq96udsvx`

Gives the following output:
```
{
  "issuer_id": null,
  "offer_id": "34460869549e37748ceaabdcff6284a98266c18052ab2a7e9eb5a1af0a5e5b7d",
  "offer_chains": [
    "43497fd7f826957108f4a30fd9cec3aeba79972084e90ead01ea330900000000"
  ],
  "description": null,
  "offer_paths": [
    {
      "blinded_hops": [
        "0339e5efc9f4935ae8f84f6db02abf2450422e1fe8ac2e2080f479b1eccf37e1a7",
        "031448f2aa7355336a93fe304a4e14642881d42df65ceae73008a2985840bf8295"
      ],
      "blinding_points": "021aeddbf39bf6e9a69bf331c7a5a524a55efaffd6643c127f66378d0ace9529f4"
    }
  ],
  "network": "testnet"
}
```
See commits for more info.
Fixes #270 #318 