### PR TITLE
bdk: check blockchain status when wallet is empty 

### DIFF
--- a/lampo-bdk-wallet/src/lib.rs
+++ b/lampo-bdk-wallet/src/lib.rs
@@ -394,20 +394,3 @@ impl WalletManager for BDKWalletManager {
         Ok(())
     }
 }
-
-/*
-#[cfg(debug_assertions)]
-impl TryFrom<(PrivateKey, Option<String>)> for BDKWalletManager {
-    type Error = bdk::Error;
-
-    fn try_from(value: (PrivateKey, Option<String>)) -> Result<Self, Self::Error> {
-        let (wallet, keymanager) = BDKWalletManager::build_from_private_key(value.0, value.1)?;
-        Ok(Self {
-            wallet: RefCell::new(Mutex::new(wallet)),
-            keymanager: Arc::new(keymanager),
-            // This should be possible only during integration testing
-            // FIXME: fix the sync method in bdk, the esplora client will crash!
-            network: Network::Regtest,
-        })
-    }
-}   */

--- a/lampo-bdk-wallet/src/lib.rs
+++ b/lampo-bdk-wallet/src/lib.rs
@@ -260,7 +260,6 @@ impl WalletManager for BDKWalletManager {
         Ok(txs)
     }
 
-    // FIXME: the code should have a timer that trigger the sync every 5 minutes
     async fn sync(&self) -> error::Result<()> {
         #[derive(Debug)]
         enum Emission {


### PR DESCRIPTION
Ensure the blockchain status is checked when the wallet is empty.
Otherwise, the wallet keeps re-indexing the blockchain even if it is empty.

This causes slow startup times when the user uses the wallet for the first time.

Fixes: https://github.com/vincenzopalazzo/lampo.rs/issues/393