### PR TITLE
fix: handle unwrap safely in the start function of the channel manager

### DIFF
--- a/lampod/src/ln/channel_manager.rs
+++ b/lampod/src/ln/channel_manager.rs
@@ -326,7 +326,8 @@ impl LampoChannelManager {
     }
 
     pub async fn start(&self) -> error::Result<()> {
-        let (block_hash, block_height) = self.onchain.get_best_block().await.unwrap();
+        let (block_hash, block_height) = self.onchain.get_best_block().await
+        .map_err(|err| error::anyhow!("Failed to connect to bitcoind: {:?}. Please ensure bitcoind is running and accessible.", err))?;
         let chain_params = ChainParameters {
             network: self.conf.network,
             best_block: BestBlock {


### PR DESCRIPTION
This PR should fix the panic! problem when we were calling `get_info` and `bitcoind` is not running.

From the issue, it's not really clear what command you ran to get the error or how to replicate it, so there're no tests to make sure it's fixed.

Fixes #394 

PS: `make check` is not passing but it's not passing on the `main` branch either. Also, I couldn't see an `error.rs` dile anywhere to reuse errors so I mapped it to a string I think could work, but maybe we want to keep it more generic?
