### PR TITLE
Remove core_url, core_pass, core_user from Option datatype

### DIFF
--- a/lampo-bdk-wallet/src/lib.rs
+++ b/lampo-bdk-wallet/src/lib.rs
@@ -136,15 +136,9 @@ impl BDKWalletManager {
     }
 
     pub fn build_client(conf: Arc<LampoConf>) -> error::Result<Client> {
-        let url = conf.core_url.as_ref().ok_or(error::anyhow!(
-            "RPC URL is missing from the configuration file"
-        ))?;
-        let user = conf.core_user.as_ref().ok_or(error::anyhow!(
-            "RPC User is missing from the configuration file"
-        ))?;
-        let pass = conf.core_pass.as_ref().ok_or(error::anyhow!(
-            "RPC Password is missing from the configuration file"
-        ))?;
+        let url = &conf.core_url;
+        let user = &conf.core_user;
+        let pass = &conf.core_pass;
         let client = Client::new(url, Auth::UserPass(user.clone(), pass.clone()))?;
         Ok(client)
     }

--- a/lampo-bdk-wallet/src/lib.rs
+++ b/lampo-bdk-wallet/src/lib.rs
@@ -136,9 +136,19 @@ impl BDKWalletManager {
     }
 
     pub fn build_client(conf: Arc<LampoConf>) -> error::Result<Client> {
-        let url = &conf.bitcoind_conf.get_url();
-        let user = &conf.bitcoind_conf.get_user();
-        let pass = &conf.bitcoind_conf.get_pass();
+        let bitcoin_conf = conf
+            .bitcoind_conf
+            .clone()
+            .ok_or(error::anyhow!("Bitcoin conf missing"))?;
+        let url = &bitcoin_conf.url;
+
+        let user = &bitcoin_conf
+            .user
+            .ok_or(error::anyhow!("User not provided"))?;
+        let pass = bitcoin_conf
+            .pass
+            .ok_or(error::anyhow!("Pass not provided"))?;
+
         let client = Client::new(url, Auth::UserPass(user.clone(), pass.clone()))?;
         Ok(client)
     }

--- a/lampo-bdk-wallet/src/lib.rs
+++ b/lampo-bdk-wallet/src/lib.rs
@@ -136,9 +136,9 @@ impl BDKWalletManager {
     }
 
     pub fn build_client(conf: Arc<LampoConf>) -> error::Result<Client> {
-        let url = &conf.core_url;
-        let user = &conf.core_user;
-        let pass = &conf.core_pass;
+        let url = &conf.bitcoind_conf.get_url();
+        let user = &conf.bitcoind_conf.get_user();
+        let pass = &conf.bitcoind_conf.get_pass();
         let client = Client::new(url, Auth::UserPass(user.clone(), pass.clone()))?;
         Ok(client)
     }

