### PR TITLE
Add newwallet subcommand to lampod-cli for wallet creation

### DIFF
--- a/lampod-cli/src/args.rs
+++ b/lampod-cli/src/args.rs
@@ -1,9 +1,16 @@
-use clap::Parser;
+// use clap::Parser;
+use clap::{Parser, Subcommand};
 
 use lampo_common::conf::{LampoConf, Network};
 use lampo_common::error;
 
-#[derive(Parser, Debug)]
+#[derive(Subcommand, Debug, Clone)]
+pub enum LampoCliSubcommand {
+    /// Create a new wallet and print the mnemonic
+    NewWallet,
+}
+
+#[derive(Parser, Debug, Clone)]
 #[command(
     name = "lampod-cli",
     about = "Lampo Daemon command line",
@@ -58,6 +65,10 @@ pub struct LampoCliArgs {
     /// Set the API port
     #[arg(long = "api-port")]
     pub api_port: Option<u64>,
+
+    /// Subcommand to run
+    #[command(subcommand)]
+    pub subcommand: Option<LampoCliSubcommand>,
 }
 
 impl TryInto<LampoConf> for LampoCliArgs {


### PR DESCRIPTION
This commit refactors the wallet creation logic in lampod-cli into a reusable function create_new_wallet and introduces a new subcommand newwallet. The subcommand allows users to create a new wallet, print the mnemonic to the console, and store it in the default data directory. The existing wallet restoration logic remains unchanged. The changes include: Adding subcommand support with clap in args.rs. Creating a new function for wallet creation in main.rs. Handling the newwallet subcommand to create and display the mnemonic.