### PR TITLE
feat: plugin system with stdio and gRPC transports

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,8 +39,8 @@ dependencies = [
  "flate2",
  "foldhash",
  "futures-core",
- "h2",
- "http",
+ "h2 0.3.26",
+ "http 0.2.12",
  "httparse",
  "httpdate",
  "itoa",
@@ -76,7 +76,7 @@ checksum = "13d324164c51f63867b57e73ba5936ea151b8a41a1d23d1031eeb9f70d0236f8"
 dependencies = [
  "bytestring",
  "cfg-if",
- "http",
+ "http 0.2.12",
  "regex",
  "regex-lite",
  "serde",
@@ -320,6 +320,67 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
+name = "asn1-rs"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5493c3bedbacf7fd7382c6346bbd66687d12bbaad3a89a2d2c303ee6cf20b048"
+dependencies = [
+ "asn1-rs-derive",
+ "asn1-rs-impl",
+ "displaydoc",
+ "nom",
+ "num-traits",
+ "rusticata-macros",
+ "thiserror",
+ "time",
+]
+
+[[package]]
+name = "asn1-rs-derive"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "965c2d33e53cb6b267e148a4cb0760bc01f4904c1cd4bb4002a085bb016d1490"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+ "synstructure",
+]
+
+[[package]]
+name = "asn1-rs-impl"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+]
+
+[[package]]
+name = "async-stream"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -331,10 +392,63 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
 name = "autocfg"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
+
+[[package]]
+name = "axum"
+version = "0.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
+dependencies = [
+ "async-trait",
+ "axum-core",
+ "bytes",
+ "futures-util",
+ "http 1.4.0",
+ "http-body",
+ "http-body-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "sync_wrapper",
+ "tower 0.5.3",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09f2bd6146b97ae3359fa0cc6d6b376d9539582c7b4220f041a33ec24c226199"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures-util",
+ "http 1.4.0",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "rustversion",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+]
 
 [[package]]
 name = "backtrace"