--- a/lampo-chain/src/lib.rs
+++ b/lampo-chain/src/lib.rs
@@ -33,9 +33,9 @@ unsafe impl Sync for LampoChainSync {}
 
 impl LampoChainSync {
     pub fn new(conf: Arc<LampoConf>) -> error::Result<Self> {
-        let core_url = &conf.core_url;
-        let core_user = &conf.core_user;
-        let core_pass = &conf.core_pass;
+        let core_url = &conf.bitcoind_conf.get_url();
+        let core_user = &conf.bitcoind_conf.get_user();
+        let core_pass = &conf.bitcoind_conf.get_pass();
 
         log::debug!("Core URL: {:?}", core_url);
         // FIXME: somehow we should fix this

--- a/lampo-chain/src/lib.rs
+++ b/lampo-chain/src/lib.rs
@@ -33,9 +33,18 @@ unsafe impl Sync for LampoChainSync {}
 
 impl LampoChainSync {
     pub fn new(conf: Arc<LampoConf>) -> error::Result<Self> {
-        let core_url = &conf.bitcoind_conf.get_url();
-        let core_user = &conf.bitcoind_conf.get_user();
-        let core_pass = &conf.bitcoind_conf.get_pass();
+        let bitcoin_conf = conf
+            .bitcoind_conf
+            .clone()
+            .ok_or(error::anyhow!("Bitcoin conf missing"))?;
+
+        let core_url = &bitcoin_conf.url;
+        let core_user = &bitcoin_conf
+            .user
+            .ok_or(error::anyhow!("User not provided"))?;
+        let core_pass = bitcoin_conf
+            .pass
+            .ok_or(error::anyhow!("Pass not provided"))?;
 
         log::debug!("Core URL: {:?}", core_url);
         // FIXME: somehow we should fix this

--- a/lampo-chain/src/lib.rs
+++ b/lampo-chain/src/lib.rs
@@ -33,15 +33,9 @@ unsafe impl Sync for LampoChainSync {}
 
 impl LampoChainSync {
     pub fn new(conf: Arc<LampoConf>) -> error::Result<Self> {
-        let core_url = conf.core_url.as_ref().ok_or(error::anyhow!(
-            "Core URL is missing from the configuration file"
-        ))?;
-        let core_user = conf.core_user.as_ref().ok_or(error::anyhow!(
-            "Core User is missing from the configuration file"
-        ))?;
-        let core_pass = conf.core_pass.as_ref().ok_or(error::anyhow!(
-            "Core Password is missing from the configuration file"
-        ))?;
+        let core_url = &conf.core_url;
+        let core_user = &conf.core_user;
+        let core_pass = &conf.core_pass;
 
         log::debug!("Core URL: {:?}", core_url);
         // FIXME: somehow we should fix this

--- a/lampo-common/src/btc_conf.rs
+++ b/lampo-common/src/btc_conf.rs
@@ -1,79 +1,43 @@
 use bitcoin::Network;
-use clightningrpc_conf::CLNConf;
+
+use crate::error;
 
 #[derive(Clone, Debug)]
 pub struct BitcoindConf {
-    url: String,
-    user: String,
-    pass: String,
+    pub url: String,
+    pub user: Option<String>,
+    pub pass: Option<String>,
 }
 
-// The default URLs for different bitcoin chains
-pub static BITCOIN_MAINNET_URL: &str = "127.0.0.1:8332";
-pub static BITCOIN_TESTNET_URL: &str = "127.0.0.1:18332";
-pub static BITCOIN_SIGNET_URL: &str = "127.0.0.1:28332";
-pub static BITCOIN_REGTEST_URL: &str = "127.0.0.1:38332";
-pub static BITCOIN_USER: &str = "user";
-pub static BITCOIN_PASS: &str = "pass";
-
 impl BitcoindConf {
-    pub fn get_default_conf(network: Network) -> Self {
+    pub fn get_default_conf(network: Network) -> Result<Self, anyhow::Error> {
         match network {
-            Network::Bitcoin => BitcoindConf {
-                url: BITCOIN_MAINNET_URL.to_string(),
-                user: BITCOIN_USER.to_string(),
-                pass: BITCOIN_PASS.to_string(),
-            },
-            Network::Testnet => BitcoindConf {
-                url: BITCOIN_TESTNET_URL.to_string(),
-                user: BITCOIN_USER.to_string(),
-                pass: BITCOIN_PASS.to_string(),
-            },
-            Network::Signet => BitcoindConf {
-                url: BITCOIN_SIGNET_URL.to_string(),
-                user: BITCOIN_USER.to_string(),
-                pass: BITCOIN_PASS.to_string(),
-            },
-            Network::Regtest => BitcoindConf {
-                url: BITCOIN_REGTEST_URL.to_string(),
-                user: BITCOIN_USER.to_string(),
-                pass: BITCOIN_PASS.to_string(),
-            },
-            Network::Testnet4 => BitcoindConf {
-                url: BITCOIN_TESTNET_URL.to_string(),
-                user: BITCOIN_USER.to_string(),
-                pass: BITCOIN_PASS.to_string(),
-            },
-            // Ideally we can no way enter here, as the network is checked whenever we are
-            // calling this function and if it is not a valid network, the program flow
-            // would not enter here.
-            _ => panic!(
-                "This shouldn't have happened, take a look at your bitcoin network just in case"
-            ),
+            Network::Bitcoin => Ok(BitcoindConf {
+                url: "127.0.0.1:8332".to_string(),
+                user: None,
+                pass: None,
+            }),
+            Network::Testnet => Ok(BitcoindConf {
+                url: "127.0.0.1:18332".to_string(),
+                user: None,
+                pass: None,
+            }),
+            Network::Signet => Ok(BitcoindConf {
+                url: "127.0.0.1:28332".to_string(),
+                user: None,
+                pass: None,
+            }),
+            Network::Regtest => Ok(BitcoindConf {
+                url: "127.0.0.1:38332".to_string(),
+                user: None,
+                pass: None,
+            }),
+            Network::Testnet4 => Ok(BitcoindConf {
+                url: "127.0.0.1:18332".to_string(),
+                user: None,
+                pass: None,
+            }),
+            _ => error::bail!("Network not supported"),
         }
-    }
-
-    pub fn get_url(&self) -> String {
-        self.url.clone()
-    }
-
-    pub fn get_user(&self) -> String {
-        self.user.clone()
-    }
-
-    pub fn get_pass(&self) -> String {
-        self.pass.clone()
-    }
-
-    pub fn set_url(&mut self, url: String) {
-        self.url = url
-    }
-
-    pub fn set_user(&mut self, user: String) {
-        self.user = user
-    }
-
-    pub fn set_pass(&mut self, pass: String) {
-        self.pass = pass
     }
 }

--- a/lampo-common/src/btc_conf.rs
+++ b/lampo-common/src/btc_conf.rs
@@ -1,0 +1,79 @@
+use bitcoin::Network;
+use clightningrpc_conf::CLNConf;
+
+#[derive(Clone, Debug)]
+pub struct BitcoindConf {
+    url: String,
+    user: String,
+    pass: String,
+}
+
+// The default URLs for different bitcoin chains
+pub static BITCOIN_MAINNET_URL: &str = "127.0.0.1:8332";
+pub static BITCOIN_TESTNET_URL: &str = "127.0.0.1:18332";
+pub static BITCOIN_SIGNET_URL: &str = "127.0.0.1:28332";
+pub static BITCOIN_REGTEST_URL: &str = "127.0.0.1:38332";
+pub static BITCOIN_USER: &str = "user";
+pub static BITCOIN_PASS: &str = "pass";
+
+impl BitcoindConf {
+    pub fn get_default_conf(network: Network) -> Self {
+        match network {
+            Network::Bitcoin => BitcoindConf {
+                url: BITCOIN_MAINNET_URL.to_string(),
+                user: BITCOIN_USER.to_string(),
+                pass: BITCOIN_PASS.to_string(),
+            },
+            Network::Testnet => BitcoindConf {
+                url: BITCOIN_TESTNET_URL.to_string(),
+                user: BITCOIN_USER.to_string(),
+                pass: BITCOIN_PASS.to_string(),
+            },
+            Network::Signet => BitcoindConf {
+                url: BITCOIN_SIGNET_URL.to_string(),
+                user: BITCOIN_USER.to_string(),
+                pass: BITCOIN_PASS.to_string(),
+            },
+            Network::Regtest => BitcoindConf {
+                url: BITCOIN_REGTEST_URL.to_string(),
+                user: BITCOIN_USER.to_string(),
+                pass: BITCOIN_PASS.to_string(),
+            },
+            Network::Testnet4 => BitcoindConf {
+                url: BITCOIN_TESTNET_URL.to_string(),
+                user: BITCOIN_USER.to_string(),
+                pass: BITCOIN_PASS.to_string(),
+            },
+            // Ideally we can no way enter here, as the network is checked whenever we are
+            // calling this function and if it is not a valid network, the program flow
+            // would not enter here.
+            _ => panic!(
+                "This shouldn't have happened, take a look at your bitcoin network just in case"
+            ),
+        }
+    }
+
+    pub fn get_url(&self) -> String {
+        self.url.clone()
+    }
+
+    pub fn get_user(&self) -> String {
+        self.user.clone()
+    }
+
+    pub fn get_pass(&self) -> String {
+        self.pass.clone()
+    }
+
+    pub fn set_url(&mut self, url: String) {
+        self.url = url
+    }
+
+    pub fn set_user(&mut self, user: String) {
+        self.user = user
+    }
+
+    pub fn set_pass(&mut self, pass: String) {
+        self.pass = pass
+    }
+}

--- a/lampo-common/src/conf.rs
+++ b/lampo-common/src/conf.rs
@@ -15,9 +15,9 @@ pub struct LampoConf {
     pub root_path: String,
     /// The backend implementation
     pub node: String,
-    pub core_url: Option<String>,
-    pub core_user: Option<String>,
-    pub core_pass: Option<String>,
+    pub core_url: String,
+    pub core_user: String,
+    pub core_pass: String,
     pub private_key: Option<String>,
     pub channels_keys: Option<String>,
     pub log_file: Option<String>,
@@ -46,9 +46,9 @@ impl Default for LampoConf {
             port: 19735,
             root_path: lampo_home,
             node: "core".to_owned(),
-            core_url: None,
-            core_user: None,
-            core_pass: None,
+            core_url: "".to_string(),
+            core_user: "".to_string(),
+            core_pass: "".to_string(),
             private_key: None,
             channels_keys: None,
             log_level: "info".to_string(),
@@ -180,26 +180,26 @@ impl TryFrom<String> for LampoConf {
         // Strip the value of whitespace
         let node = node.to_trimmed();
 
-        let mut core_url = None;
-        let mut core_user = None;
-        let mut core_pass = None;
-        if node == "core" {
-            core_url = conf
-                .get_conf("core-url")
-                .map_err(|err| anyhow::anyhow!("{err}"))?;
-            // If the value isn't none, strip the value of whitespace
-            core_url = core_url.map(|url| url.to_trimmed());
+        let Some(core_url) = conf
+            .get_conf("core-url")
+            .map_err(|err| anyhow::anyhow!("{err}"))?
+        else {
+            anyhow::bail!("Core URL must be specified")
+        };
 
-            core_user = conf
-                .get_conf("core-user")
-                .map_err(|err| anyhow::anyhow!("{err}"))?;
-            core_user = core_user.map(|user| user.to_trimmed());
+        let Some(core_user) = conf
+            .get_conf("core-user")
+            .map_err(|err| anyhow::anyhow!("{err}"))?
+        else {
+            anyhow::bail!("Core user must be specified")
+        };
 
-            core_pass = conf
-                .get_conf("core-pass")
-                .map_err(|err| anyhow::anyhow!("{err}"))?;
-            core_pass = core_pass.map(|pass| pass.to_trimmed());
-        }
+        let Some(core_pass) = conf
+            .get_conf("core-pass")
+            .map_err(|err| anyhow::anyhow!("{err}"))?
+        else {
+            anyhow::bail!("Core Password must be specified")
+        };
 
         let reindex: Option<String> = conf
             .get_conf("reindex")

--- a/lampo-common/src/conf.rs
+++ b/lampo-common/src/conf.rs
@@ -6,6 +6,7 @@ use clightningrpc_conf::{CLNConf, SyncCLNConf};
 pub use bitcoin::Network;
 pub use lightning::util::config::UserConfig;
 
+pub use crate::btc_conf::BitcoindConf;
 #[derive(Clone, Debug)]
 pub struct LampoConf {
     pub inner: Option<CLNConf>,
@@ -15,9 +16,7 @@ pub struct LampoConf {
     pub root_path: String,
     /// The backend implementation
     pub node: String,
-    pub core_url: String,
-    pub core_user: String,
-    pub core_pass: String,
+    pub bitcoind_conf: BitcoindConf,
     pub private_key: Option<String>,
     pub channels_keys: Option<String>,
     pub log_file: Option<String>,
@@ -46,9 +45,6 @@ impl Default for LampoConf {
             port: 19735,
             root_path: lampo_home,
             node: "core".to_owned(),
-            core_url: "".to_string(),
-            core_user: "".to_string(),
-            core_pass: "".to_string(),
             private_key: None,
             channels_keys: None,
             log_level: "info".to_string(),
@@ -58,6 +54,8 @@ impl Default for LampoConf {
             api_host: "127.0.0.1".to_owned(),
             api_port: 7878,
             reindex: None,
+            // By default network is testnet as mentioned above
+            bitcoind_conf: BitcoindConf::get_default_conf(Network::Testnet),
         }
     }
 }
@@ -179,26 +177,31 @@ impl TryFrom<String> for LampoConf {
             .unwrap_or("nakamoto".to_owned());
         // Strip the value of whitespace
         let node = node.to_trimmed();
+        let network = Network::from_str(&network)?;
 
-        let Some(core_url) = conf
+        // Get the default conf
+        let mut bitcoind_conf = BitcoindConf::get_default_conf(network);
+
+        // Override if there is some config specified!
+        if let Some(bitcoin_url) = conf
             .get_conf("core-url")
             .map_err(|err| anyhow::anyhow!("{err}"))?
-        else {
-            anyhow::bail!("Core URL must be specified")
+        {
+            bitcoind_conf.set_url(bitcoin_url);
         };
 
-        let Some(core_user) = conf
-            .get_conf("core-user")
-            .map_err(|err| anyhow::anyhow!("{err}"))?
-        else {
-            anyhow::bail!("Core user must be specified")
-        };
-
-        let Some(core_pass) = conf
+        if let Some(bitcoin_pass) = conf
             .get_conf("core-pass")
             .map_err(|err| anyhow::anyhow!("{err}"))?
-        else {
-            anyhow::bail!("Core Password must be specified")
+        {
+            bitcoind_conf.set_pass(bitcoin_pass);
+        };
+
+        if let Some(bitcoin_user) = conf
+            .get_conf("core-user")
+            .map_err(|err| anyhow::anyhow!("{err}"))?
+        {
+            bitcoind_conf.set_user(bitcoin_user);
         };
 
         let reindex: Option<String> = conf
@@ -227,7 +230,6 @@ impl TryFrom<String> for LampoConf {
                 .map_err(|err| anyhow::anyhow!("{err}"))?;
         }
 
-        let network = Network::from_str(&network)?;
         let root_path = Self::normalize_root_dir(&value, network);
         let log_level = conf.get_conf("log-level");
         let level = match log_level {
@@ -248,9 +250,6 @@ impl TryFrom<String> for LampoConf {
             ldk_conf: UserConfig::default(),
             port: u64::from_str(&port)?,
             node,
-            core_url,
-            core_user,
-            core_pass,
             private_key,
             channels_keys,
             log_file,
@@ -260,6 +259,7 @@ impl TryFrom<String> for LampoConf {
             api_host,
             api_port,
             reindex,
+            bitcoind_conf,
         })
     }
 }

--- a/lampo-common/src/lib.rs
+++ b/lampo-common/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod backend;
+pub mod btc_conf;
 pub mod conf;
 pub mod event;
 pub mod handler;

--- a/lampo-testing/src/lib.rs
+++ b/lampo-testing/src/lib.rs
@@ -105,9 +105,9 @@ impl LampoTesting {
         lampo_conf.api_port = port::random_free_port().unwrap().into();
         log::info!("listening on port `{}`", lampo_conf.api_port);
         let core_url: String = format!("http://127.0.0.1:{}", btc.port);
-        lampo_conf.core_pass = Some(btc.pass.clone());
-        lampo_conf.core_url = Some(core_url);
-        lampo_conf.core_user = Some(btc.user.clone());
+        lampo_conf.core_pass = btc.pass.clone();
+        lampo_conf.core_url = core_url;
+        lampo_conf.core_user = btc.user.clone();
         lampo_conf
             .ldk_conf
             .channel_handshake_limits

--- a/lampo-testing/src/lib.rs
+++ b/lampo-testing/src/lib.rs
@@ -105,9 +105,9 @@ impl LampoTesting {
         lampo_conf.api_port = port::random_free_port().unwrap().into();
         log::info!("listening on port `{}`", lampo_conf.api_port);
         let core_url: String = format!("http://127.0.0.1:{}", btc.port);
-        lampo_conf.core_pass = btc.pass.clone();
-        lampo_conf.core_url = core_url;
-        lampo_conf.core_user = btc.user.clone();
+        lampo_conf.bitcoind_conf.set_pass(btc.pass.clone());
+        lampo_conf.bitcoind_conf.set_url(core_url);
+        lampo_conf.bitcoind_conf.set_user(btc.user.clone());
         lampo_conf
             .ldk_conf
             .channel_handshake_limits

--- a/lampo-testing/src/lib.rs
+++ b/lampo-testing/src/lib.rs
@@ -13,6 +13,7 @@ use std::time::Duration;
 use clightning_testing::btc::BtcNode;
 use clightning_testing::prelude::*;
 use lampo_chain::LampoChainSync;
+use lampo_common::conf::BitcoindConf;
 use lampo_httpd::handler::HttpdHandler;
 use tempfile::TempDir;
 
@@ -105,9 +106,13 @@ impl LampoTesting {
         lampo_conf.api_port = port::random_free_port().unwrap().into();
         log::info!("listening on port `{}`", lampo_conf.api_port);
         let core_url: String = format!("http://127.0.0.1:{}", btc.port);
-        lampo_conf.bitcoind_conf.set_pass(btc.pass.clone());
-        lampo_conf.bitcoind_conf.set_url(core_url);
-        lampo_conf.bitcoind_conf.set_user(btc.user.clone());
+
+        let mut bitcoin_conf = BitcoindConf::get_default_conf(lampod::chain::Network::Regtest)?;
+        bitcoin_conf.user = Some(btc.user.clone());
+        bitcoin_conf.pass = Some(btc.pass.clone());
+        bitcoin_conf.url = core_url;
+
+        lampo_conf.bitcoind_conf = Some(bitcoin_conf);
         lampo_conf
             .ldk_conf
             .channel_handshake_limits

--- a/lampod-cli/src/args.rs
+++ b/lampod-cli/src/args.rs
@@ -78,14 +78,14 @@ impl TryInto<LampoConf> for LampoCliArgs {
         if let Some(node) = self.client {
             conf.node = node.clone();
         }
-        if self.bitcoind_url.is_some() {
-            conf.core_url = self.bitcoind_url.unwrap();
+        if let Some(btc_url) = self.bitcoind_url {
+            conf.bitcoind_conf.set_url(btc_url);
         }
-        if self.bitcoind_user.is_some() {
-            conf.core_user = self.bitcoind_user.unwrap();
+        if let Some(btc_user) = self.bitcoind_user {
+            conf.bitcoind_conf.set_user(btc_user);
         }
-        if self.bitcoind_pass.is_some() {
-            conf.core_pass = self.bitcoind_pass.unwrap();
+        if let Some(btc_pass) = self.bitcoind_pass {
+            conf.bitcoind_conf.set_pass(btc_pass);
         }
         if self.log_file.is_some() {
             conf.log_file = self.log_file;

--- a/lampod-cli/src/args.rs
+++ b/lampod-cli/src/args.rs
@@ -79,13 +79,13 @@ impl TryInto<LampoConf> for LampoCliArgs {
             conf.node = node.clone();
         }
         if self.bitcoind_url.is_some() {
-            conf.core_url = self.bitcoind_url;
+            conf.core_url = self.bitcoind_url.unwrap();
         }
         if self.bitcoind_user.is_some() {
-            conf.core_user = self.bitcoind_user;
+            conf.core_user = self.bitcoind_user.unwrap();
         }
         if self.bitcoind_pass.is_some() {
-            conf.core_pass = self.bitcoind_pass;
+            conf.core_pass = self.bitcoind_pass.unwrap();
         }
         if self.log_file.is_some() {
             conf.log_file = self.log_file;

--- a/lampod-cli/src/args.rs
+++ b/lampod-cli/src/args.rs
@@ -74,18 +74,25 @@ impl TryInto<LampoConf> for LampoCliArgs {
 
         log::debug!(target: "lampod-cli", "lampo data dir `{}`", conf.path());
         log::debug!(target: "lampod-cli", "client from args {:?}", self.client);
+
+        // We would be assigning new values to this struct and then
+        // assign this to conf.bitcoinf_conf later
+        let mut bitcoind_conf = conf
+            .bitcoind_conf
+            .clone()
+            .ok_or(error::anyhow!("No bitcoin conf present"))?;
         // Override the lampo conf with the args from the cli
         if let Some(node) = self.client {
             conf.node = node.clone();
         }
         if let Some(btc_url) = self.bitcoind_url {
-            conf.bitcoind_conf.set_url(btc_url);
+            bitcoind_conf.url = btc_url;
         }
         if let Some(btc_user) = self.bitcoind_user {
-            conf.bitcoind_conf.set_user(btc_user);
+            bitcoind_conf.user = Some(btc_user);
         }
         if let Some(btc_pass) = self.bitcoind_pass {
-            conf.bitcoind_conf.set_pass(btc_pass);
+            bitcoind_conf.pass = Some(btc_pass);
         }
         if self.log_file.is_some() {
             conf.log_file = self.log_file;
@@ -99,6 +106,8 @@ impl TryInto<LampoConf> for LampoCliArgs {
         if let Some(api_port) = self.api_port {
             conf.api_port = api_port;
         }
+
+        conf.bitcoind_conf = Some(bitcoind_conf);
         Ok(conf)
     }
 }

--- a/lampod-cli/src/main.rs
+++ b/lampod-cli/src/main.rs
@@ -61,7 +61,6 @@ fn load_words_from_file<P: AsRef<Path>>(path: P) -> error::Result<String> {
 /// Return the root directory.
 async fn run(args: LampoCliArgs) -> error::Result<()> {
     let restore_wallet = args.restore_wallet;
-
     // After this point the configuration is ready!
     let mut lampo_conf: LampoConf = args.try_into()?;
 


### PR DESCRIPTION
After we removed nakamoto backend, it is better suited to change the datatype from Option<String> to String only

What I have done in this PR?

- Removed the `core_url`, `core_user`, `core_pass` as an option type. 
- Made a new struct with the default configurations if there is no provided inside the cli arguments or `lampo.conf` as suggested by @vincenzopalazzo 
- Made different default cases for different types of network.