### PR TITLE
fix: add fee estimation fallback for IBD and insufficient data

### DIFF
--- a/lampo-chain/src/lib.rs
+++ b/lampo-chain/src/lib.rs
@@ -148,14 +148,20 @@ impl Backend for LampoChainSync {
             .call_method::<json::Value>("estimatesmartfee", &[blocks.into()])
             .await?;
         let resp: FeeRate = json::from_value(resp)?;
-        if let Some(errs) = resp.errors {
-            return Err(error::anyhow!("Error in fee rate estimation: {:?}", errs).into());
+        if resp.errors.is_some() || resp.feerate.is_none() {
+            // When estimatesmartfee fails (e.g. during Initial Block Download
+            // or when the node has insufficient data), fall back to the
+            // minimum mempool fee. This prevents returning null fee estimates
+            // to the caller. See: https://github.com/vincenzopalazzo/lampo.rs/issues/244
+            log::warn!(
+                "estimatesmartfee failed for {} blocks (errors: {:?}), falling back to minimum mempool fee",
+                blocks,
+                resp.errors
+            );
+            return self.minimum_mempool_fee().await;
         }
-        let Some(feerate) = resp.feerate else {
-            return Err(error::anyhow!("No fee rate estimation available").into());
-        };
         // estimate fee rate in BTC/kvB
-        Ok((feerate * (100_000_000 as f64)) as u32)
+        Ok((resp.feerate.unwrap() * (100_000_000 as f64)) as u32)
     }
 
     async fn get_transaction(

--- a/lampod/src/chain/blockchain.rs
+++ b/lampod/src/chain/blockchain.rs
@@ -7,6 +7,7 @@ use lampo_common::bitcoin;
 use lampo_common::bitcoin::blockdata::constants::ChainHash;
 use lampo_common::bitcoin::Transaction;
 use lampo_common::error;
+use lampo_common::json;
 use lampo_common::ldk;
 use lampo_common::ldk::block_sync::BlockSource;
 use lampo_common::ldk::chain::chaininterface::{
@@ -16,6 +17,11 @@ use lampo_common::ldk::routing::utxo::UtxoLookup;
 use lampo_common::wallet::WalletManager;
 
 use crate::sync;
+
+/// Minimum fee rate floor in sat/kw. This matches LDK's
+/// FEERATE_FLOOR_SATS_PER_KW and prevents returning zero
+/// fee rates which would cause channel operations to fail.
+const FEERATE_FLOOR_SATS_PER_KW: u32 = 253;
 
 #[derive(Clone)]
 pub struct LampoChainManager {
@@ -51,7 +57,7 @@ impl LampoChainManager {
         }
     }
 
-    pub fn estimated_fees(&self) -> HashMap<String, Option<u32>> {
+    pub fn estimated_fees(&self) -> HashMap<String, json::Value> {
         let fees_targets = vec![
             ConfirmationTarget::UrgentOnChainSweep,
             ConfirmationTarget::MinAllowedNonAnchorChannelRemoteFee,
@@ -61,11 +67,27 @@ impl LampoChainManager {
             ConfirmationTarget::ChannelCloseMinimum,
             ConfirmationTarget::OutputSpendingFee,
         ];
-        let mut map: HashMap<String, Option<u32>> = HashMap::new();
+        let mut map: HashMap<String, json::Value> = HashMap::new();
+        let mut has_fallback = false;
         for target in fees_targets {
             let fee = self.get_est_sat_per_1000_weight(target);
-            let value = if fee == 0 { None } else { Some(fee) };
+            if fee == FEERATE_FLOOR_SATS_PER_KW {
+                has_fallback = true;
+            }
+            let value = if fee == 0 {
+                json::Value::Null
+            } else {
+                json::Value::Number(fee.into())
+            };
             map.insert(self.print_ldk_target_to_string(target), value);
+        }
+        if has_fallback {
+            map.insert(
+                "warning".to_string(),
+                json::Value::String(
+                    "Some fee estimates are using fallback values. The backend node may be syncing or have insufficient fee data.".to_string(),
+                ),
+            );
         }
         map
     }
@@ -80,9 +102,30 @@ impl LampoChainManager {
 #[async_trait]
 impl FeeEstimator for LampoChainManager {
     fn get_est_sat_per_1000_weight(&self, confirmation_target: ConfirmationTarget) -> u32 {
-        // FIXME: have the result in the cache to make easy the query of it.
-        // TODO: fix this
-        256
+        let blocks = match confirmation_target {
+            ConfirmationTarget::MaximumFeeEstimate | ConfirmationTarget::UrgentOnChainSweep => 1,
+            ConfirmationTarget::MinAllowedNonAnchorChannelRemoteFee
+            | ConfirmationTarget::AnchorChannelFee
+            | ConfirmationTarget::NonAnchorChannelFee => 6,
+            ConfirmationTarget::MinAllowedAnchorChannelRemoteFee => {
+                // For this target, use the minimum mempool fee
+                let backend = self.backend.clone();
+                let fee = tokio::task::block_in_place(|| {
+                    tokio::runtime::Handle::current()
+                        .block_on(async { backend.minimum_mempool_fee().await })
+                });
+                return fee.unwrap_or(FEERATE_FLOOR_SATS_PER_KW);
+            }
+            ConfirmationTarget::ChannelCloseMinimum => 100,
+            ConfirmationTarget::OutputSpendingFee => 12,
+        };
+
+        let backend = self.backend.clone();
+        let fee = tokio::task::block_in_place(|| {
+            tokio::runtime::Handle::current()
+                .block_on(async { backend.fee_rate_estimation(blocks).await })
+        });
+        fee.unwrap_or(FEERATE_FLOOR_SATS_PER_KW)
     }
 }
 


### PR DESCRIPTION
## Summary

Fixes #244 — `fees` command returns all null values when Bitcoin Core is in Initial Block Download (IBD) or has insufficient fee estimation data.

**Three problems fixed:**

- **`fee_rate_estimation()` in `lampo-chain`**: When `estimatesmartfee` fails (IBD, insufficient data), now falls back to `minimum_mempool_fee()` instead of returning an error that gets silently swallowed
- **`get_est_sat_per_1000_weight()` in `lampod`**: Was hardcoded to return `256` — now actually queries the backend with proper confirmation targets (1/6/12/100 blocks depending on urgency)
- **`estimated_fees()` response**: Includes a `"warning"` field when fallback values are used, so users understand why estimates may be less accurate

A floor constant `FEERATE_FLOOR_SATS_PER_KW = 253` (matching LDK's internal floor) ensures we never return zero fee rates, which would block channel operations.

## Test plan

- [ ] Verify `lampo-cli fees` returns numeric values instead of nulls when the backend node is syncing
- [ ] Verify the `warning` field appears in the response when fallback values are used
- [ ] Verify normal fee estimation still works correctly when the node is fully synced
- [ ] Verify regtest still returns hardcoded 256

🤖 Generated with [Claude Code](https://claude.com/claude-code)