@@ -612,10 +726,11 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.20"
+version = "1.2.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04da6a0d40b948dfc4fa8f5bbf402b0fc1a64a28dbf7d12ffd683550f2c1b63a"
+checksum = "7a0dd1ca384932ff3641c8718a02769f1698e7563dc6974ffd03346116310423"
 dependencies = [
+ "find-msvc-tools",
  "jobserver",
  "libc",
  "shlex",
@@ -951,6 +1066,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "data-encoding"
+version = "2.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
+
+[[package]]
+name = "der-parser"
+version = "9.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cd0a5c643689626bec213c4d8bd4d96acc8ffdb4ad4bb6bc16abf27d5f4b553"
+dependencies = [
+ "asn1-rs",
+ "displaydoc",
+ "nom",
+ "num-bigint",
+ "num-traits",
+ "rusticata-macros",
+]
+
+[[package]]
 name = "deranged"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1052,6 +1187,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "env_filter"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a1c3cc8e57274ec99de65301228b537f1e4eedc1b8e0f9411c6caac8ae7308f"
+dependencies = [
+ "log",
+ "regex",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2daee4ea451f429a58296525ddf28b45a3b64f1acf6587e2067437bb11e218d"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "env_filter",
+ "jiff",
+ "log",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1093,6 +1251,18 @@ checksum = "b6427c04067bba5e8ceb9a2826fe30568c7d615ff560b4a6fec7a626b528057b"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "fixedbitset"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 
 [[package]]
 name = "flate2"
@@ -1286,7 +1456,26 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "futures-util",
- "http",
+ "http 0.2.12",
+ "indexmap 2.9.0",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "h2"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http 1.4.0",
  "indexmap 2.9.0",
  "slab",
  "tokio",
@@ -1382,6 +1571,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "http"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+dependencies = [
+ "bytes",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+dependencies = [
+ "bytes",
+ "http 1.4.0",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http 1.4.0",
+ "http-body",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1392,6 +1614,62 @@ name = "httpdate"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "hyper"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "h2 0.4.13",
+ "http 1.4.0",
+ "http-body",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "pin-utils",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-timeout"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
+dependencies = [
+ "hyper",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http 1.4.0",
+ "http-body",
+ "hyper",
+ "libc",
+ "pin-project-lite",
+ "socket2 0.6.0",
+ "tokio",
+ "tower-service",
+ "tracing",
+]
 
 [[package]]
 name = "iana-time-zone"
@@ -1632,6 +1910,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
+name = "jiff"
+version = "0.2.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a3546dc96b6d42c5f24902af9e2538e82e39ad350b0c766eb3fbf2d8f3d8359"
+dependencies = [
+ "jiff-static",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde_core",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a8c8b344124222efd714b73bb41f8b5120b27a7cc1c75593a6ff768d9d05aa4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+]
+
+[[package]]
 name = "jobserver"
 version = "0.1.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1741,6 +2043,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "lampo-plugin"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "lampo-common",
+ "lampo-plugin-common",
+ "log",
+ "prost",
+ "rcgen",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "tokio",
+ "tonic",
+ "tonic-build",
+]
+
+[[package]]
+name = "lampo-plugin-common"
+version = "0.1.0"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "lampo-plugin-sdk"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "env_logger",
+ "lampo-plugin-common",
+ "log",
+ "serde",
+ "serde_json",
+ "tokio",
+]
+
+[[package]]
 name = "lampo-testing"
 version = "0.1.0"
 dependencies = [
@@ -1764,6 +2105,8 @@ dependencies = [
  "async-trait",
  "futures",
  "lampo-common",
+ "lampo-plugin",
+ "lampo-plugin-common",
  "log",
  "once_cell",
  "time",
@@ -1781,6 +2124,8 @@ dependencies = [
  "lampo-chain",
  "lampo-common",
  "lampo-httpd",
+ "lampo-plugin",
+ "lampo-plugin-common",
  "lampod",
  "log",
  "radicle-term",
@@ -1999,6 +2344,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 
 [[package]]
+name = "matchit"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
+
+[[package]]
 name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2019,6 +2370,12 @@ dependencies = [
  "mime",
  "unicase",
 ]
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniscript"
@@ -2076,6 +2433,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "multimap"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
+
+[[package]]
 name = "newline-converter"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2094,6 +2457,16 @@ dependencies = [
  "cfg-if",
  "cfg_aliases",
  "libc",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -2130,6 +2503,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2144,6 +2527,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.100",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -2162,6 +2554,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "oid-registry"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8d8034d9489cdaf79228eb9f6a3b8d7bb32ba00d6645ebd48eef4077ceb5bd9"
+dependencies = [
+ "asn1-rs",
 ]
 
 [[package]]
@@ -2256,7 +2657,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "827a0067440b62e798bc3e8cfb7036a0f63c3adbb21fe6a56fb3d6f6d8fa53f8"
 dependencies = [
  "heck 0.4.1",
- "http",
+ "http 0.2.12",
  "lazy_static",
  "mime",
  "proc-macro-error2",
@@ -2297,10 +2698,50 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
+name = "pem"
+version = "3.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
+dependencies = [
+ "base64 0.22.1",
+ "serde_core",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
+
+[[package]]
+name = "petgraph"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3672b37090dbd86368a4145bc067582552b29c27377cad4e0a306c97f9bd7772"
+dependencies = [
+ "fixedbitset",
+ "indexmap 2.9.0",
+]
+
+[[package]]
+name = "pin-project"
+version = "1.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1749c7ed4bcaf4c3d0a3efc28538844fb29bcdd7d2b67b2be7e20ba861ff517"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b20ed30f105399776b9c883e68e536ef602a16ae6f596d2c473591d6ad64c6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+]
 
 [[package]]
 name = "pin-project-lite"
@@ -2330,6 +2771,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "091397be61a01d4be58e7841595bd4bfedb15f1cd54977d79b8271e94ed799a3"
+dependencies = [
+ "portable-atomic",
+]
+
+[[package]]
 name = "possiblyrandom"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2351,6 +2807,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy 0.8.25",
+]
+
+[[package]]
+name = "prettyplease"
+version = "0.2.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6837b9e10d61f45f987d50808f83d1ee3d206c66acf650c3e4ae2e1f6ddedf55"
+dependencies = [
+ "proc-macro2",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -2391,6 +2857,58 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "prost"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-build"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
+dependencies = [
+ "heck 0.5.0",
+ "itertools",
+ "log",
+ "multimap",
+ "once_cell",
+ "petgraph",
+ "prettyplease",
+ "prost",
+ "prost-types",
+ "regex",
+ "syn 2.0.100",
+ "tempfile",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
+dependencies = [
+ "anyhow",
+ "itertools",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52c2c1bf36ddb1a1c396b3601a3cec27c2462e45f07c386894ec3ccf5332bd16"
+dependencies = [
+ "prost",
 ]
 
 [[package]]
@@ -2500,6 +3018,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "rcgen"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75e669e5202259b5314d1ea5397316ad400819437857b90861765f24c4cf80a2"
+dependencies = [
+ "pem",
+ "ring",
+ "rustls-pki-types",
+ "time",
+ "x509-parser",
+ "yasna",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2544,6 +3076,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.16",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "rusqlite"
 version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2564,6 +3110,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
+name = "rusticata-macros"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf0c4a6ece9950b9abdb62b1cfcf2a68b3b67a10ba445b3bb85be2a293d0632"
+dependencies = [
+ "nom",
+]
+
+[[package]]
 name = "rustix"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2574,6 +3129,50 @@ dependencies = [
  "libc",
  "linux-raw-sys",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
+dependencies = [
+ "log",
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -2644,18 +3243,28 @@ checksum = "56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0"
 
 [[package]]
 name = "serde"
-version = "1.0.219"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.219"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2826,6 +3435,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
 name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2846,6 +3461,12 @@ dependencies = [
  "quote",
  "unicode-ident",
 ]
+
+[[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
 
 [[package]]
 name = "synstructure"
@@ -3007,6 +3628,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-test-shutdown-timeout"
 version = "0.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3048,6 +3690,98 @@ dependencies = [
 ]
 
 [[package]]
+name = "tonic"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877c5b330756d856ffcc4553ab34a5684481ade925ecc54bcd1bf02b1d0d4d52"
+dependencies = [
+ "async-stream",
+ "async-trait",
+ "axum",
+ "base64 0.22.1",
+ "bytes",
+ "h2 0.4.13",
+ "http 1.4.0",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-timeout",
+ "hyper-util",
+ "percent-encoding",
+ "pin-project",
+ "prost",
+ "rustls-pemfile",
+ "socket2 0.5.9",
+ "tokio",
+ "tokio-rustls",
+ "tokio-stream",
+ "tower 0.4.13",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tonic-build"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9557ce109ea773b399c9b9e5dca39294110b74f1f342cb347a80d1fce8c26a11"
+dependencies = [
+ "prettyplease",
+ "proc-macro2",
+ "prost-build",
+ "prost-types",
+ "quote",
+ "syn 2.0.100",
+]
+
+[[package]]
+name = "tower"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "indexmap 1.9.3",
+ "pin-project",
+ "pin-project-lite",
+ "rand 0.8.5",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
+
+[[package]]
 name = "tracing"
 version = "0.1.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3078,6 +3812,12 @@ checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
 dependencies = [
  "once_cell",
 ]
+
+[[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "typenum"
@@ -3140,6 +3880,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
 name = "url"
 version = "2.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3188,6 +3934,15 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
+]
 
 [[package]]
 name = "wasi"
@@ -3529,6 +4284,33 @@ name = "writeable"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
+
+[[package]]
+name = "x509-parser"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcbc162f30700d6f3f82a24bf7cc62ffe7caea42c0b2cba8bf7f3ae50cf51f69"
+dependencies = [
+ "asn1-rs",
+ "data-encoding",
+ "der-parser",
+ "lazy_static",
+ "nom",
+ "oid-registry",
+ "ring",
+ "rusticata-macros",
+ "thiserror",
+ "time",
+]
+
+[[package]]
+name = "yasna"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e17bb3549cc1321ae1296b9cdc2698e2b6cb1992adfa19a8c72e5b7a738f44cd"
+dependencies = [
+ "time",
+]
 
 [[package]]
 name = "yoke"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,9 @@
 [workspace]
 members = [
         "lampo-common",
+        "lampo-plugin-common",
+        "lampo-plugin",
+        "lampo-plugin-sdk",
         "lampod",
         "lampod-cli",
         "lampo-cli",
@@ -13,6 +16,9 @@ members = [
 
 default-members = [
         "lampo-common",
+        "lampo-plugin-common",
+        "lampo-plugin",
+        "lampo-plugin-sdk",
         "lampod",
         "lampod-cli",
         "lampo-cli",

--- a/lampo-common/src/conf.rs
+++ b/lampo-common/src/conf.rs
@@ -28,6 +28,12 @@ pub struct LampoConf {
     pub api_port: u64,
     pub reindex: Option<Height>,
     pub dev_sync: Option<bool>,
+    /// Plugin binary paths to load at startup.
+    pub plugins: Vec<String>,
+    /// Directory to scan for plugin binaries.
+    pub plugin_dir: Option<String>,
+    /// Remote plugin endpoints (e.g. "https://host:port").
+    pub remote_plugins: Vec<String>,
 }
 
 impl Default for LampoConf {
@@ -60,6 +66,9 @@ impl Default for LampoConf {
             api_port: 7878,
             reindex: None,
             dev_sync: None,
+            plugins: Vec::new(),
+            plugin_dir: None,
+            remote_plugins: Vec::new(),
         }
     }
 }
@@ -249,6 +258,12 @@ impl TryFrom<String> for LampoConf {
             .get_conf("dev-sync")
             .unwrap_or(None)
             .map(|s| s.to_lowercase() == "true" || s == "1");
+
+        // Parse plugin paths from config
+        let plugins = conf.get_confs("plugin");
+        let plugin_dir = conf.get_conf("plugin-dir").unwrap_or(None);
+        let remote_plugins = conf.get_confs("remote-plugin");
+
         Ok(Self {
             inner: Some(conf),
             root_path,
@@ -269,6 +284,9 @@ impl TryFrom<String> for LampoConf {
             api_port,
             reindex,
             dev_sync,
+            plugins,
+            plugin_dir,
+            remote_plugins,
         })
     }
 }

--- a/lampo-plugin-common/Cargo.toml
+++ b/lampo-plugin-common/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "lampo-plugin-common"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"

--- a/lampo-plugin-common/src/hooks.rs
+++ b/lampo-plugin-common/src/hooks.rs
@@ -1,0 +1,46 @@
+//! Hook point definitions.
+//!
+//! Hooks are synchronous interception points. When a hook fires,
+//! the daemon blocks until all registered plugins respond.
+use serde::{Deserialize, Serialize};
+
+/// Well-known hook points in lampo.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum HookPoint {
+    /// Fired when a peer completes the handshake.
+    PeerConnected,
+    /// Fired when a channel open request is received.
+    OpenChannel,
+    /// Fired when an HTLC is received and claimable.
+    HtlcAccepted,
+    /// Fired before any RPC command is dispatched (meta-hook).
+    RpcCommand,
+    /// Fired when an invoice is being created.
+    InvoiceCreation,
+}
+
+impl HookPoint {
+    /// The wire method name for this hook (sent as JSON-RPC method).
+    pub fn method_name(&self) -> &'static str {
+        match self {
+            Self::PeerConnected => "hook/peer_connected",
+            Self::OpenChannel => "hook/openchannel",
+            Self::HtlcAccepted => "hook/htlc_accepted",
+            Self::RpcCommand => "hook/rpc_command",
+            Self::InvoiceCreation => "hook/invoice_creation",
+        }
+    }
+
+    /// Parse from a hook name string (as declared in manifest).
+    pub fn from_name(name: &str) -> Option<Self> {
+        match name {
+            "peer_connected" => Some(Self::PeerConnected),
+            "openchannel" => Some(Self::OpenChannel),
+            "htlc_accepted" => Some(Self::HtlcAccepted),
+            "rpc_command" => Some(Self::RpcCommand),
+            "invoice_creation" => Some(Self::InvoiceCreation),
+            _ => None,
+        }
+    }
+}

--- a/lampo-plugin-common/src/lib.rs
+++ b/lampo-plugin-common/src/lib.rs
@@ -1,0 +1,13 @@
+//! Lampo Plugin Protocol Types
+//!
+//! This crate defines the wire protocol types shared between the lampo daemon
+//! and plugins. Plugins can be written in any language — they just need to
+//! speak JSON-RPC 2.0 over stdin/stdout (local) or implement the gRPC service
+//! (remote).
+pub mod hooks;
+pub mod manifest;
+pub mod messages;
+pub mod topics;
+
+pub use manifest::*;
+pub use messages::*;

--- a/lampo-plugin-common/src/manifest.rs
+++ b/lampo-plugin-common/src/manifest.rs
@@ -1,0 +1,90 @@
+//! Plugin manifest types.
+//!
+//! A plugin declares its capabilities via a `PluginManifest` returned
+//! in response to the `getmanifest` JSON-RPC call from the daemon.
+use serde::{Deserialize, Serialize};
+
+/// The full manifest a plugin returns to declare its capabilities.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct PluginManifest {
+    /// Custom RPC methods this plugin provides.
+    #[serde(default)]
+    pub rpc_methods: Vec<RpcMethodDecl>,
+    /// Event topics this plugin subscribes to (e.g. "channel_ready", "payment").
+    #[serde(default)]
+    pub subscriptions: Vec<String>,
+    /// Hooks this plugin wants to intercept.
+    #[serde(default)]
+    pub hooks: Vec<HookDecl>,
+    /// Configuration options the plugin declares.
+    #[serde(default)]
+    pub options: Vec<PluginOption>,
+    /// Whether this plugin can be started/stopped dynamically at runtime.
+    #[serde(default)]
+    pub dynamic: bool,
+    /// What to do when this plugin is unreachable.
+    #[serde(default)]
+    pub failure_mode: FailureMode,
+}
+
+/// Declaration of an RPC method a plugin provides.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RpcMethodDecl {
+    /// The method name (e.g. "hello", "mycommand").
+    pub name: String,
+    /// Human-readable description.
+    #[serde(default)]
+    pub description: String,
+    /// Usage string (e.g. "[name] [amount]").
+    #[serde(default)]
+    pub usage: String,
+}
+
+/// Declaration of a hook a plugin wants to intercept.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct HookDecl {
+    /// The hook name (e.g. "openchannel", "htlc_accepted").
+    pub name: String,
+    /// This plugin should run before these plugins.
+    #[serde(default)]
+    pub before: Vec<String>,
+    /// This plugin should run after these plugins.
+    #[serde(default)]
+    pub after: Vec<String>,
+}
+
+/// A configuration option the plugin declares.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PluginOption {
+    /// Option name.
+    pub name: String,
+    /// Option type.
+    #[serde(rename = "type")]
+    pub opt_type: OptionType,
+    /// Default value (if any).
+    #[serde(default)]
+    pub default: Option<serde_json::Value>,
+    /// Human-readable description.
+    #[serde(default)]
+    pub description: String,
+}
+
+/// Supported option types.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum OptionType {
+    String,
+    Int,
+    Bool,
+}
+
+/// What to do when a plugin is unreachable or times out.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum FailureMode {
+    /// Skip the plugin and continue (non-critical plugins).
+    #[default]
+    FailOpen,
+    /// Fail the operation if the plugin is down (critical plugins).
+    FailClosed,
+}

--- a/lampo-plugin-common/src/messages.rs
+++ b/lampo-plugin-common/src/messages.rs
@@ -1,0 +1,129 @@
+//! Wire protocol message types for plugin communication.
+//!
+//! All messages are JSON-RPC 2.0. Requests have an `id` field,
+//! notifications do not. Plugins read from stdin, write to stdout.
+use serde::{Deserialize, Serialize};
+
+use crate::manifest::PluginManifest;
+
+/// Configuration sent to the plugin during `init`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct InitConfig {
+    /// Path to lampo's data directory (e.g. "~/.lampo/testnet").
+    pub lampo_dir: String,
+    /// The network (e.g. "testnet", "bitcoin", "regtest", "signet").
+    pub network: String,
+    /// The node's public key (hex-encoded).
+    #[serde(default)]
+    pub node_id: String,
+    /// Resolved option values from the manifest.
+    #[serde(default)]
+    pub options: serde_json::Map<String, serde_json::Value>,
+}
+
+/// The `init` response from a plugin.
+///
+/// If the result contains a `disable` key, the plugin wants to
+/// disable itself. Otherwise it initialized successfully.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct InitResponse {
+    /// If set, the plugin wants to disable itself with this reason.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub disable: Option<String>,
+}
+
+impl InitResponse {
+    /// Check if the plugin wants to disable itself.
+    pub fn is_disabled(&self) -> bool {
+        self.disable.is_some()
+    }
+}
+
+/// Hook response from a plugin.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "result", rename_all = "snake_case")]
+pub enum HookResponse {
+    /// Pass to next plugin or default behavior.
+    Continue {
+        #[serde(skip_serializing_if = "Option::is_none")]
+        payload: Option<serde_json::Value>,
+    },
+    /// Short-circuit the hook chain with this result.
+    Complete { payload: serde_json::Value },
+    /// Reject/abort the operation.
+    Reject {
+        #[serde(default)]
+        message: String,
+    },
+}
+
+impl Default for HookResponse {
+    fn default() -> Self {
+        Self::Continue { payload: None }
+    }
+}
+
+/// A plugin notification (daemon → plugin, no response expected).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PluginNotification {
+    /// The notification topic (e.g. "channel_ready", "payment").
+    pub method: String,
+    /// The notification payload.
+    pub params: serde_json::Value,
+    /// JSON-RPC version — always "2.0".
+    pub jsonrpc: String,
+}
+
+impl PluginNotification {
+    pub fn new(topic: &str, params: serde_json::Value) -> Self {
+        Self {
+            method: topic.to_owned(),
+            params,
+            jsonrpc: "2.0".to_owned(),
+        }
+    }
+}
+
+/// A generic JSON-RPC 2.0 request (daemon → plugin).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PluginRequest {
+    pub method: String,
+    pub params: serde_json::Value,
+    pub id: serde_json::Value,
+    pub jsonrpc: String,
+}
+
+impl PluginRequest {
+    pub fn new(method: &str, params: serde_json::Value, id: u64) -> Self {
+        Self {
+            method: method.to_owned(),
+            params,
+            id: serde_json::Value::Number(id.into()),
+            jsonrpc: "2.0".to_owned(),
+        }
+    }
+}
+
+/// A generic JSON-RPC 2.0 response (plugin → daemon).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PluginResponse {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub result: Option<serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<PluginRpcError>,
+    pub id: serde_json::Value,
+    pub jsonrpc: String,
+}
+
+/// JSON-RPC 2.0 error object.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PluginRpcError {
+    pub code: i32,
+    pub message: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub data: Option<serde_json::Value>,
+}
+
+/// Wraps a `PluginManifest` into a manifest response.
+/// This is the result field of the `getmanifest` response.
+pub type ManifestResponse = PluginManifest;

--- a/lampo-plugin-common/src/topics.rs
+++ b/lampo-plugin-common/src/topics.rs
@@ -1,0 +1,61 @@
+//! Notification topic constants.
+//!
+//! These are the well-known event topic strings that plugins can
+//! subscribe to in their manifest. The daemon maps internal events
+//! to these topics before forwarding to plugins.
+
+/// Peer connected to our node.
+pub const PEER_CONNECTED: &str = "peer_connected";
+
+/// Channel funding confirmed, waiting for lock-in.
+pub const CHANNEL_PENDING: &str = "channel_pending";
+
+/// Channel is ready for use.
+pub const CHANNEL_READY: &str = "channel_ready";
+
+/// Channel funding started.
+pub const FUNDING_CHANNEL_START: &str = "funding_channel_start";
+
+/// Channel funding transaction created.
+pub const FUNDING_CHANNEL_END: &str = "funding_channel_end";
+
+/// Payment state changed (success or failure).
+pub const PAYMENT: &str = "payment";
+
+/// Channel state changed.
+pub const CHANNEL_EVENT: &str = "channel_event";
+
+/// Channel closed.
+pub const CHANNEL_CLOSED: &str = "channel_closed";
+
+/// New block received on-chain.
+pub const NEW_BLOCK: &str = "new_block";
+
+/// New best block header.
+pub const NEW_BEST_BLOCK: &str = "new_best_block";
+
+/// Fee estimation updated.
+pub const FEE_ESTIMATION: &str = "fee_estimation";
+
+/// Transaction confirmed on-chain.
+pub const CONFIRMED_TRANSACTION: &str = "confirmed_transaction";
+
+/// Wildcard — subscribe to all notifications.
+pub const ALL: &str = "*";
+
+/// All known topic names, for validation.
+pub const KNOWN_TOPICS: &[&str] = &[
+    PEER_CONNECTED,
+    CHANNEL_PENDING,
+    CHANNEL_READY,
+    FUNDING_CHANNEL_START,
+    FUNDING_CHANNEL_END,
+    PAYMENT,
+    CHANNEL_EVENT,
+    CHANNEL_CLOSED,
+    NEW_BLOCK,
+    NEW_BEST_BLOCK,
+    FEE_ESTIMATION,
+    CONFIRMED_TRANSACTION,
+    ALL,
+];

--- a/lampo-plugin-common/tests/manifest_tests.rs
+++ b/lampo-plugin-common/tests/manifest_tests.rs
@@ -1,0 +1,105 @@
+//! Tests for plugin protocol types serialization.
+use lampo_plugin_common::manifest::*;
+use lampo_plugin_common::messages::*;
+
+#[test]
+fn test_manifest_roundtrip() {
+    let manifest = PluginManifest {
+        rpc_methods: vec![RpcMethodDecl {
+            name: "hello".to_string(),
+            description: "Says hello".to_string(),
+            usage: "[name]".to_string(),
+        }],
+        subscriptions: vec!["channel_ready".to_string()],
+        hooks: vec![HookDecl {
+            name: "openchannel".to_string(),
+            before: vec![],
+            after: vec![],
+        }],
+        options: vec![PluginOption {
+            name: "greeting".to_string(),
+            opt_type: OptionType::String,
+            default: Some(serde_json::json!("Hello")),
+            description: "The greeting".to_string(),
+        }],
+        dynamic: true,
+        failure_mode: FailureMode::FailOpen,
+    };
+
+    let json = serde_json::to_string(&manifest).unwrap();
+    let deserialized: PluginManifest = serde_json::from_str(&json).unwrap();
+    assert_eq!(deserialized.rpc_methods.len(), 1);
+    assert_eq!(deserialized.rpc_methods[0].name, "hello");
+    assert_eq!(deserialized.subscriptions.len(), 1);
+    assert_eq!(deserialized.hooks.len(), 1);
+    assert!(deserialized.dynamic);
+}
+
+#[test]
+fn test_hook_response_continue() {
+    let resp = HookResponse::Continue { payload: None };
+    let json = serde_json::to_string(&resp).unwrap();
+    assert!(json.contains("continue"));
+
+    let deserialized: HookResponse = serde_json::from_str(&json).unwrap();
+    matches!(deserialized, HookResponse::Continue { payload: None });
+}
+
+#[test]
+fn test_hook_response_reject() {
+    let resp = HookResponse::Reject {
+        message: "too small".to_string(),
+    };
+    let json = serde_json::to_string(&resp).unwrap();
+    assert!(json.contains("reject"));
+    assert!(json.contains("too small"));
+}
+
+#[test]
+fn test_init_config_serialization() {
+    let config = InitConfig {
+        lampo_dir: "/home/user/.lampo/testnet".to_string(),
+        network: "testnet".to_string(),
+        node_id: "02abcdef".to_string(),
+        options: serde_json::Map::new(),
+    };
+    let json = serde_json::to_string(&config).unwrap();
+    assert!(json.contains("testnet"));
+    assert!(json.contains("02abcdef"));
+}
+
+#[test]
+fn test_init_response_disable() {
+    let json = r#"{"disable":"not compatible with this network"}"#;
+    let resp: InitResponse = serde_json::from_str(json).unwrap();
+    assert!(resp.is_disabled());
+    assert_eq!(
+        resp.disable.unwrap(),
+        "not compatible with this network"
+    );
+}
+
+#[test]
+fn test_init_response_ok() {
+    let json = r#"{}"#;
+    let resp: InitResponse = serde_json::from_str(json).unwrap();
+    assert!(!resp.is_disabled());
+}
+
+#[test]
+fn test_plugin_notification() {
+    let notif = PluginNotification::new("channel_ready", serde_json::json!({"channel_id": "abc"}));
+    let json = serde_json::to_string(&notif).unwrap();
+    assert!(json.contains("channel_ready"));
+    assert!(!json.contains("\"id\"")); // notifications have no id
+}
+
+#[test]
+fn test_empty_manifest_deserialize() {
+    let json = "{}";
+    let manifest: PluginManifest = serde_json::from_str(json).unwrap();
+    assert!(manifest.rpc_methods.is_empty());
+    assert!(manifest.hooks.is_empty());
+    assert!(manifest.subscriptions.is_empty());
+    assert!(!manifest.dynamic);
+}

--- a/lampo-plugin-sdk/Cargo.toml
+++ b/lampo-plugin-sdk/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "lampo-plugin-sdk"
+version = "0.1.0"
+edition = "2021"
+description = "SDK for writing lampo plugins in Rust"
+
+[dependencies]
+lampo-plugin-common = { path = "../lampo-plugin-common" }
+tokio = { version = "1", features = ["io-util", "io-std", "sync", "rt", "macros"] }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+log = { version = "0.4", features = ["std"] }
+env_logger = "0.11"
+async-trait = "0.1"
+
+[dev-dependencies]
+tokio = { version = "1", features = ["full"] }

--- a/lampo-plugin-sdk/examples/channel_filter.rs
+++ b/lampo-plugin-sdk/examples/channel_filter.rs
@@ -1,0 +1,48 @@
+//! Channel filter plugin example.
+//!
+//! Rejects channel open requests below a minimum funding threshold.
+//!
+//! Build and run:
+//! ```sh
+//! cargo build --example channel_filter -p lampo-plugin-sdk
+//! lampod --plugin target/debug/examples/channel_filter
+//! ```
+use lampo_plugin_sdk::{HookResponse, Plugin};
+use serde_json::Value;
+
+const MIN_FUNDING_SATS: u64 = 100_000;
+
+async fn on_openchannel(params: Value) -> HookResponse {
+    let funding = params
+        .get("funding_satoshis")
+        .and_then(|v| v.as_u64())
+        .unwrap_or(0);
+
+    if funding < MIN_FUNDING_SATS {
+        log::info!("rejecting channel: {} sats < {} minimum", funding, MIN_FUNDING_SATS);
+        HookResponse::Reject {
+            message: format!("channel too small: {} < {}", funding, MIN_FUNDING_SATS),
+        }
+    } else {
+        HookResponse::Continue { payload: None }
+    }
+}
+
+async fn on_channel_ready(params: Value) {
+    let channel_id = params
+        .get("channel_id")
+        .and_then(|v| v.as_str())
+        .unwrap_or("unknown");
+    log::info!("channel ready: {}", channel_id);
+}
+
+#[tokio::main]
+async fn main() {
+    env_logger::init();
+    Plugin::new()
+        .hook("openchannel", on_openchannel)
+        .subscribe("channel_ready", on_channel_ready)
+        .dynamic(true)
+        .start()
+        .await;
+}

--- a/lampo-plugin-sdk/examples/hello_world.rs
+++ b/lampo-plugin-sdk/examples/hello_world.rs
@@ -1,0 +1,29 @@
+//! Hello World plugin example.
+//!
+//! Registers a single RPC method `hello` that returns a greeting.
+//!
+//! Build and run:
+//! ```sh
+//! cargo build --example hello_world -p lampo-plugin-sdk
+//! lampod --plugin target/debug/examples/hello_world
+//! ```
+use lampo_plugin_sdk::Plugin;
+use serde_json::Value;
+
+async fn handle_hello(params: Value) -> Result<Value, String> {
+    let name = params
+        .get("name")
+        .and_then(|n| n.as_str())
+        .unwrap_or("world");
+    Ok(serde_json::json!({"message": format!("hello, {}!", name)}))
+}
+
+#[tokio::main]
+async fn main() {
+    env_logger::init();
+    Plugin::new()
+        .rpc_method("hello", "Says hello", "[name]", handle_hello)
+        .dynamic(true)
+        .start()
+        .await;
+}

--- a/lampo-plugin-sdk/src/io.rs
+++ b/lampo-plugin-sdk/src/io.rs
@@ -1,0 +1,150 @@
+//! JSON-RPC I/O loop for plugin lifecycle.
+//!
+//! Reads newline-delimited JSON-RPC from input, dispatches to handlers,
+//! writes responses to output.
+use std::collections::HashMap;
+
+use tokio::io::{AsyncBufReadExt, AsyncRead, AsyncWrite, AsyncWriteExt, BufReader};
+
+use lampo_plugin_common::manifest::PluginManifest;
+use serde_json::Value;
+
+use crate::{HookHandler, NotifyHandler, RpcHandler};
+
+pub async fn run_plugin<R, W>(
+    input: R,
+    mut output: W,
+    manifest: PluginManifest,
+    rpc_handlers: HashMap<String, RpcHandler>,
+    hook_handlers: HashMap<String, HookHandler>,
+    notify_handlers: HashMap<String, NotifyHandler>,
+) where
+    R: AsyncRead + Unpin,
+    W: AsyncWrite + Unpin,
+{
+    let reader = BufReader::new(input);
+    let mut lines = reader.lines();
+
+    while let Ok(Some(line)) = lines.next_line().await {
+        let line = line.trim().to_string();
+        if line.is_empty() {
+            continue;
+        }
+
+        let msg: Value = match serde_json::from_str(&line) {
+            Ok(v) => v,
+            Err(e) => {
+                log::warn!("invalid JSON: {}", e);
+                continue;
+            }
+        };
+
+        let method = msg
+            .get("method")
+            .and_then(|m| m.as_str())
+            .unwrap_or("")
+            .to_string();
+        let id = msg.get("id").cloned();
+        let params = msg.get("params").cloned().unwrap_or(Value::Object(Default::default()));
+
+        // If no "id", it's a notification (fire-and-forget)
+        if id.is_none() {
+            if let Some(handler) = notify_handlers.get(&method) {
+                handler(params).await;
+            }
+            continue;
+        }
+
+        let id = id.unwrap();
+
+        let response = match method.as_str() {
+            "getmanifest" => {
+                let manifest_json = serde_json::to_value(&manifest).unwrap_or(Value::Object(Default::default()));
+                serde_json::json!({
+                    "jsonrpc": "2.0",
+                    "id": id,
+                    "result": manifest_json
+                })
+            }
+            "init" => {
+                // Plugin could inspect params for config, for now just acknowledge
+                serde_json::json!({
+                    "jsonrpc": "2.0",
+                    "id": id,
+                    "result": {}
+                })
+            }
+            "shutdown" => {
+                // Write ack and exit
+                let resp = serde_json::json!({
+                    "jsonrpc": "2.0",
+                    "id": id,
+                    "result": {}
+                });
+                let mut resp_str = serde_json::to_string(&resp).unwrap();
+                resp_str.push('\n');
+                let _ = output.write_all(resp_str.as_bytes()).await;
+                let _ = output.flush().await;
+                return;
+            }
+            m if m.starts_with("hook/") => {
+                // Find hook handler by the hook name (without "hook/" prefix)
+                let hook_name = &m["hook/".len()..];
+                if let Some(handler) = hook_handlers.get(hook_name) {
+                    let hook_resp = handler(params).await;
+                    let result = serde_json::to_value(&hook_resp).unwrap_or(serde_json::json!({"result": "continue"}));
+                    serde_json::json!({
+                        "jsonrpc": "2.0",
+                        "id": id,
+                        "result": result
+                    })
+                } else {
+                    // Unknown hook — continue
+                    serde_json::json!({
+                        "jsonrpc": "2.0",
+                        "id": id,
+                        "result": {"result": "continue"}
+                    })
+                }
+            }
+            _ => {
+                // Try RPC handler
+                if let Some(handler) = rpc_handlers.get(&method) {
+                    match handler(params).await {
+                        Ok(result) => {
+                            serde_json::json!({
+                                "jsonrpc": "2.0",
+                                "id": id,
+                                "result": result
+                            })
+                        }
+                        Err(msg) => {
+                            serde_json::json!({
+                                "jsonrpc": "2.0",
+                                "id": id,
+                                "error": {"code": -32000, "message": msg}
+                            })
+                        }
+                    }
+                } else {
+                    serde_json::json!({
+                        "jsonrpc": "2.0",
+                        "id": id,
+                        "error": {"code": -32601, "message": "method not found"}
+                    })
+                }
+            }
+        };
+
+        let mut resp_str = serde_json::to_string(&response).unwrap();
+        resp_str.push('\n');
+        if let Err(e) = output.write_all(resp_str.as_bytes()).await {
+            log::error!("failed to write response: {}", e);
+            return;
+        }
+        if let Err(e) = output.flush().await {
+            log::error!("failed to flush output: {}", e);
+            return;
+        }
+    }
+}

--- a/lampo-plugin-sdk/src/lib.rs
+++ b/lampo-plugin-sdk/src/lib.rs
@@ -1,0 +1,181 @@
+//! Lampo Plugin SDK
+//!
+//! Builder-pattern API for writing lampo plugins in Rust.
+//!
+//! # Example
+//!
+//! ```no_run
+//! use lampo_plugin_sdk::Plugin;
+//! use serde_json::Value;
+//!
+//! async fn handle_hello(_params: Value) -> Result<Value, String> {
+//!     Ok(serde_json::json!({"message": "hello from plugin!"}))
+//! }
+//!
+//! #[tokio::main]
+//! async fn main() {
+//!     Plugin::new()
+//!         .rpc_method("hello", "Says hello", "[name]", handle_hello)
+//!         .start()
+//!         .await;
+//! }
+//! ```
+mod io;
+
+use std::collections::HashMap;
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+
+use lampo_plugin_common::manifest::{HookDecl, PluginOption, RpcMethodDecl};
+use serde_json::Value;
+
+/// Type alias for an async RPC handler.
+pub type RpcHandler = Arc<
+    dyn Fn(Value) -> Pin<Box<dyn Future<Output = Result<Value, String>> + Send>> + Send + Sync,
+>;
+
+/// Type alias for an async hook handler.
+pub type HookHandler = Arc<
+    dyn Fn(Value) -> Pin<Box<dyn Future<Output = HookResponse> + Send>> + Send + Sync,
+>;
+
+/// Type alias for an async notification handler.
+pub type NotifyHandler = Arc<
+    dyn Fn(Value) -> Pin<Box<dyn Future<Output = ()> + Send>> + Send + Sync,
+>;
+
+/// Builder for constructing a lampo plugin.
+pub struct Plugin {
+    manifest: PluginManifest,
+    rpc_handlers: HashMap<String, RpcHandler>,
+    hook_handlers: HashMap<String, HookHandler>,
+    notify_handlers: HashMap<String, NotifyHandler>,
+}
+
+impl Plugin {
+    /// Create a new plugin builder.
+    pub fn new() -> Self {
+        Self {
+            manifest: PluginManifest::default(),
+            rpc_handlers: HashMap::new(),
+            hook_handlers: HashMap::new(),
+            notify_handlers: HashMap::new(),
+        }
+    }
+
+    /// Register an RPC method with a handler.
+    pub fn rpc_method<F, Fut>(mut self, name: &str, description: &str, usage: &str, handler: F) -> Self
+    where
+        F: Fn(Value) -> Fut + Send + Sync + 'static,
+        Fut: Future<Output = Result<Value, String>> + Send + 'static,
+    {
+        self.manifest.rpc_methods.push(RpcMethodDecl {
+            name: name.to_string(),
+            description: description.to_string(),
+            usage: usage.to_string(),
+        });
+        let handler = Arc::new(move |params: Value| {
+            Box::pin(handler(params)) as Pin<Box<dyn Future<Output = Result<Value, String>> + Send>>
+        });
+        self.rpc_handlers.insert(name.to_string(), handler);
+        self
+    }
+
+    /// Subscribe to a notification topic with a handler.
+    pub fn subscribe<F, Fut>(mut self, topic: &str, handler: F) -> Self
+    where
+        F: Fn(Value) -> Fut + Send + Sync + 'static,
+        Fut: Future<Output = ()> + Send + 'static,
+    {
+        self.manifest.subscriptions.push(topic.to_string());
+        let handler = Arc::new(move |params: Value| {
+            Box::pin(handler(params)) as Pin<Box<dyn Future<Output = ()> + Send>>
+        });
+        self.notify_handlers.insert(topic.to_string(), handler);
+        self
+    }
+
+    /// Register a hook handler.
+    pub fn hook<F, Fut>(mut self, name: &str, handler: F) -> Self
+    where
+        F: Fn(Value) -> Fut + Send + Sync + 'static,
+        Fut: Future<Output = HookResponse> + Send + 'static,
+    {
+        self.manifest.hooks.push(HookDecl {
+            name: name.to_string(),
+            before: vec![],
+            after: vec![],
+        });
+        let handler = Arc::new(move |params: Value| {
+            Box::pin(handler(params)) as Pin<Box<dyn Future<Output = HookResponse> + Send>>
+        });
+        self.hook_handlers.insert(name.to_string(), handler);
+        self
+    }
+
+    /// Declare a plugin option.
+    pub fn option(
+        mut self,
+        name: &str,
+        opt_type: OptionType,
+        default: Option<Value>,
+        description: &str,
+    ) -> Self {
+        self.manifest.options.push(PluginOption {
+            name: name.to_string(),
+            opt_type,
+            default,
+            description: description.to_string(),
+        });
+        self
+    }
+
+    /// Mark the plugin as dynamic (can be started/stopped at runtime).
+    pub fn dynamic(mut self, dynamic: bool) -> Self {
+        self.manifest.dynamic = dynamic;
+        self
+    }
+
+    /// Set the failure mode.
+    pub fn failure_mode(mut self, mode: FailureMode) -> Self {
+        self.manifest.failure_mode = mode;
+        self
+    }
+
+    /// Start the plugin, reading from stdin and writing to stdout.
+    ///
+    /// This blocks until the daemon sends a shutdown signal.
+    pub async fn start(self) {
+        let stdin = tokio::io::stdin();
+        let stdout = tokio::io::stdout();
+        self.run(stdin, stdout).await;
+    }
+
+    /// Run the plugin with custom I/O (for testing).
+    pub async fn run<R, W>(self, input: R, output: W)
+    where
+        R: tokio::io::AsyncRead + Unpin,
+        W: tokio::io::AsyncWrite + Unpin,
+    {
+        io::run_plugin(
+            input,
+            output,
+            self.manifest,
+            self.rpc_handlers,
+            self.hook_handlers,
+            self.notify_handlers,
+        )
+        .await;
+    }
+}
+
+impl Default for Plugin {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+// Re-export commonly used types for plugin authors.
+pub use lampo_plugin_common::manifest::{FailureMode, OptionType, PluginManifest};
+pub use lampo_plugin_common::messages::{HookResponse, InitConfig};

--- a/lampo-plugin-sdk/tests/sdk_tests.rs
+++ b/lampo-plugin-sdk/tests/sdk_tests.rs
@@ -1,0 +1,158 @@
+//! Integration tests for the plugin SDK.
+//!
+//! Tests the full lifecycle using mock I/O (no real stdin/stdout).
+use lampo_plugin_sdk::{HookResponse, Plugin};
+use serde_json::Value;
+use tokio::io::{duplex, AsyncWriteExt, BufReader, AsyncBufReadExt};
+
+/// Helper: send a JSON-RPC request and read the response.
+async fn roundtrip(
+    writer: &mut (impl tokio::io::AsyncWrite + Unpin),
+    reader: &mut (impl tokio::io::AsyncBufRead + Unpin),
+    method: &str,
+    params: Value,
+    id: u64,
+) -> Value {
+    let req = serde_json::json!({
+        "method": method,
+        "params": params,
+        "id": id,
+        "jsonrpc": "2.0"
+    });
+    let mut line = serde_json::to_string(&req).unwrap();
+    line.push('\n');
+    writer.write_all(line.as_bytes()).await.unwrap();
+    writer.flush().await.unwrap();
+
+    let mut response_line = String::new();
+    reader.read_line(&mut response_line).await.unwrap();
+    serde_json::from_str(&response_line).unwrap()
+}
+
+#[tokio::test]
+async fn test_sdk_full_lifecycle() {
+    // Create duplex streams for mock I/O
+    let (plugin_input, mut test_writer) = duplex(4096);
+    let (mut plugin_output_reader, plugin_output) = duplex(4096);
+
+    let plugin = Plugin::new()
+        .rpc_method("hello", "Says hello", "[name]", |_params| async {
+            Ok(serde_json::json!({"message": "hello from sdk!"}))
+        })
+        .hook("openchannel", |params| async move {
+            let funding = params.get("funding_satoshis")
+                .and_then(|v| v.as_u64())
+                .unwrap_or(0);
+            if funding < 10000 {
+                HookResponse::Reject { message: "too small".to_string() }
+            } else {
+                HookResponse::Continue { payload: None }
+            }
+        })
+        .subscribe("channel_ready", |_params| async {
+            // Just absorb the notification
+        });
+
+    // Run plugin in background
+    let handle = tokio::spawn(async move {
+        plugin.run(plugin_input, plugin_output).await;
+    });
+
+    let mut reader = BufReader::new(&mut plugin_output_reader);
+
+    // 1. getmanifest
+    let resp = roundtrip(&mut test_writer, &mut reader, "getmanifest", serde_json::json!({}), 1).await;
+    let result = resp.get("result").unwrap();
+    let methods = result.get("rpc_methods").unwrap().as_array().unwrap();
+    assert_eq!(methods.len(), 1);
+    assert_eq!(methods[0]["name"].as_str().unwrap(), "hello");
+    let hooks = result.get("hooks").unwrap().as_array().unwrap();
+    assert_eq!(hooks.len(), 1);
+    assert_eq!(hooks[0]["name"].as_str().unwrap(), "openchannel");
+    let subs = result.get("subscriptions").unwrap().as_array().unwrap();
+    assert_eq!(subs.len(), 1);
+    assert_eq!(subs[0].as_str().unwrap(), "channel_ready");
+
+    // 2. init
+    let resp = roundtrip(&mut test_writer, &mut reader, "init", serde_json::json!({
+        "lampo_dir": "/tmp/test",
+        "network": "regtest",
+        "node_id": "",
+        "options": {}
+    }), 2).await;
+    assert!(resp.get("result").is_some());
+
+    // 3. RPC call
+    let resp = roundtrip(&mut test_writer, &mut reader, "hello", serde_json::json!({}), 3).await;
+    assert_eq!(
+        resp["result"]["message"].as_str().unwrap(),
+        "hello from sdk!"
+    );
+
+    // 4. Hook — large channel (continue)
+    let resp = roundtrip(&mut test_writer, &mut reader, "hook/openchannel", serde_json::json!({
+        "funding_satoshis": 100000
+    }), 4).await;
+    let hook_result = resp["result"]["result"].as_str().unwrap();
+    assert_eq!(hook_result, "continue");
+
+    // 5. Hook — small channel (reject)
+    let resp = roundtrip(&mut test_writer, &mut reader, "hook/openchannel", serde_json::json!({
+        "funding_satoshis": 5000
+    }), 5).await;
+    assert_eq!(resp["result"]["result"].as_str().unwrap(), "reject");
+    assert_eq!(resp["result"]["message"].as_str().unwrap(), "too small");
+
+    // 6. Notification (no id, no response expected)
+    let notif = serde_json::json!({
+        "method": "channel_ready",
+        "params": {"channel_id": "abc"},
+        "jsonrpc": "2.0"
+    });
+    let mut notif_str = serde_json::to_string(&notif).unwrap();
+    notif_str.push('\n');
+    test_writer.write_all(notif_str.as_bytes()).await.unwrap();
+    test_writer.flush().await.unwrap();
+
+    // 7. Unknown method
+    let resp = roundtrip(&mut test_writer, &mut reader, "unknown", serde_json::json!({}), 6).await;
+    assert!(resp.get("error").is_some());
+
+    // 8. Shutdown
+    let resp = roundtrip(&mut test_writer, &mut reader, "shutdown", serde_json::json!({}), 7).await;
+    assert!(resp.get("result").is_some());
+
+    // Plugin should exit
+    handle.await.unwrap();
+}
+
+#[tokio::test]
+async fn test_sdk_rpc_error_handling() {
+    let (plugin_input, mut test_writer) = duplex(4096);
+    let (mut plugin_output_reader, plugin_output) = duplex(4096);
+
+    let plugin = Plugin::new()
+        .rpc_method("fail_me", "Always fails", "", |_| async {
+            Err("something went wrong".to_string())
+        });
+
+    let handle = tokio::spawn(async move {
+        plugin.run(plugin_input, plugin_output).await;
+    });
+
+    let mut reader = BufReader::new(&mut plugin_output_reader);
+
+    // Skip getmanifest + init
+    let _ = roundtrip(&mut test_writer, &mut reader, "getmanifest", serde_json::json!({}), 1).await;
+    let _ = roundtrip(&mut test_writer, &mut reader, "init", serde_json::json!({}), 2).await;
+
+    // Call the failing method
+    let resp = roundtrip(&mut test_writer, &mut reader, "fail_me", serde_json::json!({}), 3).await;
+    let error = resp.get("error").unwrap();
+    assert_eq!(error["message"].as_str().unwrap(), "something went wrong");
+    assert_eq!(error["code"].as_i64().unwrap(), -32000);
+
+    // Shutdown
+    let _ = roundtrip(&mut test_writer, &mut reader, "shutdown", serde_json::json!({}), 4).await;
+    handle.await.unwrap();
+}

--- a/lampo-plugin/Cargo.toml
+++ b/lampo-plugin/Cargo.toml
@@ -1,0 +1,30 @@
+[package]
+name = "lampo-plugin"
+version = "0.1.0"
+edition = "2021"
+
+[features]
+default = []
+grpc = ["tonic", "prost", "rcgen", "tonic-build"]
+
+[dependencies]
+lampo-common = { path = "../lampo-common" }
+lampo-plugin-common = { path = "../lampo-plugin-common" }
+
+tokio = { version = "1", features = ["process", "io-util", "sync", "rt", "macros", "time"] }
+async-trait = "0.1"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+log = { version = "0.4", features = ["std"] }
+
+# gRPC transport (optional, behind "grpc" feature)
+tonic = { version = "0.12", features = ["tls", "transport"], optional = true }
+prost = { version = "0.13", optional = true }
+rcgen = { version = "0.13", features = ["pem", "x509-parser"], optional = true }
+
+[build-dependencies]
+tonic-build = { version = "0.12", optional = true, features = ["prost"] }
+
+[dev-dependencies]
+tokio = { version = "1", features = ["full"] }
+tempfile = "3"

--- a/lampo-plugin/build.rs
+++ b/lampo-plugin/build.rs
@@ -1,0 +1,10 @@
+fn main() {
+    #[cfg(feature = "grpc")]
+    {
+        tonic_build::configure()
+            .build_server(false) // daemon is the client
+            .build_client(true)
+            .compile_protos(&["proto/plugin.proto"], &["proto/"])
+            .expect("failed to compile plugin.proto");
+    }
+}

--- a/lampo-plugin/proto/plugin.proto
+++ b/lampo-plugin/proto/plugin.proto
@@ -1,0 +1,95 @@
+syntax = "proto3";
+package lampo.plugin.v1;
+
+/// LampoPlugin is the service that a remote plugin implements.
+/// The daemon connects to the plugin as a gRPC client and drives
+/// the full lifecycle: manifest → init → rpc/hook/notify → shutdown.
+service LampoPlugin {
+    /// Request the plugin's manifest (capabilities declaration).
+    rpc GetManifest(ManifestRequest) returns (ManifestResponse);
+
+    /// Initialize the plugin with node configuration.
+    rpc Init(InitRequest) returns (InitResponse);
+
+    /// Forward an RPC call to the plugin.
+    rpc HandleRpc(RpcRequest) returns (RpcResponse);
+
+    /// Invoke a synchronous hook on the plugin.
+    rpc HandleHook(HookRequest) returns (HookResponse);
+
+    /// Send a fire-and-forget notification to the plugin.
+    rpc Notify(NotifyRequest) returns (NotifyResponse);
+
+    /// Request graceful shutdown.
+    rpc Shutdown(ShutdownRequest) returns (ShutdownResponse);
+}
+
+// --- Manifest ---
+
+message ManifestRequest {}
+
+message ManifestResponse {
+    /// JSON-encoded PluginManifest (same schema as stdio protocol).
+    string manifest_json = 1;
+}
+
+// --- Init ---
+
+message InitRequest {
+    /// JSON-encoded InitConfig.
+    string config_json = 1;
+}
+
+message InitResponse {
+    /// Empty if OK. Set disable_message to opt out.
+    string disable_message = 1;
+}
+
+// --- RPC ---
+
+message RpcRequest {
+    /// The RPC method name.
+    string method = 1;
+    /// JSON-encoded parameters.
+    string params_json = 2;
+}
+
+message RpcResponse {
+    /// JSON-encoded result on success.
+    string result_json = 1;
+    /// If non-empty, the call failed with this error message.
+    string error_message = 2;
+    /// JSON-RPC error code (e.g. -32000 for application errors).
+    int32 error_code = 3;
+}
+
+// --- Hook ---
+
+message HookRequest {
+    /// The hook name (e.g. "hook/openchannel").
+    string hook_name = 1;
+    /// JSON-encoded hook payload.
+    string payload_json = 2;
+}
+
+message HookResponse {
+    /// JSON-encoded HookResponse (continue/complete/reject).
+    string response_json = 1;
+}
+
+// --- Notify ---
+
+message NotifyRequest {
+    /// The notification topic (e.g. "channel_ready").
+    string topic = 1;
+    /// JSON-encoded payload.
+    string payload_json = 2;
+}
+
+message NotifyResponse {}
+
+// --- Shutdown ---
+
+message ShutdownRequest {}
+
+message ShutdownResponse {}

--- a/lampo-plugin/src/lib.rs
+++ b/lampo-plugin/src/lib.rs
@@ -1,0 +1,10 @@
+//! Lampo Plugin Infrastructure
+//!
+//! Daemon-side plugin management: transport layer, lifecycle,
+//! and integration with the lampo handler chain.
+pub mod manager;
+#[cfg(feature = "grpc")]
+pub mod tls;
+pub mod transport;
+
+pub use manager::PluginManager;

--- a/lampo-plugin/src/manager.rs
+++ b/lampo-plugin/src/manager.rs
@@ -1,0 +1,705 @@
+//! Plugin lifecycle management and RPC dispatch.
+//!
+//! `PluginManager` implements `ExternalHandler` and slots into
+//! the existing lampo handler chain. It manages plugin lifecycle
+//! (start, stop) and routes RPC calls to the correct plugin.
+//!
+//! It also provides:
+//! - **Hook chain execution**: synchronous interception points
+//! - **Notification dispatch**: async event forwarding to plugins
+use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use lampo_common::error;
+use lampo_common::handler::ExternalHandler;
+use lampo_common::json;
+use lampo_common::jsonrpc::Request;
+use lampo_plugin_common::hooks::HookPoint;
+use lampo_plugin_common::manifest::FailureMode;
+use lampo_plugin_common::messages::{HookResponse, InitConfig, InitResponse};
+use lampo_plugin_common::topics;
+use lampo_plugin_common::PluginManifest;
+use tokio::sync::RwLock;
+
+use crate::transport::stdio::StdioTransport;
+use crate::transport::PluginTransport;
+#[cfg(feature = "grpc")]
+use crate::transport::grpc::{GrpcConfig, GrpcTransport};
+
+/// State of a running plugin.
+#[derive(Debug, Clone, PartialEq)]
+pub enum PluginState {
+    Starting,
+    Running,
+    Stopping,
+    Stopped,
+}
+
+/// A running plugin instance.
+pub struct PluginInstance {
+    /// Plugin name (derived from the binary name or manifest).
+    pub name: String,
+    /// Path to the plugin binary.
+    pub path: String,
+    /// The plugin's declared capabilities.
+    pub manifest: PluginManifest,
+    /// Transport for communicating with the plugin.
+    pub transport: Box<dyn PluginTransport>,
+    /// Current state.
+    pub state: PluginState,
+    /// RPC methods registered by this plugin.
+    pub registered_methods: HashSet<String>,
+}
+
+/// Manages plugin lifecycles and dispatches RPC calls.
+///
+/// Uses name-based indexing (not positional) to avoid index invalidation
+/// when plugins are added or removed.
+pub struct PluginManager {
+    /// Running plugins keyed by name.
+    plugins: RwLock<HashMap<String, Arc<RwLock<PluginInstance>>>>,
+    /// RPC method name → plugin name that owns it.
+    method_index: RwLock<HashMap<String, String>>,
+    /// Hook name → ordered list of plugin names.
+    hook_index: RwLock<HashMap<String, Vec<String>>>,
+    /// Notification topic → list of plugin names.
+    subscription_index: RwLock<HashMap<String, Vec<String>>>,
+}
+
+impl PluginManager {
+    pub fn new() -> Self {
+        Self {
+            plugins: RwLock::new(HashMap::new()),
+            method_index: RwLock::new(HashMap::new()),
+            hook_index: RwLock::new(HashMap::new()),
+            subscription_index: RwLock::new(HashMap::new()),
+        }
+    }
+
+    /// Start a local plugin from a binary path.
+    ///
+    /// Performs the two-phase handshake:
+    /// 1. `getmanifest` — ask plugin what it can do
+    /// 2. `init` — send configuration to the plugin
+    pub async fn start_plugin(
+        &self,
+        path: &str,
+        init_config: &InitConfig,
+    ) -> error::Result<String> {
+        log::info!(target: "plugin", "starting plugin: {}", path);
+
+        let transport = StdioTransport::new(path).await?;
+
+        // Phase 1: getmanifest
+        let manifest_req = serde_json::json!({
+            "method": "getmanifest",
+            "params": {},
+            "jsonrpc": "2.0"
+        });
+        let manifest_resp = transport.request(manifest_req).await?;
+
+        // Check for JSON-RPC error in response
+        if let Some(error) = manifest_resp.get("error") {
+            let msg = error
+                .get("message")
+                .and_then(|m| m.as_str())
+                .unwrap_or("unknown error");
+            error::bail!("plugin `{}`: getmanifest failed: {}", path, msg);
+        }
+
+        let manifest_result = manifest_resp
+            .get("result")
+            .ok_or_else(|| error::anyhow!("plugin `{}`: getmanifest returned no result", path))?;
+        let manifest: PluginManifest = serde_json::from_value(manifest_result.clone())
+            .map_err(|e| error::anyhow!("plugin `{}`: invalid manifest: {}", path, e))?;
+
+        log::info!(
+            target: "plugin",
+            "plugin `{}`: manifest received, {} rpc methods, {} hooks, {} subscriptions",
+            path,
+            manifest.rpc_methods.len(),
+            manifest.hooks.len(),
+            manifest.subscriptions.len()
+        );
+
+        // Derive plugin name from the binary path
+        let plugin_name = std::path::Path::new(path)
+            .file_name()
+            .and_then(|n| n.to_str())
+            .unwrap_or(path)
+            .to_string();
+
+        // Check for method name collisions
+        {
+            let method_index = self.method_index.read().await;
+            for method in &manifest.rpc_methods {
+                if method_index.contains_key(&method.name) {
+                    error::bail!(
+                        "plugin `{}`: method `{}` already registered by another plugin",
+                        plugin_name,
+                        method.name
+                    );
+                }
+            }
+        }
+
+        // Phase 2: init
+        let init_req = serde_json::json!({
+            "method": "init",
+            "params": serde_json::to_value(init_config)?,
+            "jsonrpc": "2.0"
+        });
+        let init_resp = transport.request(init_req).await?;
+
+        // Check for JSON-RPC error in init response
+        if let Some(error) = init_resp.get("error") {
+            let msg = error
+                .get("message")
+                .and_then(|m| m.as_str())
+                .unwrap_or("unknown error");
+            error::bail!("plugin `{}`: init failed: {}", plugin_name, msg);
+        }
+
+        // Check if the plugin wants to disable itself
+        if let Some(result) = init_resp.get("result") {
+            if let Ok(init_result) = serde_json::from_value::<InitResponse>(result.clone()) {
+                if let Some(disable) = init_result.disable {
+                    log::warn!(
+                        target: "plugin",
+                        "plugin `{}` disabled itself: {}",
+                        plugin_name, disable
+                    );
+                    transport.shutdown().await?;
+                    error::bail!("plugin `{}` disabled itself: {}", plugin_name, disable);
+                }
+            }
+        }
+
+        // Register the plugin
+        let registered_methods: HashSet<String> =
+            manifest.rpc_methods.iter().map(|m| m.name.clone()).collect();
+        let hook_names: Vec<String> = manifest.hooks.iter().map(|h| h.name.clone()).collect();
+        let subscriptions: Vec<String> = manifest.subscriptions.clone();
+
+        let instance = PluginInstance {
+            name: plugin_name.clone(),
+            path: path.to_string(),
+            manifest,
+            transport: Box::new(transport),
+            state: PluginState::Running,
+            registered_methods: registered_methods.clone(),
+        };
+
+        let instance = Arc::new(RwLock::new(instance));
+
+        // Add to the plugins map and update all indices
+        {
+            let mut plugins = self.plugins.write().await;
+            plugins.insert(plugin_name.clone(), instance);
+
+            let mut method_index = self.method_index.write().await;
+            for method_name in &registered_methods {
+                log::info!(
+                    target: "plugin",
+                    "plugin `{}`: registered method `{}`",
+                    plugin_name, method_name
+                );
+                method_index.insert(method_name.clone(), plugin_name.clone());
+            }
+
+            // Register hooks
+            let mut hook_index = self.hook_index.write().await;
+            for hook_name in hook_names {
+                log::info!(
+                    target: "plugin",
+                    "plugin `{}`: registered hook `{}`",
+                    plugin_name, hook_name
+                );
+                hook_index.entry(hook_name).or_default().push(plugin_name.clone());
+            }
+
+            // Register subscriptions
+            let mut sub_index = self.subscription_index.write().await;
+            for topic in subscriptions {
+                log::info!(
+                    target: "plugin",
+                    "plugin `{}`: subscribed to `{}`",
+                    plugin_name, topic
+                );
+                sub_index.entry(topic).or_default().push(plugin_name.clone());
+            }
+        }
+
+        log::info!(target: "plugin", "plugin `{}` started successfully", plugin_name);
+        Ok(plugin_name)
+    }
+
+    /// Start a remote plugin via gRPC.
+    ///
+    /// The daemon connects as a gRPC client to the remote plugin server,
+    /// then performs the same two-phase handshake as local plugins.
+    #[cfg(feature = "grpc")]
+    pub async fn start_remote_plugin(
+        &self,
+        config: GrpcConfig,
+        init_config: &InitConfig,
+    ) -> error::Result<String> {
+        let endpoint = config.endpoint.clone();
+        log::info!(target: "plugin", "connecting to remote plugin: {}", endpoint);
+
+        let transport = GrpcTransport::connect(config).await?;
+
+        // Same two-phase handshake as local plugins
+        let manifest_req = serde_json::json!({
+            "method": "getmanifest",
+            "params": {},
+            "jsonrpc": "2.0"
+        });
+        let manifest_resp = transport.request(manifest_req).await?;
+
+        // Check for JSON-RPC error
+        if let Some(error) = manifest_resp.get("error") {
+            let msg = error
+                .get("message")
+                .and_then(|m| m.as_str())
+                .unwrap_or("unknown error");
+            error::bail!("remote plugin `{}`: getmanifest failed: {}", endpoint, msg);
+        }
+
+        let manifest_result = manifest_resp
+            .get("result")
+            .ok_or_else(|| error::anyhow!("remote plugin `{}`: getmanifest returned no result", endpoint))?;
+        let manifest: PluginManifest = serde_json::from_value(manifest_result.clone())
+            .map_err(|e| error::anyhow!("remote plugin `{}`: invalid manifest: {}", endpoint, e))?;
+
+        log::info!(
+            target: "plugin",
+            "remote plugin `{}`: manifest received, {} rpc methods, {} hooks, {} subscriptions",
+            endpoint,
+            manifest.rpc_methods.len(),
+            manifest.hooks.len(),
+            manifest.subscriptions.len()
+        );
+
+        // Derive name from endpoint (host:port)
+        let plugin_name = endpoint
+            .trim_start_matches("https://")
+            .trim_start_matches("http://")
+            .replace([':', '/'], "_");
+
+        // Check for method collisions
+        {
+            let method_index = self.method_index.read().await;
+            for method in &manifest.rpc_methods {
+                if method_index.contains_key(&method.name) {
+                    error::bail!(
+                        "remote plugin `{}`: method `{}` already registered by another plugin",
+                        plugin_name,
+                        method.name
+                    );
+                }
+            }
+        }
+
+        // Phase 2: init
+        let init_req = serde_json::json!({
+            "method": "init",
+            "params": serde_json::to_value(init_config)?,
+            "jsonrpc": "2.0"
+        });
+        let init_resp = transport.request(init_req).await?;
+
+        // Check for JSON-RPC error
+        if let Some(error) = init_resp.get("error") {
+            let msg = error
+                .get("message")
+                .and_then(|m| m.as_str())
+                .unwrap_or("unknown error");
+            error::bail!("remote plugin `{}`: init failed: {}", plugin_name, msg);
+        }
+
+        if let Some(result) = init_resp.get("result") {
+            if let Ok(init_result) = serde_json::from_value::<InitResponse>(result.clone()) {
+                if let Some(disable) = init_result.disable {
+                    log::warn!(
+                        target: "plugin",
+                        "remote plugin `{}` disabled itself: {}",
+                        plugin_name, disable
+                    );
+                    transport.shutdown().await?;
+                    error::bail!("remote plugin `{}` disabled itself: {}", plugin_name, disable);
+                }
+            }
+        }
+
+        // Register
+        let registered_methods: HashSet<String> =
+            manifest.rpc_methods.iter().map(|m| m.name.clone()).collect();
+        let hook_names: Vec<String> = manifest.hooks.iter().map(|h| h.name.clone()).collect();
+        let subscriptions: Vec<String> = manifest.subscriptions.clone();
+
+        let instance = PluginInstance {
+            name: plugin_name.clone(),
+            path: endpoint.clone(),
+            manifest,
+            transport: Box::new(transport),
+            state: PluginState::Running,
+            registered_methods: registered_methods.clone(),
+        };
+
+        let instance = Arc::new(RwLock::new(instance));
+
+        {
+            let mut plugins = self.plugins.write().await;
+            plugins.insert(plugin_name.clone(), instance);
+
+            let mut method_index = self.method_index.write().await;
+            for method_name in &registered_methods {
+                log::info!(
+                    target: "plugin",
+                    "remote plugin `{}`: registered method `{}`",
+                    plugin_name, method_name
+                );
+                method_index.insert(method_name.clone(), plugin_name.clone());
+            }
+
+            let mut hook_index = self.hook_index.write().await;
+            for hook_name in hook_names {
+                hook_index.entry(hook_name).or_default().push(plugin_name.clone());
+            }
+
+            let mut sub_index = self.subscription_index.write().await;
+            for topic in subscriptions {
+                sub_index.entry(topic).or_default().push(plugin_name.clone());
+            }
+        }
+
+        log::info!(target: "plugin", "remote plugin `{}` started successfully", plugin_name);
+        Ok(plugin_name)
+    }
+
+    /// Stop a plugin by name.
+    pub async fn stop_plugin(&self, name: &str) -> error::Result<()> {
+        // Remove from plugins map
+        let plugin = {
+            let mut plugins = self.plugins.write().await;
+            plugins
+                .remove(name)
+                .ok_or_else(|| error::anyhow!("plugin `{}` not found", name))?
+        };
+
+        // Remove from all indices
+        {
+            let mut method_index = self.method_index.write().await;
+            method_index.retain(|_, plugin_name| plugin_name != name);
+        }
+        {
+            let mut hook_index = self.hook_index.write().await;
+            for entries in hook_index.values_mut() {
+                entries.retain(|plugin_name| plugin_name != name);
+            }
+            // Remove empty entries
+            hook_index.retain(|_, entries| !entries.is_empty());
+        }
+        {
+            let mut sub_index = self.subscription_index.write().await;
+            for entries in sub_index.values_mut() {
+                entries.retain(|plugin_name| plugin_name != name);
+            }
+            sub_index.retain(|_, entries| !entries.is_empty());
+        }
+
+        // Shut down the transport
+        let plugin = plugin.write().await;
+        plugin.transport.shutdown().await?;
+        log::info!(target: "plugin", "plugin `{}` stopped", name);
+        Ok(())
+    }
+
+    /// Stop all running plugins.
+    pub async fn shutdown_all(&self) {
+        let plugins = self.plugins.read().await;
+        for (_, plugin) in plugins.iter() {
+            let plugin = plugin.read().await;
+            if let Err(e) = plugin.transport.shutdown().await {
+                log::warn!(
+                    target: "plugin",
+                    "error shutting down plugin `{}`: {}",
+                    plugin.name, e
+                );
+            }
+        }
+    }
+
+    /// List running plugins.
+    pub async fn list_plugins(&self) -> Vec<String> {
+        let plugins = self.plugins.read().await;
+        plugins.keys().cloned().collect()
+    }
+
+    /// Execute a hook chain for the given hook point.
+    ///
+    /// Sends the hook request to each registered plugin in order.
+    /// The chain stops on `Complete` or `Reject`. `Continue` passes
+    /// to the next plugin (optionally with a modified payload).
+    ///
+    /// Returns the final `HookResponse` after the chain completes.
+    pub async fn run_hook(
+        &self,
+        hook: &HookPoint,
+        payload: serde_json::Value,
+    ) -> error::Result<HookResponse> {
+        let hook_name = match hook {
+            HookPoint::PeerConnected => "peer_connected",
+            HookPoint::OpenChannel => "openchannel",
+            HookPoint::HtlcAccepted => "htlc_accepted",
+            HookPoint::RpcCommand => "rpc_command",
+            HookPoint::InvoiceCreation => "invoice_creation",
+        };
+
+        // Snapshot the plugin names for this hook
+        let plugin_names = {
+            let hook_index = self.hook_index.read().await;
+            match hook_index.get(hook_name) {
+                Some(names) => names.clone(),
+                None => return Ok(HookResponse::Continue { payload: None }),
+            }
+        };
+
+        let plugins = self.plugins.read().await;
+        let mut current_payload = payload;
+
+        for plugin_name in &plugin_names {
+            let Some(plugin) = plugins.get(plugin_name) else {
+                // Plugin was removed between index snapshot and now
+                continue;
+            };
+            let plugin = plugin.read().await;
+            if plugin.state != PluginState::Running {
+                continue;
+            }
+
+            let hook_req = serde_json::json!({
+                "method": hook.method_name(),
+                "params": current_payload,
+                "jsonrpc": "2.0"
+            });
+
+            // Send hook request with 30s timeout (hooks are synchronous)
+            let result = tokio::time::timeout(
+                std::time::Duration::from_secs(30),
+                plugin.transport.request(hook_req),
+            )
+            .await;
+
+            match result {
+                Ok(Ok(response)) => {
+                    // Parse the hook response from the result field
+                    let result_value = response
+                        .get("result")
+                        .cloned()
+                        .unwrap_or(serde_json::json!({"result": "continue"}));
+
+                    let hook_resp: HookResponse =
+                        serde_json::from_value(result_value).unwrap_or_default();
+
+                    match hook_resp {
+                        HookResponse::Continue {
+                            payload: Some(modified),
+                        } => {
+                            // Pass modified payload to next plugin
+                            current_payload = modified;
+                        }
+                        HookResponse::Continue { payload: None } => {
+                            // Continue with same payload
+                        }
+                        HookResponse::Complete { .. } | HookResponse::Reject { .. } => {
+                            // Short-circuit the chain
+                            log::info!(
+                                target: "plugin",
+                                "plugin `{}` short-circuited hook `{}`",
+                                plugin.name, hook_name
+                            );
+                            return Ok(hook_resp);
+                        }
+                    }
+                }
+                Ok(Err(e)) => {
+                    // Transport error — apply failure mode
+                    match plugin.manifest.failure_mode {
+                        FailureMode::FailOpen => {
+                            log::warn!(
+                                target: "plugin",
+                                "plugin `{}` failed on hook `{}` (fail-open): {}",
+                                plugin.name, hook_name, e
+                            );
+                            continue;
+                        }
+                        FailureMode::FailClosed => {
+                            return Ok(HookResponse::Reject {
+                                message: format!(
+                                    "plugin `{}` failed on hook `{}`: {}",
+                                    plugin.name, hook_name, e
+                                ),
+                            });
+                        }
+                    }
+                }
+                Err(_timeout) => {
+                    // Timeout — apply failure mode
+                    match plugin.manifest.failure_mode {
+                        FailureMode::FailOpen => {
+                            log::warn!(
+                                target: "plugin",
+                                "plugin `{}` timed out on hook `{}` (fail-open)",
+                                plugin.name, hook_name
+                            );
+                            continue;
+                        }
+                        FailureMode::FailClosed => {
+                            return Ok(HookResponse::Reject {
+                                message: format!(
+                                    "plugin `{}` timed out on hook `{}`",
+                                    plugin.name, hook_name
+                                ),
+                            });
+                        }
+                    }
+                }
+            }
+        }
+
+        // All plugins returned Continue
+        Ok(HookResponse::Continue { payload: None })
+    }
+
+    /// Send a notification to all plugins subscribed to the given topic.
+    ///
+    /// This is fire-and-forget — errors are logged but not propagated.
+    pub async fn notify(&self, topic: &str, payload: serde_json::Value) {
+        // Snapshot plugin names for this topic
+        let mut target_names: Vec<String> = Vec::new();
+        {
+            let sub_index = self.subscription_index.read().await;
+            if let Some(names) = sub_index.get(topic) {
+                target_names.extend(names.iter().cloned());
+            }
+            if let Some(names) = sub_index.get(topics::ALL) {
+                target_names.extend(names.iter().cloned());
+            }
+        }
+        // Deduplicate
+        target_names.sort_unstable();
+        target_names.dedup();
+
+        if target_names.is_empty() {
+            return;
+        }
+
+        let plugins = self.plugins.read().await;
+        let notification = serde_json::json!({
+            "method": topic,
+            "params": payload,
+            "jsonrpc": "2.0"
+        });
+
+        for plugin_name in &target_names {
+            let Some(plugin) = plugins.get(plugin_name) else {
+                continue;
+            };
+            let plugin = plugin.read().await;
+            if plugin.state != PluginState::Running {
+                continue;
+            }
+
+            if let Err(e) = plugin.transport.notify(notification.clone()).await {
+                log::warn!(
+                    target: "plugin",
+                    "failed to send notification `{}` to plugin `{}`: {}",
+                    topic, plugin.name, e
+                );
+            }
+        }
+    }
+}
+
+impl Default for PluginManager {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl ExternalHandler for PluginManager {
+    async fn handle(&self, req: &Request<json::Value>) -> error::Result<Option<json::Value>> {
+        // Look up which plugin owns this method
+        let plugin_name = {
+            let method_index = self.method_index.read().await;
+            match method_index.get(&req.method) {
+                Some(name) => name.clone(),
+                None => return Ok(None),
+            }
+        };
+
+        let plugins = self.plugins.read().await;
+        let Some(plugin) = plugins.get(&plugin_name) else {
+            return Ok(None);
+        };
+
+        let plugin = plugin.read().await;
+        if plugin.state != PluginState::Running {
+            log::warn!(
+                target: "plugin",
+                "plugin `{}` is not running, skipping method `{}`",
+                plugin.name, req.method
+            );
+            return Ok(None);
+        }
+
+        // Build the JSON-RPC request for the plugin
+        let plugin_req = serde_json::json!({
+            "method": req.method,
+            "params": req.params,
+            "jsonrpc": "2.0"
+        });
+
+        // Forward to the plugin
+        let result = plugin.transport.request(plugin_req).await;
+
+        match result {
+            Ok(response) => {
+                // Extract the result from the JSON-RPC response
+                if let Some(error) = response.get("error") {
+                    let msg = error
+                        .get("message")
+                        .and_then(|m| m.as_str())
+                        .unwrap_or("unknown plugin error");
+                    error::bail!("plugin `{}` error: {}", plugin.name, msg);
+                }
+                let result = response.get("result").cloned().unwrap_or(json::json!({}));
+                Ok(Some(result))
+            }
+            Err(e) => {
+                // Apply failure mode
+                match plugin.manifest.failure_mode {
+                    FailureMode::FailOpen => {
+                        log::warn!(
+                            target: "plugin",
+                            "plugin `{}` failed (fail-open), skipping: {}",
+                            plugin.name, e
+                        );
+                        Ok(None)
+                    }
+                    FailureMode::FailClosed => {
+                        error::bail!(
+                            "plugin `{}` failed (fail-closed): {}",
+                            plugin.name,
+                            e
+                        );
+                    }
+                }
+            }
+        }
+    }
+}

--- a/lampo-plugin/src/tls.rs
+++ b/lampo-plugin/src/tls.rs
@@ -1,0 +1,142 @@
+//! TLS certificate generation and management for remote plugins.
+//!
+//! On first run, lampo generates a self-signed CA and uses it to
+//! issue client certificates. Remote plugins must present a server
+//! certificate signed by the same CA (or a user-provided CA).
+//!
+//! Tonic handles the actual TLS handshake; this module only manages
+//! PEM files on disk.
+#![cfg(feature = "grpc")]
+
+use std::fs;
+use std::path::PathBuf;
+
+use lampo_common::error;
+use rcgen::{CertificateParams, DistinguishedName, DnType, KeyPair};
+
+/// Directory layout for plugin certificates.
+///
+/// ```text
+/// <lampo_dir>/plugin-certs/
+///   ca.pem           — CA certificate
+///   ca-key.pem       — CA private key
+///   client.pem       — Client certificate (daemon identity)
+///   client-key.pem   — Client private key
+/// ```
+pub struct CertStore {
+    base_dir: PathBuf,
+}
+
+impl CertStore {
+    pub fn new(lampo_dir: &str) -> Self {
+        Self {
+            base_dir: PathBuf::from(lampo_dir).join("plugin-certs"),
+        }
+    }
+
+    /// Ensure the cert directory and CA exist. Generate if missing.
+    pub fn ensure_initialized(&self) -> error::Result<()> {
+        fs::create_dir_all(&self.base_dir)?;
+
+        if !self.ca_cert_path().exists() {
+            log::info!(target: "plugin::tls", "generating new CA for plugin mTLS");
+            self.generate_ca()?;
+        }
+
+        if !self.client_cert_path().exists() {
+            log::info!(target: "plugin::tls", "generating client certificate for daemon");
+            self.generate_client_cert()?;
+        }
+
+        Ok(())
+    }
+
+    pub fn ca_cert_path(&self) -> PathBuf {
+        self.base_dir.join("ca.pem")
+    }
+
+    pub fn ca_key_path(&self) -> PathBuf {
+        self.base_dir.join("ca-key.pem")
+    }
+
+    pub fn client_cert_path(&self) -> PathBuf {
+        self.base_dir.join("client.pem")
+    }
+
+    pub fn client_key_path(&self) -> PathBuf {
+        self.base_dir.join("client-key.pem")
+    }
+
+    /// Read CA certificate PEM.
+    pub fn ca_cert_pem(&self) -> error::Result<String> {
+        Ok(fs::read_to_string(self.ca_cert_path())?)
+    }
+
+    /// Read client certificate PEM.
+    pub fn client_cert_pem(&self) -> error::Result<String> {
+        Ok(fs::read_to_string(self.client_cert_path())?)
+    }
+
+    /// Read client key PEM.
+    pub fn client_key_pem(&self) -> error::Result<String> {
+        Ok(fs::read_to_string(self.client_key_path())?)
+    }
+
+    fn generate_ca(&self) -> error::Result<()> {
+        let mut params = CertificateParams::default();
+        let mut dn = DistinguishedName::new();
+        dn.push(DnType::CommonName, "lampo-plugin-ca");
+        dn.push(DnType::OrganizationName, "lampo");
+        params.distinguished_name = dn;
+        params.is_ca = rcgen::IsCa::Ca(rcgen::BasicConstraints::Unconstrained);
+
+        let key_pair = KeyPair::generate()?;
+        let cert = params.self_signed(&key_pair)?;
+
+        fs::write(self.ca_cert_path(), cert.pem())?;
+        fs::write(self.ca_key_path(), key_pair.serialize_pem())?;
+
+        // Restrict permissions on the CA key
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            fs::set_permissions(self.ca_key_path(), fs::Permissions::from_mode(0o600))?;
+        }
+
+        Ok(())
+    }
+
+    fn generate_client_cert(&self) -> error::Result<()> {
+        // Load CA
+        let ca_cert_pem = fs::read_to_string(self.ca_cert_path())?;
+        let ca_key_pem = fs::read_to_string(self.ca_key_path())?;
+
+        let ca_key = KeyPair::from_pem(&ca_key_pem)?;
+        let ca_params = CertificateParams::from_ca_cert_pem(&ca_cert_pem)?;
+        let ca_cert = ca_params.self_signed(&ca_key)?;
+
+        // Generate client cert
+        let mut params = CertificateParams::default();
+        let mut dn = DistinguishedName::new();
+        dn.push(DnType::CommonName, "lampo-daemon");
+        dn.push(DnType::OrganizationName, "lampo");
+        params.distinguished_name = dn;
+
+        let client_key = KeyPair::generate()?;
+        let client_cert = params.signed_by(&client_key, &ca_cert, &ca_key)?;
+
+        fs::write(self.client_cert_path(), client_cert.pem())?;
+        fs::write(self.client_key_path(), client_key.serialize_pem())?;
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            fs::set_permissions(
+                self.client_key_path(),
+                fs::Permissions::from_mode(0o600),
+            )?;
+        }
+
+        Ok(())
+    }
+}

--- a/lampo-plugin/src/transport/grpc.rs
+++ b/lampo-plugin/src/transport/grpc.rs
@@ -1,0 +1,213 @@
+//! gRPC transport for remote plugins.
+//!
+//! The daemon connects as a gRPC client to a remote plugin server.
+//! This mirrors the stdio transport semantics: daemon drives the lifecycle
+//! (getmanifest → init → rpc/hook/notify → shutdown).
+//!
+//! Optional mTLS: the daemon presents a client certificate and verifies
+//! the plugin's server certificate against a shared CA.
+#![cfg(feature = "grpc")]
+
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use lampo_common::error;
+use tonic::transport::{Certificate, Channel, ClientTlsConfig, Identity};
+
+use super::PluginTransport;
+
+/// Generated gRPC client stubs.
+pub mod proto {
+    tonic::include_proto!("lampo.plugin.v1");
+}
+
+use proto::lampo_plugin_client::LampoPluginClient;
+
+/// Configuration for connecting to a remote plugin.
+pub struct GrpcConfig {
+    /// The endpoint URL (e.g. "https://host:port").
+    pub endpoint: String,
+    /// Optional: CA certificate PEM for verifying the plugin server.
+    pub ca_cert_pem: Option<String>,
+    /// Optional: Client certificate PEM (daemon identity).
+    pub client_cert_pem: Option<String>,
+    /// Optional: Client private key PEM.
+    pub client_key_pem: Option<String>,
+}
+
+/// Transport that communicates with a remote plugin over gRPC.
+pub struct GrpcTransport {
+    client: tokio::sync::Mutex<LampoPluginClient<Channel>>,
+    alive: Arc<AtomicBool>,
+    endpoint: String,
+}
+
+impl GrpcTransport {
+    /// Connect to a remote plugin.
+    pub async fn connect(config: GrpcConfig) -> error::Result<Self> {
+        let mut endpoint = tonic::transport::Endpoint::from_shared(config.endpoint.clone())
+            .map_err(|e| error::anyhow!("invalid endpoint `{}`: {}", config.endpoint, e))?;
+
+        // Configure TLS if certificates are provided
+        if let Some(ref ca_pem) = config.ca_cert_pem {
+            let mut tls = ClientTlsConfig::new().ca_certificate(Certificate::from_pem(ca_pem));
+
+            if let (Some(ref cert_pem), Some(ref key_pem)) =
+                (&config.client_cert_pem, &config.client_key_pem)
+            {
+                tls = tls.identity(Identity::from_pem(cert_pem, key_pem));
+            }
+
+            endpoint = endpoint.tls_config(tls)?;
+        }
+
+        let channel = endpoint
+            .connect()
+            .await
+            .map_err(|e| error::anyhow!("failed to connect to `{}`: {}", config.endpoint, e))?;
+
+        let client = LampoPluginClient::new(channel);
+
+        Ok(Self {
+            client: tokio::sync::Mutex::new(client),
+            alive: Arc::new(AtomicBool::new(true)),
+            endpoint: config.endpoint,
+        })
+    }
+
+    /// Get the endpoint URL.
+    pub fn endpoint(&self) -> &str {
+        &self.endpoint
+    }
+}
+
+#[async_trait]
+impl PluginTransport for GrpcTransport {
+    async fn request(&self, msg: serde_json::Value) -> error::Result<serde_json::Value> {
+        let method = msg
+            .get("method")
+            .and_then(|m| m.as_str())
+            .unwrap_or("")
+            .to_string();
+        let params = msg.get("params").cloned().unwrap_or(serde_json::json!({}));
+        // Preserve the request id for the response envelope
+        let req_id = msg.get("id").cloned().unwrap_or(serde_json::json!(null));
+
+        let mut client = self.client.lock().await;
+
+        match method.as_str() {
+            "getmanifest" => {
+                let resp = client
+                    .get_manifest(proto::ManifestRequest {})
+                    .await
+                    .map_err(|e| error::anyhow!("getmanifest gRPC error: {}", e))?;
+                let manifest_json = resp.into_inner().manifest_json;
+                let manifest: serde_json::Value = serde_json::from_str(&manifest_json)
+                    .map_err(|e| error::anyhow!("invalid manifest JSON: {}", e))?;
+                Ok(serde_json::json!({
+                    "jsonrpc": "2.0",
+                    "id": req_id,
+                    "result": manifest
+                }))
+            }
+            "init" => {
+                let config_json = serde_json::to_string(&params)?;
+                let resp = client
+                    .init(proto::InitRequest { config_json })
+                    .await
+                    .map_err(|e| error::anyhow!("init gRPC error: {}", e))?;
+                let inner = resp.into_inner();
+                let result = if inner.disable_message.is_empty() {
+                    serde_json::json!({})
+                } else {
+                    serde_json::json!({"disable": inner.disable_message})
+                };
+                Ok(serde_json::json!({
+                    "jsonrpc": "2.0",
+                    "id": req_id,
+                    "result": result
+                }))
+            }
+            m if m.starts_with("hook/") => {
+                let resp = client
+                    .handle_hook(proto::HookRequest {
+                        hook_name: method.clone(),
+                        payload_json: serde_json::to_string(&params)?,
+                    })
+                    .await
+                    .map_err(|e| error::anyhow!("hook gRPC error: {}", e))?;
+                let response_json = resp.into_inner().response_json;
+                let result: serde_json::Value = serde_json::from_str(&response_json)
+                    .unwrap_or(serde_json::json!({"result": "continue"}));
+                Ok(serde_json::json!({
+                    "jsonrpc": "2.0",
+                    "id": req_id,
+                    "result": result
+                }))
+            }
+            _ => {
+                // Regular RPC method
+                let resp = client
+                    .handle_rpc(proto::RpcRequest {
+                        method: method.clone(),
+                        params_json: serde_json::to_string(&params)?,
+                    })
+                    .await
+                    .map_err(|e| error::anyhow!("rpc gRPC error: {}", e))?;
+                let inner = resp.into_inner();
+                if !inner.error_message.is_empty() {
+                    Ok(serde_json::json!({
+                        "jsonrpc": "2.0",
+                        "id": req_id,
+                        "error": {
+                            "code": inner.error_code,
+                            "message": inner.error_message
+                        }
+                    }))
+                } else {
+                    let result: serde_json::Value =
+                        serde_json::from_str(&inner.result_json).unwrap_or(serde_json::json!({}));
+                    Ok(serde_json::json!({
+                        "jsonrpc": "2.0",
+                        "id": req_id,
+                        "result": result
+                    }))
+                }
+            }
+        }
+    }
+
+    async fn notify(&self, msg: serde_json::Value) -> error::Result<()> {
+        let topic = msg
+            .get("method")
+            .and_then(|m| m.as_str())
+            .unwrap_or("")
+            .to_string();
+        let params = msg.get("params").cloned().unwrap_or(serde_json::json!({}));
+
+        let mut client = self.client.lock().await;
+        client
+            .notify(proto::NotifyRequest {
+                topic,
+                payload_json: serde_json::to_string(&params)?,
+            })
+            .await
+            .map_err(|e| {
+                log::warn!(target: "plugin::grpc", "notify error: {}", e);
+                error::anyhow!("notify gRPC error: {}", e)
+            })?;
+        Ok(())
+    }
+
+    async fn shutdown(&self) -> error::Result<()> {
+        let mut client = self.client.lock().await;
+        let _ = client.shutdown(proto::ShutdownRequest {}).await;
+        self.alive.store(false, Ordering::Release);
+        Ok(())
+    }
+
+    fn is_alive(&self) -> bool {
+        self.alive.load(Ordering::Acquire)
+    }
+}

--- a/lampo-plugin/src/transport/mod.rs
+++ b/lampo-plugin/src/transport/mod.rs
@@ -1,0 +1,31 @@
+//! Plugin transport implementations.
+//!
+//! The `PluginTransport` trait abstracts how the daemon communicates
+//! with a plugin. Implementations include:
+//! - `StdioTransport`: local subprocess via stdin/stdout
+//! - `GrpcTransport`: remote plugin via gRPC+mTLS (requires `grpc` feature)
+pub mod stdio;
+#[cfg(feature = "grpc")]
+pub mod grpc;
+
+use async_trait::async_trait;
+use lampo_common::error;
+
+/// Transport-agnostic plugin communication.
+///
+/// A plugin transport sends JSON-RPC requests/notifications
+/// to a plugin and receives responses.
+#[async_trait]
+pub trait PluginTransport: Send + Sync {
+    /// Send a JSON-RPC request and wait for the response.
+    async fn request(&self, msg: serde_json::Value) -> error::Result<serde_json::Value>;
+
+    /// Send a JSON-RPC notification (no response expected).
+    async fn notify(&self, msg: serde_json::Value) -> error::Result<()>;
+
+    /// Gracefully shut down the transport and the plugin process.
+    async fn shutdown(&self) -> error::Result<()>;
+
+    /// Check if the plugin is still alive.
+    fn is_alive(&self) -> bool;
+}

--- a/lampo-plugin/src/transport/stdio.rs
+++ b/lampo-plugin/src/transport/stdio.rs
@@ -1,0 +1,280 @@
+//! Stdio-based plugin transport.
+//!
+//! Spawns a plugin as a child process and communicates via
+//! newline-delimited JSON-RPC 2.0 over stdin/stdout.
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use lampo_common::error;
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::process::{Child, Command};
+use tokio::sync::{oneshot, Mutex, RwLock};
+
+use super::PluginTransport;
+
+/// Transport that communicates with a plugin subprocess via stdin/stdout.
+pub struct StdioTransport {
+    /// Stdin writer for the child process.
+    stdin: Mutex<tokio::process::ChildStdin>,
+    /// Pending requests waiting for responses, keyed by JSON-RPC id.
+    pending: Arc<RwLock<HashMap<u64, oneshot::Sender<serde_json::Value>>>>,
+    /// Next request id counter.
+    next_id: AtomicU64,
+    /// Whether the plugin process is still running.
+    alive: Arc<AtomicBool>,
+    /// Handle to the child process (for cleanup on drop).
+    child: Arc<Mutex<Child>>,
+}
+
+impl StdioTransport {
+    /// Spawn a plugin subprocess and set up the transport.
+    pub async fn new(plugin_path: &str) -> error::Result<Self> {
+        let mut child = Command::new(plugin_path)
+            .stdin(std::process::Stdio::piped())
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped())
+            .spawn()
+            .map_err(|e| error::anyhow!("failed to spawn plugin `{}`: {}", plugin_path, e))?;
+
+        let stdin = child
+            .stdin
+            .take()
+            .ok_or_else(|| error::anyhow!("failed to capture plugin stdin"))?;
+        let stdout = child
+            .stdout
+            .take()
+            .ok_or_else(|| error::anyhow!("failed to capture plugin stdout"))?;
+        let stderr = child
+            .stderr
+            .take()
+            .ok_or_else(|| error::anyhow!("failed to capture plugin stderr"))?;
+
+        let alive = Arc::new(AtomicBool::new(true));
+        let pending: Arc<RwLock<HashMap<u64, oneshot::Sender<serde_json::Value>>>> =
+            Arc::new(RwLock::new(HashMap::new()));
+
+        // Background task: read stdout and dispatch responses
+        let pending_clone = pending.clone();
+        let alive_clone = alive.clone();
+        let plugin_name = plugin_path.to_string();
+        tokio::spawn(async move {
+            let reader = BufReader::new(stdout);
+            let mut lines = reader.lines();
+            loop {
+                match lines.next_line().await {
+                    Ok(Some(line)) => {
+                        let line = line.trim().to_string();
+                        if line.is_empty() {
+                            continue;
+                        }
+                        match serde_json::from_str::<serde_json::Value>(&line) {
+                            Ok(msg) => {
+                                // Extract the id to find the pending request
+                                if let Some(id) = msg.get("id").and_then(|v| v.as_u64()) {
+                                    let mut pending = pending_clone.write().await;
+                                    if let Some(sender) = pending.remove(&id) {
+                                        let _ = sender.send(msg);
+                                    } else {
+                                        log::warn!(
+                                            target: "plugin",
+                                            "plugin `{}`: response for unknown id {}",
+                                            plugin_name, id
+                                        );
+                                    }
+                                } else {
+                                    // Could be a notification from the plugin
+                                    log::debug!(
+                                        target: "plugin",
+                                        "plugin `{}`: received message without id: {}",
+                                        plugin_name, line
+                                    );
+                                }
+                            }
+                            Err(e) => {
+                                log::warn!(
+                                    target: "plugin",
+                                    "plugin `{}`: invalid JSON from stdout: {} (line: {})",
+                                    plugin_name, e, line
+                                );
+                            }
+                        }
+                    }
+                    Ok(None) => {
+                        // EOF: plugin closed stdout
+                        log::info!(
+                            target: "plugin",
+                            "plugin `{}`: stdout closed",
+                            plugin_name
+                        );
+                        alive_clone.store(false, Ordering::SeqCst);
+                        break;
+                    }
+                    Err(e) => {
+                        log::error!(
+                            target: "plugin",
+                            "plugin `{}`: error reading stdout: {}",
+                            plugin_name, e
+                        );
+                        alive_clone.store(false, Ordering::SeqCst);
+                        break;
+                    }
+                }
+            }
+        });
+
+        // Background task: log stderr at debug level
+        let plugin_name = plugin_path.to_string();
+        tokio::spawn(async move {
+            let reader = BufReader::new(stderr);
+            let mut lines = reader.lines();
+            while let Ok(Some(line)) = lines.next_line().await {
+                log::debug!(target: "plugin", "plugin `{}` stderr: {}", plugin_name, line);
+            }
+        });
+
+        Ok(Self {
+            stdin: Mutex::new(stdin),
+            pending,
+            next_id: AtomicU64::new(1),
+            alive,
+            child: Arc::new(Mutex::new(child)),
+        })
+    }
+
+    /// Allocate a unique request id.
+    fn next_id(&self) -> u64 {
+        self.next_id.fetch_add(1, Ordering::SeqCst)
+    }
+}
+
+/// Ensure the child process is reaped if the transport is dropped
+/// without an explicit shutdown call.
+impl Drop for StdioTransport {
+    fn drop(&mut self) {
+        self.alive.store(false, Ordering::SeqCst);
+        let child = self.child.clone();
+        // Spawn a task to reap the child process so we don't block drop
+        tokio::spawn(async move {
+            let mut child = child.lock().await;
+            // Try to kill; ignore errors (child may have already exited)
+            let _ = child.kill().await;
+            let _ = child.wait().await;
+        });
+    }
+}
+
+#[async_trait]
+impl PluginTransport for StdioTransport {
+    async fn request(&self, mut msg: serde_json::Value) -> error::Result<serde_json::Value> {
+        if !self.is_alive() {
+            error::bail!("plugin is not alive");
+        }
+
+        let id = self.next_id();
+
+        // Inject the id into the message
+        if let Some(obj) = msg.as_object_mut() {
+            obj.insert("id".to_owned(), serde_json::Value::Number(id.into()));
+        }
+
+        // Register a pending receiver before sending
+        let (tx, rx) = oneshot::channel();
+        {
+            let mut pending = self.pending.write().await;
+            pending.insert(id, tx);
+        }
+
+        // Send the message
+        let line = serde_json::to_string(&msg)?;
+        {
+            let mut stdin = self.stdin.lock().await;
+            stdin
+                .write_all(line.as_bytes())
+                .await
+                .map_err(|e| error::anyhow!("failed to write to plugin stdin: {}", e))?;
+            stdin
+                .write_all(b"\n")
+                .await
+                .map_err(|e| error::anyhow!("failed to write newline to plugin stdin: {}", e))?;
+            stdin
+                .flush()
+                .await
+                .map_err(|e| error::anyhow!("failed to flush plugin stdin: {}", e))?;
+        }
+
+        // Wait for the response with a timeout
+        let response = tokio::time::timeout(std::time::Duration::from_secs(60), rx).await;
+
+        match response {
+            Ok(Ok(value)) => Ok(value),
+            Ok(Err(_)) => {
+                // Channel dropped — clean up pending entry
+                let mut pending = self.pending.write().await;
+                pending.remove(&id);
+                error::bail!("plugin response channel dropped")
+            }
+            Err(_timeout) => {
+                // Timeout — clean up the pending entry to avoid leak
+                let mut pending = self.pending.write().await;
+                pending.remove(&id);
+                error::bail!("plugin request timed out after 60s")
+            }
+        }
+    }
+
+    async fn notify(&self, msg: serde_json::Value) -> error::Result<()> {
+        if !self.is_alive() {
+            error::bail!("plugin is not alive");
+        }
+
+        let line = serde_json::to_string(&msg)?;
+        let mut stdin = self.stdin.lock().await;
+        stdin
+            .write_all(line.as_bytes())
+            .await
+            .map_err(|e| error::anyhow!("failed to write notification to plugin stdin: {}", e))?;
+        stdin
+            .write_all(b"\n")
+            .await
+            .map_err(|e| error::anyhow!("failed to write newline: {}", e))?;
+        stdin
+            .flush()
+            .await
+            .map_err(|e| error::anyhow!("failed to flush: {}", e))?;
+        Ok(())
+    }
+
+    async fn shutdown(&self) -> error::Result<()> {
+        // Send shutdown notification
+        let shutdown_msg = serde_json::json!({
+            "method": "shutdown",
+            "params": {},
+            "jsonrpc": "2.0"
+        });
+        // Best-effort: plugin may already be dead
+        let _ = self.notify(shutdown_msg).await;
+
+        // Give the plugin 5 seconds to exit gracefully
+        let mut child = self.child.lock().await;
+        let timeout = tokio::time::timeout(std::time::Duration::from_secs(5), child.wait()).await;
+
+        match timeout {
+            Ok(Ok(status)) => {
+                log::info!(target: "plugin", "plugin exited with status: {}", status);
+            }
+            _ => {
+                log::warn!(target: "plugin", "plugin did not exit gracefully, killing");
+                let _ = child.kill().await;
+            }
+        }
+
+        self.alive.store(false, Ordering::SeqCst);
+        Ok(())
+    }
+
+    fn is_alive(&self) -> bool {
+        self.alive.load(Ordering::SeqCst)
+    }
+}

--- a/lampo-plugin/tests/mock_plugin.sh
+++ b/lampo-plugin/tests/mock_plugin.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# Mock plugin for testing the lampo plugin system.
+# Reads JSON-RPC from stdin, writes responses to stdout.
+# This is a minimal example of a plugin in any language.
+
+while IFS= read -r line; do
+    # Parse method from JSON (simple extraction)
+    method=$(echo "$line" | sed -n 's/.*"method"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')
+    id=$(echo "$line" | sed -n 's/.*"id"[[:space:]]*:[[:space:]]*\([0-9]*\).*/\1/p')
+
+    case "$method" in
+        "getmanifest")
+            echo "{\"id\":$id,\"jsonrpc\":\"2.0\",\"result\":{\"rpc_methods\":[{\"name\":\"hello\",\"description\":\"Says hello\",\"usage\":\"[name]\"}],\"hooks\":[],\"subscriptions\":[],\"options\":[],\"dynamic\":true,\"failure_mode\":\"fail_open\"}}"
+            ;;
+        "init")
+            echo "{\"id\":$id,\"jsonrpc\":\"2.0\",\"result\":{}}"
+            ;;
+        "hello")
+            echo "{\"id\":$id,\"jsonrpc\":\"2.0\",\"result\":{\"message\":\"hello from plugin!\"}}"
+            ;;
+        "shutdown")
+            exit 0
+            ;;
+        *)
+            echo "{\"id\":$id,\"jsonrpc\":\"2.0\",\"error\":{\"code\":-32601,\"message\":\"method not found\"}}"
+            ;;
+    esac
+done

