### PR TITLE
ldk: remove the ldk bolt11 dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1436,7 +1436,6 @@ dependencies = [
  "lightning",
  "lightning-background-processor",
  "lightning-block-sync",
- "lightning-invoice",
  "lightning-net-tokio",
  "lightning-persister",
  "lightning-rapid-gossip-sync",

--- a/lampo-common/Cargo.toml
+++ b/lampo-common/Cargo.toml
@@ -12,7 +12,6 @@ lightning-persister = { version = "0.1.0" }
 lightning-background-processor = { version = "0.1", features = ["futures"] }
 lightning-net-tokio = { version = "0.1.0" }
 lightning-rapid-gossip-sync = { version = "0.1.0" }
-lightning-invoice = { version = "0.33" }
 
 async-trait = "0.1"
 bitcoin = { version = "0.32", features = ["serde"] }

--- a/lampo-common/src/keys.rs
+++ b/lampo-common/src/keys.rs
@@ -1,6 +1,7 @@
 use std::{sync::Arc, time::SystemTime};
 
 use bitcoin::secp256k1::{Secp256k1, SecretKey};
+use lightning::bolt11_invoice;
 use lightning::sign::{InMemorySigner, NodeSigner, OutputSpender, SignerProvider};
 
 use crate::ldk::sign::{EntropySource, KeysManager};
@@ -145,7 +146,7 @@ impl NodeSigner for LampoKeysManager {
 
     fn sign_invoice(
         &self,
-        invoice: &lightning_invoice::RawBolt11Invoice,
+        invoice: &bolt11_invoice::RawBolt11Invoice,
         recipient: lightning::sign::Recipient,
     ) -> Result<bitcoin::secp256k1::ecdsa::RecoverableSignature, ()> {
         self.inner.sign_invoice(invoice, recipient)

--- a/lampo-common/src/lib.rs
+++ b/lampo-common/src/lib.rs
@@ -11,10 +11,10 @@ pub mod utils;
 pub mod wallet;
 
 pub mod ldk {
+    pub use lightning::bolt11_invoice as invoice;
     pub use lightning::*;
     pub use lightning_background_processor as processor;
     pub use lightning_block_sync as block_sync;
-    pub use lightning_invoice as invoice;
     pub use lightning_net_tokio as net;
     pub use lightning_persister as persister;
 }


### PR DESCRIPTION
LDK includes the bolt11 crate within the repository and re-exports it, so we can safely remove the separate dependency.

Fixes: https://github.com/vincenzopalazzo/lampo.rs/issues/405