### PR TITLE
core: fix regression in lkd migration

### DIFF
--- a/lampod/src/lib.rs
+++ b/lampod/src/lib.rs
@@ -255,7 +255,9 @@ impl LampoDaemon {
                 |d| {
                     Box::pin(async move {
                         tokio::time::sleep(d).await;
-                        true
+                        // if we return true, ldk is going to stop the processor
+                        // so we should use this when we have the stop command
+                        false
                     })
                 },
                 false,


### PR DESCRIPTION
While we was migrating ldk in https://github.com/vincenzopalazzo/lampo.rs/pull/380 we introduce a regression by returning true and not false inside the sleeper function.

This commit fix the regression and add a test to avoid future regression, and add a comment to clarify it!