--- a/lampo-plugin/tests/mock_plugin_hooks.sh
+++ b/lampo-plugin/tests/mock_plugin_hooks.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+# Mock plugin that registers hooks and subscriptions for testing.
+# Registers: openchannel hook, channel_ready subscription, "greet" RPC method.
+# The openchannel hook rejects channels with funding < 50000 sats.
+
+while IFS= read -r line; do
+    method=$(echo "$line" | sed -n 's/.*"method"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')
+    id=$(echo "$line" | sed -n 's/.*"id"[[:space:]]*:[[:space:]]*\([0-9]*\).*/\1/p')
+
+    case "$method" in
+        "getmanifest")
+            echo "{\"id\":$id,\"jsonrpc\":\"2.0\",\"result\":{\"rpc_methods\":[{\"name\":\"greet\",\"description\":\"Greets\",\"usage\":\"\"}],\"hooks\":[{\"name\":\"openchannel\",\"before\":[],\"after\":[]}],\"subscriptions\":[\"channel_ready\"],\"options\":[],\"dynamic\":true,\"failure_mode\":\"fail_open\"}}"
+            ;;
+        "init")
+            echo "{\"id\":$id,\"jsonrpc\":\"2.0\",\"result\":{}}"
+            ;;
+        "greet")
+            echo "{\"id\":$id,\"jsonrpc\":\"2.0\",\"result\":{\"greeting\":\"hi there!\"}}"
+            ;;
+        "hook/openchannel")
+            # Reject channels under 50000 sats
+            funding=$(echo "$line" | sed -n 's/.*"funding_satoshis"[[:space:]]*:[[:space:]]*\([0-9]*\).*/\1/p')
+            if [ -n "$funding" ] && [ "$funding" -lt 50000 ] 2>/dev/null; then
+                echo "{\"id\":$id,\"jsonrpc\":\"2.0\",\"result\":{\"result\":\"reject\",\"message\":\"channel too small\"}}"
+            else
+                echo "{\"id\":$id,\"jsonrpc\":\"2.0\",\"result\":{\"result\":\"continue\"}}"
+            fi
+            ;;
+        "channel_ready")
+            # Notification — no response needed (no id)
+            ;;
+        "shutdown")
+            exit 0
+            ;;
+        *)
+            echo "{\"id\":$id,\"jsonrpc\":\"2.0\",\"error\":{\"code\":-32601,\"message\":\"method not found\"}}"
+            ;;
+    esac
+done

