### PR TITLE
test: corrected `fund_channel_with` to match with its name

### DIFF
--- a/tests/tests/src/lampo_tests.rs
+++ b/tests/tests/src/lampo_tests.rs
@@ -114,10 +114,10 @@ pub async fn pay_invoice_simple_case_lampo() -> error::Result<()> {
     let btc = node1.btc.clone();
     let node2 = Arc::new(LampoTesting::new(btc.clone()).await?);
 
-    // There is a channel node2 -> node1
+    // There is a channel node1 -> node2
     node1.fund_channel_with(node2.clone(), 100_000_000).await?;
 
-    let invoice: response::Invoice = node1
+    let invoice: response::Invoice = node2
         .lampod()
         .call(
             "invoice",
@@ -129,9 +129,9 @@ pub async fn pay_invoice_simple_case_lampo() -> error::Result<()> {
         )
         .await?;
 
-    log::info!(target: &node2.info.node_id, "invoice generated `{:?}`", invoice);
+    log::info!(target: &node1.info.node_id, "invoice generated `{:?}`", invoice);
 
-    let pay: response::PayResult = node2
+    let pay: response::PayResult = node1
         .lampod()
         .call(
             "pay",
@@ -142,7 +142,7 @@ pub async fn pay_invoice_simple_case_lampo() -> error::Result<()> {
             },
         )
         .await?;
-    log::info!(target: &node1.info.node_id, "payment made `{:?}`", pay);
+    log::info!(target: &node2.info.node_id, "payment made `{:?}`", pay);
     Ok(())
 }
 
@@ -153,10 +153,10 @@ pub async fn pay_offer_simple_case_lampo() -> error::Result<()> {
     let btc = node1.btc.clone();
     let node2 = Arc::new(LampoTesting::new(btc.clone()).await?);
 
-    // There is a channel node2 -> node1
+    // There is a channel node1 -> node2
     node1.fund_channel_with(node2.clone(), 100_000_000).await?;
 
-    let offer: response::Offer = node1
+    let offer: response::Offer = node2
         .lampod()
         .call(
             "offer",
@@ -167,9 +167,9 @@ pub async fn pay_offer_simple_case_lampo() -> error::Result<()> {
         )
         .await?;
 
-    log::info!(target: &node2.info.node_id, "offer generated `{:?}`", offer);
+    log::info!(target: &node1.info.node_id, "offer generated `{:?}`", offer);
 
-    let pay: response::PayResult = node2
+    let pay: response::PayResult = node1
         .lampod()
         .call(
             "pay",
@@ -180,7 +180,7 @@ pub async fn pay_offer_simple_case_lampo() -> error::Result<()> {
             },
         )
         .await?;
-    log::info!(target: &node1.info.node_id, "payment made `{:?}`", pay);
+    log::info!(target: &node2.info.node_id, "payment made `{:?}`", pay);
     Ok(())
 }
 


### PR DESCRIPTION
The `fund_channel_with` function has been refactored so that `self` (the node the method is called on) is the one that initiates and funds the channel to the `counterparty`. The channel direction is now correctly `self -> counterparty`.

![image](https://github.com/user-attachments/assets/40b27578-866e-4b13-ac18-f7035cb49aca)

Fixes #460 