### PR TITLE
bdk: avoid to scan the mempool

### DIFF
--- a/lampo-bdk-wallet/src/lib.rs
+++ b/lampo-bdk-wallet/src/lib.rs
@@ -298,7 +298,7 @@ impl WalletManager for BDKWalletManager {
             while let Some(emission) = emitter.next_block()? {
                 sender.send(Emission::Block(emission))?;
             }
-            sender.send(Emission::Mempool(emitter.mempool()?))?;
+            //sender.send(Emission::Mempool(emitter.mempool()?))?;
             Ok::<_, error::Error>(())
         });
 


### PR DESCRIPTION
I am just interested in confirmed transactions in the lightning node, so it probably will make sense to remove the mempool scan

cc @ValuedMammal