--- a/lampo-plugin/tests/plugin_tests.rs
+++ b/lampo-plugin/tests/plugin_tests.rs
@@ -1,0 +1,305 @@
+//! Integration tests for the lampo plugin system.
+use lampo_plugin::manager::PluginManager;
+use lampo_plugin::transport::stdio::StdioTransport;
+use lampo_plugin::transport::PluginTransport;
+use lampo_plugin_common::hooks::HookPoint;
+use lampo_plugin_common::messages::{HookResponse, InitConfig};
+
+fn mock_plugin_path() -> String {
+    let manifest_dir = env!("CARGO_MANIFEST_DIR");
+    format!("{}/tests/mock_plugin.sh", manifest_dir)
+}
+
+fn test_init_config() -> InitConfig {
+    InitConfig {
+        lampo_dir: "/tmp/lampo-test".to_string(),
+        network: "regtest".to_string(),
+        node_id: "02abc123".to_string(),
+        options: serde_json::Map::new(),
+    }
+}
+
+#[tokio::test]
+async fn test_stdio_transport_lifecycle() {
+    let path = mock_plugin_path();
+    let transport = StdioTransport::new(&path).await.unwrap();
+    assert!(transport.is_alive());
+
+    // Send getmanifest
+    let req = serde_json::json!({
+        "method": "getmanifest",
+        "params": {},
+        "jsonrpc": "2.0"
+    });
+    let resp = transport.request(req).await.unwrap();
+    assert!(resp.get("result").is_some());
+
+    let result = resp.get("result").unwrap();
+    let methods = result.get("rpc_methods").unwrap().as_array().unwrap();
+    assert_eq!(methods.len(), 1);
+    assert_eq!(methods[0].get("name").unwrap().as_str().unwrap(), "hello");
+
+    // Send init
+    let init_req = serde_json::json!({
+        "method": "init",
+        "params": {
+            "lampo_dir": "/tmp/test",
+            "network": "regtest",
+            "node_id": "",
+            "options": {}
+        },
+        "jsonrpc": "2.0"
+    });
+    let init_resp = transport.request(init_req).await.unwrap();
+    assert!(init_resp.get("result").is_some());
+
+    // Call the hello method
+    let hello_req = serde_json::json!({
+        "method": "hello",
+        "params": {},
+        "jsonrpc": "2.0"
+    });
+    let hello_resp = transport.request(hello_req).await.unwrap();
+    let result = hello_resp.get("result").unwrap();
+    assert_eq!(
+        result.get("message").unwrap().as_str().unwrap(),
+        "hello from plugin!"
+    );
+
+    // Shutdown
+    transport.shutdown().await.unwrap();
+    assert!(!transport.is_alive());
+}
+
+#[tokio::test]
+async fn test_plugin_manager_start_and_route() {
+    let path = mock_plugin_path();
+    let manager = PluginManager::new();
+    let config = test_init_config();
+
+    // Start the mock plugin
+    let name = manager.start_plugin(&path, &config).await.unwrap();
+    assert_eq!(name, "mock_plugin.sh");
+
+    // Verify plugin is listed
+    let plugins = manager.list_plugins().await;
+    assert_eq!(plugins.len(), 1);
+    assert!(plugins.contains(&"mock_plugin.sh".to_string()));
+
+    // Route an RPC call through ExternalHandler
+    use lampo_common::handler::ExternalHandler;
+    let req = lampo_common::jsonrpc::Request::new("hello", serde_json::json!({}));
+    let result = manager.handle(&req).await.unwrap();
+    assert!(result.is_some());
+    let result = result.unwrap();
+    assert_eq!(
+        result.get("message").unwrap().as_str().unwrap(),
+        "hello from plugin!"
+    );
+
+    // Unknown method should return None (not handled)
+    let unknown_req = lampo_common::jsonrpc::Request::new("unknown_method", serde_json::json!({}));
+    let result = manager.handle(&unknown_req).await.unwrap();
+    assert!(result.is_none());
+
+    // Shutdown
+    manager.shutdown_all().await;
+}
+
+#[tokio::test]
+async fn test_method_collision_rejected() {
+    let path = mock_plugin_path();
+    let manager = PluginManager::new();
+    let config = test_init_config();
+
+    // Start first plugin
+    manager.start_plugin(&path, &config).await.unwrap();
+
+    // Starting the same plugin again should fail (method collision)
+    let result = manager.start_plugin(&path, &config).await;
+    assert!(result.is_err());
+    let err = result.unwrap_err().to_string();
+    assert!(err.contains("already registered"));
+
+    manager.shutdown_all().await;
+}
+
+#[tokio::test]
+async fn test_plugin_stop() {
+    let path = mock_plugin_path();
+    let manager = PluginManager::new();
+    let config = test_init_config();
+
+    let name = manager.start_plugin(&path, &config).await.unwrap();
+    assert_eq!(manager.list_plugins().await.len(), 1);
+
+    manager.stop_plugin(&name).await.unwrap();
+    assert_eq!(manager.list_plugins().await.len(), 0);
+
+    // Method should no longer route
+    use lampo_common::handler::ExternalHandler;
+    let req = lampo_common::jsonrpc::Request::new("hello", serde_json::json!({}));
+    let result = manager.handle(&req).await.unwrap();
+    assert!(result.is_none());
+}
+
+fn mock_hooks_plugin_path() -> String {
+    let manifest_dir = env!("CARGO_MANIFEST_DIR");
+    format!("{}/tests/mock_plugin_hooks.sh", manifest_dir)
+}
+
+#[tokio::test]
+async fn test_hook_continue() {
+    let path = mock_hooks_plugin_path();
+    let manager = PluginManager::new();
+    let config = test_init_config();
+
+    manager.start_plugin(&path, &config).await.unwrap();
+
+    // Large channel should pass (continue)
+    let payload = serde_json::json!({
+        "funding_satoshis": 100000,
+        "counterparty_node_id": "02abc",
+        "temporary_channel_id": "deadbeef",
+    });
+    let result = manager.run_hook(&HookPoint::OpenChannel, payload).await.unwrap();
+    assert!(matches!(result, HookResponse::Continue { .. }));
+
+    manager.shutdown_all().await;
+}
+
+#[tokio::test]
+async fn test_hook_reject() {
+    let path = mock_hooks_plugin_path();
+    let manager = PluginManager::new();
+    let config = test_init_config();
+
+    manager.start_plugin(&path, &config).await.unwrap();
+
+    // Small channel should be rejected by the hook plugin
+    let payload = serde_json::json!({
+        "funding_satoshis": 1000,
+        "counterparty_node_id": "02abc",
+        "temporary_channel_id": "deadbeef",
+    });
+    let result = manager.run_hook(&HookPoint::OpenChannel, payload).await.unwrap();
+    match result {
+        HookResponse::Reject { message } => {
+            assert_eq!(message, "channel too small");
+        }
+        other => panic!("expected Reject, got {:?}", other),
+    }
+
+    manager.shutdown_all().await;
+}
+
+#[tokio::test]
+async fn test_hook_no_plugins_registered() {
+    let path = mock_plugin_path(); // basic plugin has no hooks
+    let manager = PluginManager::new();
+    let config = test_init_config();
+
+    manager.start_plugin(&path, &config).await.unwrap();
+
+    // No plugin registered for openchannel hook — should get Continue
+    let payload = serde_json::json!({"funding_satoshis": 1000});
+    let result = manager.run_hook(&HookPoint::OpenChannel, payload).await.unwrap();
+    assert!(matches!(result, HookResponse::Continue { payload: None }));
+
+    manager.shutdown_all().await;
+}
+
+#[tokio::test]
+async fn test_notification_does_not_crash() {
+    let path = mock_hooks_plugin_path();
+    let manager = PluginManager::new();
+    let config = test_init_config();
+
+    manager.start_plugin(&path, &config).await.unwrap();
+
+    // Send a notification the plugin is subscribed to
+    manager
+        .notify(
+            "channel_ready",
+            serde_json::json!({
+                "channel_id": "abc123",
+                "counterparty_node_id": "02def",
+            }),
+        )
+        .await;
+
+    // Send a notification the plugin is NOT subscribed to (should be a no-op)
+    manager
+        .notify(
+            "payment",
+            serde_json::json!({"state": "success"}),
+        )
+        .await;
+
+    // Plugin should still be alive and responsive after notifications
+    use lampo_common::handler::ExternalHandler;
+    let req = lampo_common::jsonrpc::Request::new("greet", serde_json::json!({}));
+    let result = manager.handle(&req).await.unwrap();
+    assert!(result.is_some());
+    assert_eq!(
+        result.unwrap().get("greeting").unwrap().as_str().unwrap(),
+        "hi there!"
+    );
+
+    manager.shutdown_all().await;
+}
+
+#[tokio::test]
+async fn test_two_plugins_different_methods() {
+    let path1 = mock_plugin_path(); // registers "hello"
+    let path2 = mock_hooks_plugin_path(); // registers "greet"
+    let manager = PluginManager::new();
+    let config = test_init_config();
+
+    manager.start_plugin(&path1, &config).await.unwrap();
+    manager.start_plugin(&path2, &config).await.unwrap();
+
+    assert_eq!(manager.list_plugins().await.len(), 2);
+
+    // Both methods should route correctly
+    use lampo_common::handler::ExternalHandler;
+    let hello_req = lampo_common::jsonrpc::Request::new("hello", serde_json::json!({}));
+    let result = manager.handle(&hello_req).await.unwrap().unwrap();
+    assert_eq!(result.get("message").unwrap().as_str().unwrap(), "hello from plugin!");
+
+    let greet_req = lampo_common::jsonrpc::Request::new("greet", serde_json::json!({}));
+    let result = manager.handle(&greet_req).await.unwrap().unwrap();
+    assert_eq!(result.get("greeting").unwrap().as_str().unwrap(), "hi there!");
+
+    manager.shutdown_all().await;
+}
+
+#[cfg(feature = "grpc")]
+#[test]
+fn test_tls_cert_generation() {
+    use lampo_plugin::tls::CertStore;
+
+    let dir = tempfile::tempdir().unwrap();
+    let store = CertStore::new(dir.path().to_str().unwrap());
+
+    // First call generates CA + client certs
+    store.ensure_initialized().unwrap();
+
+    assert!(store.ca_cert_path().exists());
+    assert!(store.ca_key_path().exists());
+    assert!(store.client_cert_path().exists());
+    assert!(store.client_key_path().exists());
+
+    // PEM strings should be readable
+    let ca_pem = store.ca_cert_pem().unwrap();
+    assert!(ca_pem.contains("BEGIN CERTIFICATE"));
+
+    let client_pem = store.client_cert_pem().unwrap();
+    assert!(client_pem.contains("BEGIN CERTIFICATE"));
+
+    let client_key = store.client_key_pem().unwrap();
+    assert!(client_key.contains("PRIVATE KEY"));
+
+    // Second call should be a no-op (idempotent)
+    store.ensure_initialized().unwrap();
+}

