### PR TITLE
fix: return insufficient funds error instead of blocking forever

### DIFF
--- a/lampo-chain/src/lib.rs
+++ b/lampo-chain/src/lib.rs
@@ -129,13 +129,19 @@ impl Backend for LampoChainSync {
             .call_method::<json::Value>("sendrawtransaction", &[serialize_hex(tx).into()])
             .await;
         log::info!("Broadcasting tx result: {:?}", resp);
-        if resp.is_ok() {
-            let Some(handler) = self.handler.get() else {
-                return;
-            };
-            handler.emit(Event::OnChain(OnChainEvent::SendRawTransaction(tx.clone())));
+        let Some(handler) = self.handler.get() else {
+            return;
+        };
+        match resp {
+            Ok(_) => {
+                handler.emit(Event::OnChain(OnChainEvent::SendRawTransaction(tx.clone())));
+            }
+            Err(err) => {
+                let msg = format!("Failed to broadcast transaction: {err}");
+                log::error!(target: "lampo-chain", "{}", msg);
+                handler.emit(Event::OnChain(OnChainEvent::FundingChannelFailed(msg)));
+            }
         }
-        // FIXME: emit the brodcast event for lampo in case of errors, just to unlock the client
     }
 
     async fn fee_rate_estimation(&self, blocks: u64) -> lampo_common::error::Result<u32> {

--- a/lampo-common/src/event/onchain.rs
+++ b/lampo-common/src/event/onchain.rs
@@ -11,6 +11,10 @@ pub enum OnChainEvent {
     NewBestBlock((Header, Height)),
     FeeEstimation(u32),
     SendRawTransaction(Transaction),
+    /// Emitted when funding a channel fails (e.g. insufficient funds),
+    /// so that the `open_channel` wait loop can return an error
+    /// instead of blocking forever.
+    FundingChannelFailed(String),
     ConfirmedTransaction((Transaction, u32, Header, Height)),
     DiscardedTransaction(Txid),
     UnconfirmedTransaction(Txid),
@@ -31,6 +35,9 @@ impl Debug for OnChainEvent {
             Self::NewBlock(block) => write!(f, "NewBlock({})", block.block_hash()),
             Self::SendRawTransaction(tx) => write!(f, "SendRawTransaction({})", tx.txid()),
             Self::UnconfirmedTransaction(tx) => write!(f, "UnconfirmedTransaction({})", tx),
+            Self::FundingChannelFailed(reason) => {
+                write!(f, "FundingChannelFailed({})", reason)
+            }
             _ => write!(f, "Debug fmt not unsupported"),
         }
     }

--- a/lampod/src/actions/handler.rs
+++ b/lampod/src/actions/handler.rs
@@ -11,6 +11,7 @@ use lampo_common::chan;
 use lampo_common::error;
 use lampo_common::error::Ok;
 use lampo_common::event::ln::LightningEvent;
+use lampo_common::event::onchain::OnChainEvent;
 use lampo_common::event::{Emitter, Event, Subscriber};
 use lampo_common::handler::ExternalHandler;
 use lampo_common::handler::Handler as EventHandler;
@@ -275,7 +276,7 @@ impl Handler for LampoHandler {
                 log::info!("fee estimated {:?} sats", fee);
 
                 let best_block = self.channel_manager.manager().current_best_block().height;
-                let transaction = self
+                let transaction = match self
                     .wallet_manager
                     .create_transaction(
                         output_script,
@@ -284,7 +285,18 @@ impl Handler for LampoHandler {
                         // FIXME: remove unwrap
                         Height::from_consensus(best_block).unwrap(),
                     )
-                    .await?;
+                    .await
+                {
+                    std::result::Result::Ok(tx) => tx,
+                    Err(err) => {
+                        let msg = format!("Failed to create funding transaction: {err}");
+                        log::error!(target: "lampo", "{}", msg);
+                        self.emit(Event::OnChain(OnChainEvent::FundingChannelFailed(
+                            msg.clone(),
+                        )));
+                        return Err(err);
+                    }
+                };
                 log::info!(
                     "funding transaction created `{}`",
                     transaction.compute_txid()

--- a/lampod/src/ln/channel_manager.rs
+++ b/lampod/src/ln/channel_manager.rs
@@ -255,19 +255,22 @@ impl LampoChannelManager {
             )
             .map_err(|err| error::anyhow!("{:?}", err))?;
 
-        // Wait for SendRawTransaction to be received so to get the funding transaction
-        // FIXME: we can loop forever here
+        // Wait for SendRawTransaction or FundingChannelFailed to be received
+        let mut events = self.handler().events();
         let tx: Option<Transaction> = loop {
-            let mut events = self.handler().events();
-            // FIXME: put the receive code inside a macro, in this way we do not need
-            // to repeat the same code
             let event = events
                 .recv()
                 .await
-                .ok_or(error::anyhow!("Channel close no event received"))?;
+                .ok_or(error::anyhow!("Channel funding: no event received"))?;
 
-            if let Event::OnChain(OnChainEvent::SendRawTransaction(tx)) = event {
-                break Some(tx);
+            match event {
+                Event::OnChain(OnChainEvent::SendRawTransaction(tx)) => {
+                    break Some(tx);
+                }
+                Event::OnChain(OnChainEvent::FundingChannelFailed(reason)) => {
+                    return Err(error::anyhow!("{}", reason));
+                }
+                _ => {}
             }
         };
 


### PR DESCRIPTION
## Summary

Fixes #237 — `fundchannel` hangs indefinitely when the wallet has insufficient funds instead of returning an error.

**Root cause:** The `open_channel()` wait loop only listened for `SendRawTransaction` events. When `create_transaction()` failed (e.g. insufficient funds), the error was logged but no event was emitted, so the loop blocked forever.

**Changes:**
- Add `FundingChannelFailed(String)` variant to `OnChainEvent` to carry funding failure reasons
- Emit `FundingChannelFailed` in the `FundingGenerationReady` handler when `create_transaction()` fails
- Emit `FundingChannelFailed` in `brodcast_tx()` when transaction broadcast fails
- Match on `FundingChannelFailed` in the `open_channel()` wait loop to return the error to the caller

## Files changed

| File | Change |
|---|---|
| `lampo-common/src/event/onchain.rs` | Add `FundingChannelFailed` event variant |
| `lampod/src/actions/handler.rs` | Emit error event on tx creation failure |
| `lampod/src/ln/channel_manager.rs` | Handle error event in wait loop |
| `lampo-chain/src/lib.rs` | Emit error event on broadcast failure |

## Test plan

- [ ] Attempt `fundchannel` with insufficient wallet balance — should return an error message instead of hanging
- [ ] Attempt `fundchannel` with sufficient balance — should work as before
- [ ] Verify `cargo check` passes cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)