### PR TITLE
Avoid channel clone

### DIFF
--- a/lampo-common/src/model/network.rs
+++ b/lampo-common/src/model/network.rs
@@ -15,8 +15,8 @@ pub mod response {
         pub node_two: String,
     }
 
-    impl From<ChannelInfo> for NetworkChannel {
-        fn from(value: ChannelInfo) -> Self {
+    impl<'a> From<&'a ChannelInfo> for NetworkChannel {
+        fn from(value: &'a ChannelInfo) -> Self {
             Self {
                 node_one: value.node_one.to_string(),
                 node_two: value.node_two.to_string(),

--- a/lampod/src/jsonrpc/inventory.rs
+++ b/lampod/src/jsonrpc/inventory.rs
@@ -21,7 +21,7 @@ pub fn json_network_channels(ctx: &LampoDaemon, _: &json::Value) -> Result<json:
         let Some(channel) = network_graph.channel(*short_id) else {
             continue;
         };
-        network_channels.push(NetworkChannel::from(channel.clone()));
+        network_channels.push(NetworkChannel::from(channel));
     }
     Ok(json::to_value(NetworkChannels {
         channels: network_channels,


### PR DESCRIPTION
This PR resolves #280 by avoiding the use of `.clone()` 
https://github.com/vincenzopalazzo/lampo.rs/blob/61b216f05243280ff2b673904f0b61fa28005f48/lampod/src/jsonrpc/inventory.rs#L23-L25