--- a/lampod-cli/Cargo.toml
+++ b/lampod-cli/Cargo.toml
@@ -10,6 +10,8 @@ lampo-common = { path = "../lampo-common" }
 lampo-chain = { path = "../lampo-chain" }
 lampo-bdk-wallet = { path = "../lampo-bdk-wallet" }
 lampo-httpd = { path = "../lampo-httpd" }
+lampo-plugin = { path = "../lampo-plugin", features = ["grpc"] }
+lampo-plugin-common = { path = "../lampo-plugin-common" }
 tokio = { version = "1.47.1", features = ["rt", "macros"] }
 clap = { version = "4.5", features = ["derive"] }
 filelock-rs = "0.1.0-beta.2"

--- a/lampod-cli/src/args.rs
+++ b/lampod-cli/src/args.rs
@@ -66,6 +66,18 @@ pub struct LampoCliArgs {
     #[arg(long = "api-port")]
     pub api_port: Option<u64>,
 
+    /// Load a plugin from the given path (can be repeated)
+    #[arg(long = "plugin")]
+    pub plugins: Vec<String>,
+
+    /// Load all plugins from this directory
+    #[arg(long = "plugin-dir")]
+    pub plugin_dir: Option<String>,
+
+    /// Connect to a remote plugin via gRPC (e.g. https://host:port, can be repeated)
+    #[arg(long = "remote-plugin")]
+    pub remote_plugins: Vec<String>,
+
     /// Subcommand to run
     #[command(subcommand)]
     pub subcommand: Option<LampoCliSubcommand>,
@@ -118,6 +130,16 @@ impl TryInto<LampoConf> for LampoCliArgs {
         }
         if let Some(api_port) = self.api_port {
             conf.api_port = api_port;
+        }
+        // Merge plugin paths from CLI args with those from config file
+        if !self.plugins.is_empty() {
+            conf.plugins.extend(self.plugins);
+        }
+        if self.plugin_dir.is_some() {
+            conf.plugin_dir = self.plugin_dir;
+        }
+        if !self.remote_plugins.is_empty() {
+            conf.remote_plugins.extend(self.remote_plugins);
         }
         Ok(conf)
     }

--- a/lampod-cli/src/main.rs
+++ b/lampod-cli/src/main.rs
@@ -19,6 +19,10 @@ use lampo_common::conf::LampoConf;
 use lampo_common::error;
 use lampo_common::logger;
 use lampo_httpd::handler::HttpdHandler;
+use lampo_plugin::PluginManager;
+use lampo_plugin::tls::CertStore;
+use lampo_plugin::transport::grpc::GrpcConfig;
+use lampo_plugin_common::messages::InitConfig;
 use lampod::chain::WalletManager;
 use lampod::LampoDaemon;
 
@@ -191,6 +195,14 @@ async fn run(args: LampoCliArgs) -> error::Result<()> {
 
     let lampod = Arc::new(lampod);
 
+    // Start plugins before httpd so plugin methods get priority
+    let plugin_manager = Arc::new(start_plugins(&lampo_conf).await?);
+    lampod
+        .add_external_handler(plugin_manager.clone())
+        .await?;
+    // Wire plugin manager into handler for hooks and notifications
+    lampod.set_plugin_manager(plugin_manager).await?;
+
     run_httpd(lampod.clone()).await?;
 
     let handler = Arc::new(HttpdHandler::new(format!(
@@ -210,6 +222,107 @@ async fn run(args: LampoCliArgs) -> error::Result<()> {
     log::info!(target: "lampod-cli", "------------ Starting Server ------------");
     lampod.listen().await??;
     Ok(())
+}
+
+/// Discover and start all plugins from config and CLI args.
+async fn start_plugins(conf: &LampoConf) -> error::Result<PluginManager> {
+    let manager = PluginManager::new();
+
+    let init_config = InitConfig {
+        lampo_dir: conf.path(),
+        network: conf.network.to_string(),
+        node_id: String::new(),
+        options: lampo_common::json::Map::new(),
+    };
+
+    // Collect plugin paths from explicit --plugin args and plugin-dir
+    let mut plugin_paths: Vec<String> = conf.plugins.clone();
+
+    // Scan plugin directory if configured
+    if let Some(ref dir) = conf.plugin_dir {
+        if let Ok(entries) = std::fs::read_dir(dir) {
+            for entry in entries.flatten() {
+                let path = entry.path();
+                if path.is_file() {
+                    // Check if the file is executable (Unix)
+                    #[cfg(unix)]
+                    {
+                        use std::os::unix::fs::PermissionsExt;
+                        if let Ok(metadata) = path.metadata() {
+                            if metadata.permissions().mode() & 0o111 != 0 {
+                                if let Some(p) = path.to_str() {
+                                    plugin_paths.push(p.to_string());
+                                }
+                            }
+                        }
+                    }
+                    #[cfg(not(unix))]
+                    {
+                        if let Some(p) = path.to_str() {
+                            plugin_paths.push(p.to_string());
+                        }
+                    }
+                }
+            }
+        } else {
+            log::warn!(target: "plugin", "plugin directory `{}` not found", dir);
+        }
+    }
+
+    // Start each plugin
+    for plugin_path in &plugin_paths {
+        match manager.start_plugin(plugin_path, &init_config).await {
+            Ok(name) => {
+                log::info!(target: "lampod-cli", "plugin `{}` started", name);
+            }
+            Err(e) => {
+                log::error!(target: "lampod-cli", "failed to start plugin `{}`: {}", plugin_path, e);
+            }
+        }
+    }
+
+    // Start remote plugins via gRPC
+    if !conf.remote_plugins.is_empty() {
+        // Initialize TLS certificates for mTLS
+        let cert_store = CertStore::new(&conf.path());
+        cert_store.ensure_initialized()?;
+
+        for endpoint in &conf.remote_plugins {
+            let grpc_config = GrpcConfig {
+                endpoint: endpoint.clone(),
+                ca_cert_pem: cert_store.ca_cert_pem().ok(),
+                client_cert_pem: cert_store.client_cert_pem().ok(),
+                client_key_pem: cert_store.client_key_pem().ok(),
+            };
+            match manager
+                .start_remote_plugin(grpc_config, &init_config)
+                .await
+            {
+                Ok(name) => {
+                    log::info!(target: "lampod-cli", "remote plugin `{}` started", name);
+                }
+                Err(e) => {
+                    log::error!(
+                        target: "lampod-cli",
+                        "failed to start remote plugin `{}`: {}",
+                        endpoint, e
+                    );
+                }
+            }
+        }
+    }
+
+    let total = manager.list_plugins().await.len();
+    if total > 0 {
+        log::info!(
+            target: "lampod-cli",
+            "started {} plugin(s): {:?}",
+            total,
+            manager.list_plugins().await
+        );
+    }
+
+    Ok(manager)
 }
 
 pub async fn run_httpd(lampod: Arc<LampoDaemon>) -> error::Result<()> {

--- a/lampod/Cargo.toml
+++ b/lampod/Cargo.toml
@@ -8,6 +8,8 @@ edition = "2021"
 [dependencies]
 tokio = { version = "^1.47.1", features = ["rt-multi-thread", "parking_lot"] }
 lampo-common = { path = "../lampo-common" }
+lampo-plugin = { path = "../lampo-plugin" }
+lampo-plugin-common = { path = "../lampo-plugin-common" }
 log = "0.4.17"
 time = "0.3.37"
 futures = "0.3.28"

--- a/lampod/src/actions/handler.rs
+++ b/lampod/src/actions/handler.rs
@@ -19,6 +19,10 @@ use lampo_common::jsonrpc::Request;
 use lampo_common::ldk;
 use lampo_common::model::response::PaymentHop;
 use lampo_common::model::response::PaymentState;
+use lampo_plugin::PluginManager;
+use lampo_plugin_common::hooks::HookPoint;
+use lampo_plugin_common::messages::HookResponse;
+use lampo_plugin_common::topics;
 
 use crate::chain::{LampoChainManager, WalletManager};
 use crate::command::Command;
@@ -37,6 +41,8 @@ pub struct LampoHandler {
     #[allow(dead_code)]
     emitter: Emitter<Event>,
     subscriber: Subscriber<Event>,
+    /// Plugin manager for hook invocation and notifications.
+    plugin_manager: RwLock<Option<Arc<PluginManager>>>,
 }
 
 unsafe impl Send for LampoHandler {}
@@ -55,6 +61,7 @@ impl LampoHandler {
             external_handlers: RwLock::new(Vec::new()),
             emitter,
             subscriber,
+            plugin_manager: RwLock::new(None),
         }
     }
 
@@ -65,6 +72,34 @@ impl LampoHandler {
         let mut external_handlers = self.external_handlers.write().await;
         external_handlers.push(handler);
         Ok(())
+    }
+
+    /// Set the plugin manager for hook invocation and notifications.
+    pub async fn set_plugin_manager(&self, manager: Arc<PluginManager>) {
+        let mut pm = self.plugin_manager.write().await;
+        *pm = Some(manager);
+    }
+
+    /// Send a notification to subscribed plugins (fire-and-forget).
+    async fn notify_plugins(&self, topic: &str, payload: json::Value) {
+        let pm = self.plugin_manager.read().await;
+        if let Some(ref manager) = *pm {
+            manager.notify(topic, payload).await;
+        }
+    }
+
+    /// Run a hook chain and return the response.
+    async fn run_hook(
+        &self,
+        hook: &HookPoint,
+        payload: json::Value,
+    ) -> error::Result<HookResponse> {
+        let pm = self.plugin_manager.read().await;
+        if let Some(ref manager) = *pm {
+            manager.run_hook(hook, payload).await
+        } else {
+            Ok(HookResponse::Continue { payload: None })
+        }
     }
 
     /// Call any method supported by the lampod configuration. This includes
@@ -128,7 +163,23 @@ impl Handler for LampoHandler {
                 is_announced: _,
                 params: _
             } => {
-                Err(error::anyhow!("Request for open a channel received, unfortunatly we do not support this feature yet."))
+                // Run the openchannel hook — plugins can accept/reject
+                let hook_payload = json::json!({
+                    "temporary_channel_id": temporary_channel_id.to_string(),
+                    "counterparty_node_id": counterparty_node_id.to_string(),
+                    "funding_satoshis": funding_satoshis,
+                    "channel_type": format!("{:?}", channel_type),
+                });
+                let hook_result = self.run_hook(&HookPoint::OpenChannel, hook_payload).await?;
+                match hook_result {
+                    HookResponse::Reject { message } => {
+                        log::info!(target: "plugin", "openchannel rejected by plugin: {}", message);
+                        Err(error::anyhow!("Channel open rejected by plugin: {}", message))
+                    }
+                    _ => {
+                        Err(error::anyhow!("Request for open a channel received, unfortunately we do not support this feature yet."))
+                    }
+                }
             }
             ldk::events::Event::ChannelReady {
                 channel_id,
@@ -137,6 +188,11 @@ impl Handler for LampoHandler {
                 channel_type,
             } => {
                 log::info!("channel ready with node `{counterparty_node_id}`, and channel type {channel_type}");
+                self.notify_plugins(topics::CHANNEL_READY, json::json!({
+                    "counterparty_node_id": counterparty_node_id.to_string(),
+                    "channel_id": channel_id.to_string(),
+                    "channel_type": format!("{:?}", channel_type),
+                })).await;
                 self.emit(Event::Lightning(LightningEvent::ChannelReady {
                     counterparty_node_id,
                     channel_id,
@@ -210,6 +266,12 @@ impl Handler for LampoHandler {
 
                 let node_id = counterparty_node_id.map(|id| id.to_string());
                 let txo = channel_funding_txo.map(|txo| txo.to_string());
+                self.notify_plugins(topics::CHANNEL_CLOSED, json::json!({
+                    "channel_id": channel_id.to_string(),
+                    "reason": detailed_reason.clone(),
+                    "counterparty_node_id": node_id,
+                    "funding_utxo": txo,
+                })).await;
                 self.emit(Event::Lightning(LightningEvent::CloseChannelEvent {
                     channel_id: channel_id.to_string(),
                     message: detailed_reason.clone(),
@@ -279,6 +341,10 @@ impl Handler for LampoHandler {
                     "channel pending with node `{}` with funding `{funding_txo}`",
                     counterparty_node_id.to_string()
                 );
+                self.notify_plugins(topics::CHANNEL_PENDING, json::json!({
+                    "counterparty_node_id": counterparty_node_id.to_string(),
+                    "funding_txo": funding_txo.to_string(),
+                })).await;
                 self.emit(Event::Lightning(LightningEvent::ChannelPending { counterparty_node_id, funding_transaction: funding_txo }));
                 Ok(())
             }
@@ -340,6 +406,10 @@ impl Handler for LampoHandler {
             },
             ldk::events::Event::PaymentPathSuccessful { payment_hash, path, .. } => {
                 let path = path.hops.iter().map(|hop| PaymentHop::from(hop.clone())).collect::<Vec<PaymentHop>>();
+                self.notify_plugins(topics::PAYMENT, json::json!({
+                    "state": "success",
+                    "payment_hash": payment_hash.map(|h| h.to_string()),
+                })).await;
                 let hop = LightningEvent::PaymentEvent { state: PaymentState::Success, payment_hash: payment_hash.map(|hash| hash.to_string()), path, reason: None };
                 self.emit(Event::Lightning(hop));
                 Ok(())
@@ -386,6 +456,11 @@ impl Handler for LampoHandler {
                     },
                 };
 
+                self.notify_plugins(topics::PAYMENT, json::json!({
+                    "state": "failure",
+                    "payment_hash": payment_hash.map(|h| h.to_string()),
+                    "reason": &detailed_reason,
+                })).await;
                 let hop = LightningEvent::PaymentEvent {
                     state: PaymentState::Failure,
                     payment_hash: payment_hash.map(|hash| hash.to_string()),

--- a/lampod/src/lib.rs
+++ b/lampod/src/lib.rs
@@ -29,6 +29,7 @@ use lampo_common::conf::LampoConf;
 use lampo_common::handler::ExternalHandler;
 use lampo_common::json;
 use lampo_common::ldk::events::{Event, ReplayEvent};
+use lampo_plugin::PluginManager;
 use lampo_common::ldk::io;
 use lampo_common::ldk::processor::{process_events_async, BackgroundProcessor, GossipSync};
 use lampo_common::types::LampoGraph;
@@ -224,6 +225,18 @@ impl LampoDaemon {
             error::bail!("Initial handler is None");
         };
         handler.add_external_handler(ext_handler).await?;
+        Ok(())
+    }
+
+    /// Set the plugin manager on the handler for hook invocation and notifications.
+    pub async fn set_plugin_manager(
+        &self,
+        manager: Arc<PluginManager>,
+    ) -> error::Result<()> {
+        let Some(ref handler) = self.handler else {
+            error::bail!("Initial handler is None");
+        };
+        handler.set_plugin_manager(manager).await;
         Ok(())
     }
 


### PR DESCRIPTION
## Summary

Implements the plugin framework (#17) that allows extending lampo with plugins written in **any language**.

- **Local plugins**: JSON-RPC 2.0 over stdin/stdout (subprocess). A Python/bash script that reads JSON lines from stdin and writes responses to stdout is a valid plugin.
- **Remote plugins**: gRPC + mTLS transport (feature-gated behind `grpc`). The daemon connects as a client to the remote plugin's gRPC server.
- **Hook system**: synchronous interception points (openchannel, peer_connected, htlc_accepted, rpc_command, invoice_creation) with chain execution and configurable failure modes (fail-open / fail-closed).
- **Notification system**: async fire-and-forget event forwarding (channel_ready, payment, channel_closed, etc.) to subscribed plugins.
- **Rust SDK**: builder-pattern API (`Plugin::new().rpc_method(...).hook(...).subscribe(...).start().await`) with generic I/O for testability.

### New crates
| Crate | Purpose |
|-------|---------|
| `lampo-plugin-common` | Shared protocol types (manifest, hooks, messages, topics) |
| `lampo-plugin` | Daemon-side plugin manager, stdio/gRPC transports, TLS cert generation |
| `lampo-plugin-sdk` | Rust SDK for writing plugins with builder pattern |

### Design decisions
- Name-based indexing (not positional) in PluginManager to avoid index invalidation races when plugins are added/removed
- Two-phase handshake (`getmanifest` → `init`) inspired by CLN
- `PluginManager` implements `ExternalHandler` and slots into the existing chain of responsibility
- `Drop` impl on `StdioTransport` ensures child processes are reaped
- Pending request cleanup on timeout to prevent memory leaks

## Test plan

- [x] 10 integration tests for `lampo-plugin` (stdio transport, manager routing, hook continue/reject, notifications, multi-plugin, TLS cert generation)
- [x] 2 integration tests for `lampo-plugin-sdk` (full lifecycle with mock I/O, RPC error handling)
- [x] 1 doc-test for SDK
- [x] Full workspace builds cleanly
- [ ] Manual testing with example plugins against running lampod

🤖 Generated with [Claude Code](https://claude.com/claude-code)