### PR TITLE
build(deps): upgrade rust-lightning from 0.1.x to 0.2.x

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -619,6 +619,7 @@ dependencies = [
  "iana-time-zone",
  "js-sys",
  "num-traits",
+ "serde",
  "wasm-bindgen",
  "windows-link 0.1.1",
 ]
@@ -1807,9 +1808,9 @@ dependencies = [
 
 [[package]]
 name = "lightning"
-version = "0.1.5"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e540fcb289a76826c9c0b078d3dd1f05691972c5a53fb4d3120540862040a147"
+checksum = "4c90397b635e3ece6b9a723fb470a46cb9b3592f217d72e40540a5fada00289d"
 dependencies = [
  "bech32",
  "bitcoin",
@@ -1817,28 +1818,31 @@ dependencies = [
  "hashbrown 0.13.2",
  "libm",
  "lightning-invoice",
+ "lightning-macros",
  "lightning-types",
  "possiblyrandom",
 ]
 
 [[package]]
 name = "lightning-background-processor"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04231b97fd7509d73ce9857a416eb1477a55d076d4e22cbf26c649a772bde909"
+checksum = "abdc5450264184deba88b1dc61fa8d2ca905e21748bad556915757ac73d91103"
 dependencies = [
  "bitcoin",
  "bitcoin-io",
  "bitcoin_hashes 0.14.0",
  "lightning",
+ "lightning-liquidity",
  "lightning-rapid-gossip-sync",
+ "possiblyrandom",
 ]
 
 [[package]]
 name = "lightning-block-sync"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baab5bdee174a2047d939a4ca0dc2e1c23caa0f8cab0b4380aed77a20e116f1e"
+checksum = "ee5069846b07a62aaecdaf25233e067bc69f245b7c8fd00cc9c217053221f875"
 dependencies = [
  "bitcoin",
  "chunked_transfer",
@@ -1848,20 +1852,48 @@ dependencies = [
 
 [[package]]
 name = "lightning-invoice"
-version = "0.33.2"
+version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11209f386879b97198b2bfc9e9c1e5d42870825c6bd4376f17f95357244d6600"
+checksum = "b85e5e14bcdb30d746e9785b04f27938292e8944f78f26517e01e91691f6b3f2"
 dependencies = [
  "bech32",
  "bitcoin",
  "lightning-types",
+ "serde",
+]
+
+[[package]]
+name = "lightning-liquidity"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58a6480d4d7726c49b4cd170b18a39563bbe897d0b8960be11d5e4a0cebd43b0"
+dependencies = [
+ "bitcoin",
+ "chrono",
+ "lightning",
+ "lightning-invoice",
+ "lightning-macros",
+ "lightning-types",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "lightning-macros"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4c717494cdc2c8bb85bee7113031248f5f6c64f8802b33c1c9e2d98e594aa71"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
 ]
 
 [[package]]
 name = "lightning-net-tokio"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb6a6c93b1e592f1d46bb24233cac4a33b4015c99488ee229927a81d16226e45"
+checksum = "8055737e3d2d06240a3fdf10e26b2716110fcea90011a0839e8e82fc6e58ff5e"
 dependencies = [
  "bitcoin",
  "lightning",
@@ -1870,9 +1902,9 @@ dependencies = [
 
 [[package]]
 name = "lightning-persister"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d80558dc398eb4609b1079044d8eb5760a58724627ff57c6d7c194c78906e026"
+checksum = "e6d78990de56ca75c5535c3f8e6f86b183a1aa8f521eb32afb9e8181f3bd91d7"
 dependencies = [
  "bitcoin",
  "lightning",
@@ -1881,9 +1913,9 @@ dependencies = [
 
 [[package]]
 name = "lightning-rapid-gossip-sync"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78dacdef3e2f5d727754f902f4e6bbc43bfc886fec8e71f36757711060916ebe"
+checksum = "b094f79f22713aa95194a166c77b2f6c7d68f9d76622a43552a29b8fe6fa92d0"
 dependencies = [
  "bitcoin",
  "bitcoin-io",
@@ -1893,9 +1925,9 @@ dependencies = [
 
 [[package]]
 name = "lightning-types"
-version = "0.2.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2cd84d4e71472035903e43caded8ecc123066ce466329ccd5ae537a8d5488c7"
+checksum = "cb1aac93f22f2c2eac8a0ee83bb1a1ea58673caa2c82847302710b83364d04e6"
 dependencies = [
  "bitcoin",
 ]

--- a/lampo-chain/Cargo.toml
+++ b/lampo-chain/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 [dependencies]
 lampo-common = { path = "../lampo-common" }
 lampod = { path = "../lampod" }
-lightning-block-sync = { version = "0.1", features = [ "rpc-client" ] }
+lightning-block-sync = { version = "0.2.0", features = [ "rpc-client" ] }
 log = "0.4.17"
 tokio ={ version = "*"}
 base64 = "*"

--- a/lampo-common/Cargo.toml
+++ b/lampo-common/Cargo.toml
@@ -6,12 +6,12 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-lightning = { version = "0.1.5", features = [] }
-lightning-block-sync = { version = "0.1.0" }
-lightning-persister = { version = "0.1.0" }
-lightning-background-processor = { version = "0.1", features = ["futures"] }
-lightning-net-tokio = { version = "0.1.0" }
-lightning-rapid-gossip-sync = { version = "0.1.0" }
+lightning = { version = "0.2.2", features = [] }
+lightning-block-sync = { version = "0.2.0" }
+lightning-persister = { version = "0.2.0" }
+lightning-background-processor = { version = "0.2.0" }
+lightning-net-tokio = { version = "0.2.0" }
+lightning-rapid-gossip-sync = { version = "0.2.0" }
 
 async-trait = "0.1"
 bitcoin = { version = "0.32", features = ["serde"] }

--- a/lampo-common/src/event/onchain.rs
+++ b/lampo-common/src/event/onchain.rs
@@ -22,14 +22,14 @@ impl Debug for OnChainEvent {
             Self::ConfirmedTransaction((tx, idx, header, height)) => write!(
                 f,
                 "ConfirmedTransaction(txid: {}, idx {idx}, block: {:?}, height: {height})",
-                tx.txid(),
+                tx.compute_txid(),
                 header
             ),
             Self::NewBestBlock((header, height)) => {
                 write!(f, "NewBestBlock({}, {height})", header.block_hash())
             }
             Self::NewBlock(block) => write!(f, "NewBlock({})", block.block_hash()),
-            Self::SendRawTransaction(tx) => write!(f, "SendRawTransaction({})", tx.txid()),
+            Self::SendRawTransaction(tx) => write!(f, "SendRawTransaction({})", tx.compute_txid()),
             Self::UnconfirmedTransaction(tx) => write!(f, "UnconfirmedTransaction({})", tx),
             _ => write!(f, "Debug fmt not unsupported"),
         }

--- a/lampo-common/src/keys.rs
+++ b/lampo-common/src/keys.rs
@@ -1,6 +1,6 @@
 use std::{sync::Arc, time::SystemTime};
 
-use bitcoin::secp256k1::{Secp256k1, SecretKey};
+use bitcoin::secp256k1::{All, SecretKey};
 use lightning::bolt11_invoice;
 use lightning::sign::{InMemorySigner, NodeSigner, OutputSpender, SignerProvider};
 
@@ -57,7 +57,7 @@ impl LampoKeys {
 }
 
 pub struct LampoKeysManager {
-    pub(crate) inner: KeysManager,
+    pub inner: KeysManager,
 
     funding_key: Option<SecretKey>,
     revocation_base_secret: Option<SecretKey>,
@@ -69,7 +69,7 @@ pub struct LampoKeysManager {
 
 impl LampoKeysManager {
     pub fn new(seed: &[u8; 32], starting_time_secs: u64, starting_time_nanos: u32) -> Self {
-        let inner = KeysManager::new(seed, starting_time_secs, starting_time_nanos);
+        let inner = KeysManager::new(seed, starting_time_secs, starting_time_nanos, false);
         Self {
             inner,
             funding_key: None,
@@ -81,7 +81,9 @@ impl LampoKeysManager {
         }
     }
 
-    // FIXME: put this under a debug a feature flag like `unsafe_channel_keys`
+    // FIXME: Custom channel keys are not currently supported with LDK 0.2 because
+    // InMemorySigner::new is private. The keys will be stored but silently ignored
+    // in derive_channel_signer. Put this under a feature flag like `unsafe_channel_keys`.
     pub fn set_channels_keys(
         &mut self,
         funding_key: String,
@@ -119,8 +121,16 @@ impl NodeSigner for LampoKeysManager {
         self.inner.ecdh(recipient, other_key, tweak)
     }
 
-    fn get_inbound_payment_key(&self) -> lightning::ln::inbound_payment::ExpandedKey {
-        self.inner.get_inbound_payment_key()
+    fn get_expanded_key(&self) -> lightning::ln::inbound_payment::ExpandedKey {
+        self.inner.get_expanded_key()
+    }
+
+    fn get_peer_storage_key(&self) -> lightning::sign::PeerStorageKey {
+        self.inner.get_peer_storage_key()
+    }
+
+    fn get_receive_auth_key(&self) -> lightning::sign::ReceiveAuthKey {
+        self.inner.get_receive_auth_key()
     }
 
     fn get_node_id(
@@ -151,17 +161,21 @@ impl NodeSigner for LampoKeysManager {
     ) -> Result<bitcoin::secp256k1::ecdsa::RecoverableSignature, ()> {
         self.inner.sign_invoice(invoice, recipient)
     }
+
+    fn sign_message(&self, msg: &[u8]) -> Result<String, ()> {
+        self.inner.sign_message(msg)
+    }
 }
 
 impl OutputSpender for LampoKeysManager {
-    fn spend_spendable_outputs<C: bitcoin::secp256k1::Signing>(
+    fn spend_spendable_outputs(
         &self,
         descriptors: &[&lightning::sign::SpendableOutputDescriptor],
         outputs: Vec<bitcoin::TxOut>,
         change_destination_script: bitcoin::ScriptBuf,
         feerate_sat_per_1000_weight: u32,
         locktime: Option<bitcoin::absolute::LockTime>,
-        secp_ctx: &bitcoin::secp256k1::Secp256k1<C>,
+        secp_ctx: &bitcoin::secp256k1::Secp256k1<All>,
     ) -> Result<bitcoin::Transaction, ()> {
         self.inner.spend_spendable_outputs(
             descriptors,
@@ -180,40 +194,22 @@ impl SignerProvider for LampoKeysManager {
 
     fn derive_channel_signer(
         &self,
-        channel_value_satoshis: u64,
         channel_keys_id: [u8; 32],
     ) -> Self::EcdsaSigner {
-        if self.funding_key.is_some() {
-            // FIXME(vincenzopalazzo): make this a general
-            let commitment_seed = [
-                255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
-                255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
-            ];
-            return InMemorySigner::new(
-                &Secp256k1::new(),
-                self.funding_key.unwrap(),
-                self.revocation_base_secret.unwrap(),
-                self.payment_base_secret.unwrap(),
-                self.delayed_payment_base_secret.unwrap(),
-                self.htlc_base_secret.unwrap(),
-                commitment_seed,
-                channel_value_satoshis,
-                channel_keys_id,
-                self.shachain_seed.unwrap(),
-            );
-        }
+        // FIXME: InMemorySigner::new is now private in LDK 0.2, so custom channel keys
+        // (set_channels_keys) are not currently supported. The derive_channel_keys path
+        // from the inner KeysManager is always used.
         self.inner
-            .derive_channel_signer(channel_value_satoshis, channel_keys_id)
+            .derive_channel_signer(channel_keys_id)
     }
 
     fn generate_channel_keys_id(
         &self,
         inbound: bool,
-        channel_value_satoshis: u64,
         user_channel_id: u128,
     ) -> [u8; 32] {
         self.inner
-            .generate_channel_keys_id(inbound, channel_value_satoshis, user_channel_id)
+            .generate_channel_keys_id(inbound, user_channel_id)
     }
 
     fn get_destination_script(&self, channel_keys_id: [u8; 32]) -> Result<bitcoin::ScriptBuf, ()> {
@@ -224,10 +220,4 @@ impl SignerProvider for LampoKeysManager {
         self.inner.get_shutdown_scriptpubkey()
     }
 
-    fn read_chan_signer(
-        &self,
-        reader: &[u8],
-    ) -> Result<Self::EcdsaSigner, lightning::ln::msgs::DecodeError> {
-        self.inner.read_chan_signer(reader)
-    }
 }

--- a/lampo-common/src/types.rs
+++ b/lampo-common/src/types.rs
@@ -27,6 +27,7 @@ pub type LampoChainMonitor = ChainMonitor<
     Arc<dyn FeeEstimator + Send + Sync>,
     Arc<LampoLogger>,
     Arc<FilesystemStore>,
+    Arc<LampoKeysManager>,
 >;
 
 pub type LampoArcChannelManager<M, L> = ChannelManager<
@@ -37,7 +38,7 @@ pub type LampoArcChannelManager<M, L> = ChannelManager<
     Arc<LampoKeysManager>,
     Arc<dyn FeeEstimator + Send + Sync>,
     Arc<LampoRouter>,
-    Arc<DefaultMessageRouter<Arc<LampoGraph>, Arc<LampoLogger>, Arc<LampoKeysManager>>>,
+    Arc<DefaultMessageRouter<Arc<LampoGraph>, Arc<L>, Arc<LampoKeysManager>>>,
     Arc<L>,
 >;
 

--- a/lampod/src/actions/handler.rs
+++ b/lampod/src/actions/handler.rs
@@ -117,10 +117,10 @@ impl Handler for LampoHandler {
         self.emit(Event::RawLDK(event.clone()));
         match event {
             ldk::events::Event::OpenChannelRequest {
-                temporary_channel_id,
-                counterparty_node_id,
-                funding_satoshis,
-                channel_type,
+                temporary_channel_id: _,
+                counterparty_node_id: _,
+                funding_satoshis: _,
+                channel_type: _,
                 channel_negotiation_type: _,
                 is_announced: _,
                 params: _
@@ -129,9 +129,10 @@ impl Handler for LampoHandler {
             }
             ldk::events::Event::ChannelReady {
                 channel_id,
-                user_channel_id,
+                user_channel_id: _,
                 counterparty_node_id,
                 channel_type,
+                funding_txo: _,
             } => {
                 log::info!("channel ready with node `{counterparty_node_id}`, and channel type {channel_type}");
                 self.emit(Event::Lightning(LightningEvent::ChannelReady {
@@ -155,10 +156,10 @@ impl Handler for LampoHandler {
 
                 // Provide detailed closure reason based on the ClosureReason enum
                 let detailed_reason = match reason {
-                    ldk::events::ClosureReason::CounterpartyForceClosed { peer_msg } => {
+                    ldk::events::ClosureReason::CounterpartyForceClosed { peer_msg, .. } => {
                         format!("Counterparty force-closed the channel. Peer message: {}", peer_msg)
                     },
-                    ldk::events::ClosureReason::HolderForceClosed { broadcasted_latest_txn } => {
+                    ldk::events::ClosureReason::HolderForceClosed { broadcasted_latest_txn, .. } => {
                         let broadcast_status = match broadcasted_latest_txn {
                             Some(true) => "with broadcasting latest transaction",
                             Some(false) => "without broadcasting latest transaction",
@@ -196,12 +197,15 @@ impl Handler for LampoHandler {
                     ldk::events::ClosureReason::FundingBatchClosure => {
                         "Channel closed because another channel in the same funding batch closed".to_string()
                     },
-                    ldk::events::ClosureReason::HTLCsTimedOut => {
+                    ldk::events::ClosureReason::HTLCsTimedOut { .. } => {
                         "Channel closed due to HTLC timeout".to_string()
                     },
                     ldk::events::ClosureReason::PeerFeerateTooLow { peer_feerate_sat_per_kw, required_feerate_sat_per_kw } => {
                         format!("Channel closed due to peer's feerate too low. Peer feerate: {} sat/kw, Required: {} sat/kw",
                                peer_feerate_sat_per_kw, required_feerate_sat_per_kw)
+                    },
+                    ldk::events::ClosureReason::LocallyCoopClosedUnfundedChannel => {
+                        "We cooperatively closed an unfunded channel".to_string()
                     },
                 };
 
@@ -279,23 +283,9 @@ impl Handler for LampoHandler {
                 self.emit(Event::Lightning(LightningEvent::ChannelPending { counterparty_node_id, funding_transaction: funding_txo }));
                 Ok(())
             }
-            ldk::events::Event::PendingHTLCsForwardable { time_forwardable } => {
-                self.channel_manager
-                    .manager()
-                    .process_pending_htlc_forwards();
-                Ok(())
-            }
             ldk::events::Event::PaymentClaimable {
-                receiver_node_id,
-                payment_hash,
-                onion_fields,
-                amount_msat,
-                counterparty_skimmed_fee_msat,
                 purpose,
-                via_channel_id,
-                via_user_channel_id,
-                claim_deadline,
-                payment_id: _,
+                ..
             } => {
                 let preimage = match purpose {
                     ldk::events::PaymentPurpose::Bolt11InvoicePayment  {
@@ -311,13 +301,10 @@ impl Handler for LampoHandler {
                 Ok(())
             }
             ldk::events::Event::PaymentClaimed {
-                receiver_node_id,
-                payment_hash,
-                amount_msat,
                 purpose,
                 ..
             } => {
-                let (payment_preimage, payment_secret) = match purpose {
+                let (_payment_preimage, _payment_secret) = match purpose {
                     ldk::events::PaymentPurpose::Bolt11InvoicePayment {
                         payment_preimage,
                         payment_secret,

--- a/lampod/src/command.rs
+++ b/lampod/src/command.rs
@@ -1,5 +1,4 @@
 //! All the Lampo Node Events that the node is able to react to
-use lampo_common::chan;
 use lampo_common::error;
 use lampo_common::json;
 use lampo_common::jsonrpc::Request;

--- a/lampod/src/jsonrpc/inventory.rs
+++ b/lampod/src/jsonrpc/inventory.rs
@@ -6,7 +6,7 @@ use lampo_common::model::request::NetworkInfo;
 use lampo_common::model::response::{NetworkChannel, NetworkChannels};
 use lampo_common::model::GetInfo;
 
-use crate::{async_run, LampoDaemon};
+use crate::LampoDaemon;
 
 // FIXME: change the name to `json_get_info`
 pub async fn json_getinfo(ctx: &LampoDaemon, request: &json::Value) -> Result<json::Value, Error> {

--- a/lampod/src/jsonrpc/offchain.rs
+++ b/lampod/src/jsonrpc/offchain.rs
@@ -37,7 +37,7 @@ pub async fn json_offer(ctx: &LampoDaemon, request: &json::Value) -> Result<json
     let request: GenerateOffer = json::from_value(request.clone())?;
     let manager = ctx.channel_manager().manager();
     let mut offer_builder = manager
-        .create_offer_builder(None)
+        .create_offer_builder()
         .map_err(|err| crate::rpc_error!("{:?}", err))?;
 
     if let Some(description) = request.description {

--- a/lampod/src/lib.rs
+++ b/lampod/src/lib.rs
@@ -30,7 +30,9 @@ use lampo_common::handler::ExternalHandler;
 use lampo_common::json;
 use lampo_common::ldk::events::{Event, ReplayEvent};
 use lampo_common::ldk::io;
-use lampo_common::ldk::processor::{process_events_async, GossipSync};
+use lampo_common::ldk::processor::{
+    process_events_async_with_kv_store_sync, BackgroundProcessor, GossipSync, NO_LIQUIDITY_MANAGER,
+};
 use lampo_common::types::LampoGraph;
 use lampo_common::utils;
 use lampo_common::wallet::WalletManager;
@@ -249,7 +251,7 @@ impl LampoDaemon {
         let _ = self.channel_manager().listen();
 
         tokio::spawn(async move {
-            process_events_async(
+            process_events_async_with_kv_store_sync(
                 self.persister.clone(),
                 |env| self.handler_ldk_events(env),
                 self.channel_manager().chain_monitor(),
@@ -257,6 +259,18 @@ impl LampoDaemon {
                 Some(self.peer_manager().onion_messager()),
                 GossipSync::p2p(gossip_sync),
                 self.peer_manager().manager(),
+                NO_LIQUIDITY_MANAGER,
+                // FIXME: implement output sweeper to automatically claim spendable outputs
+                // from force-closed channels
+                None::<Arc<ldk::util::sweep::OutputSweeperSync<
+                    Arc<dyn ldk::chain::chaininterface::BroadcasterInterface + Send + Sync>,
+                    Arc<dyn ldk::sign::ChangeDestinationSourceSync + Send + Sync>,
+                    Arc<dyn ldk::chain::chaininterface::FeeEstimator + Send + Sync>,
+                    Arc<dyn ldk::chain::Filter + Send + Sync>,
+                    Arc<LampoPersistence>,
+                    Arc<LampoLogger>,
+                    Arc<dyn ldk::sign::OutputSpender + Send + Sync>,
+                >>>,
                 self.logger.clone(),
                 Some(self.channel_manager().scorer()),
                 |d| {

--- a/lampod/src/ln/channel_manager.rs
+++ b/lampod/src/ln/channel_manager.rs
@@ -11,7 +11,6 @@ use lampo_common::error;
 use lampo_common::event::onchain::OnChainEvent;
 use lampo_common::event::Event;
 use lampo_common::handler::Handler;
-use lampo_common::json::de;
 use lampo_common::keys::LampoKeysManager;
 use lampo_common::ldk::block_sync::BlockSource;
 use lampo_common::ldk::chain::chaininterface::{BroadcasterInterface, FeeEstimator};
@@ -25,7 +24,7 @@ use lampo_common::ldk::routing::router::DefaultRouter;
 use lampo_common::ldk::routing::scoring::{
     ProbabilisticScorer, ProbabilisticScoringDecayParameters, ProbabilisticScoringFeeParameters,
 };
-use lampo_common::ldk::sign::InMemorySigner;
+use lampo_common::ldk::sign::{InMemorySigner, NodeSigner};
 use lampo_common::ldk::util::persist::read_channel_monitors;
 use lampo_common::ldk::util::ser::ReadableArgs;
 use lampo_common::model::request;
@@ -37,7 +36,6 @@ use lampo_common::types::LampoScorer;
 use lampo_common::types::{LampoArcChannelManager, LampoChainMonitor};
 
 use crate::actions::handler::LampoHandler;
-use crate::async_run;
 use crate::chain::{LampoChainManager, WalletManager};
 use crate::persistence::LampoPersistence;
 use crate::utils::logger::LampoLogger;
@@ -100,6 +98,8 @@ impl LampoChannelManager {
     }
 
     fn build_channel_monitor(&self) -> LampoChainMonitor {
+        let keys = self.wallet_manager.ldk_keys().keys_manager.clone();
+        let peer_storage_key = keys.inner.get_peer_storage_key();
         ChainMonitor::new(
             // FIXME: this is needed when use esplora or electrum
             None,
@@ -107,6 +107,8 @@ impl LampoChannelManager {
             self.logger.clone(),
             self.onchain.clone(),
             self.persister.clone(),
+            keys,
+            peer_storage_key,
         )
     }
 
@@ -245,7 +247,7 @@ impl LampoChannelManager {
                 0,
                 0,
                 None,
-                Some(self.conf.ldk_conf),
+                Some(self.conf.ldk_conf.clone()),
             )
             .map_err(|err| error::anyhow!("{:?}", err))?;
 
@@ -265,7 +267,7 @@ impl LampoChannelManager {
             }
         };
 
-        let txid = tx.as_ref().map(|tx| tx.txid());
+        let txid = tx.as_ref().map(|tx| tx.compute_txid());
 
         Ok(response::OpenChannel {
             node_id: open_channel.node_id,
@@ -320,7 +322,7 @@ impl LampoChannelManager {
             self.router.get().expect("router not initialized").clone(),
             default_message_router,
             self.logger.clone(),
-            self.conf.ldk_conf,
+            self.conf.ldk_conf.clone(),
             monitors,
         );
         let mut channel_manager_file = File::open(format!("{}/manager", self.conf.path()))?;
@@ -339,7 +341,7 @@ impl LampoChannelManager {
         let chain_params = ChainParameters {
             network: self.conf.network,
             best_block: BestBlock {
-                block_hash: block_hash,
+                block_hash,
                 // FIXME: the default could be dangerus here
                 height: block_height.unwrap_or_default(),
             },
@@ -370,7 +372,7 @@ impl LampoChannelManager {
             keymanagers.clone(),
             keymanagers.clone(),
             keymanagers,
-            self.conf.ldk_conf,
+            self.conf.ldk_conf.clone(),
             chain_params,
             now.as_secs() as u32,
         ));

--- a/lampod/src/ln/inventory_manager.rs
+++ b/lampod/src/ln/inventory_manager.rs
@@ -5,8 +5,6 @@ use lampo_common::error;
 use lampo_common::model::response::NetworkInfo;
 use lampo_common::model::GetInfo;
 
-use crate::async_run;
-
 use super::{LampoChannelManager, LampoPeerManager};
 
 pub struct LampoInventoryManager {

--- a/lampod/src/ln/offchain_manager.rs
+++ b/lampod/src/ln/offchain_manager.rs
@@ -21,12 +21,12 @@ use lampo_common::conf::LampoConf;
 use lampo_common::error;
 use lampo_common::keys::LampoKeysManager;
 use lampo_common::ldk;
-use lampo_common::ldk::ln::channelmanager::Retry;
-use lampo_common::ldk::ln::channelmanager::{PaymentId, RecipientOnionFields};
-use lampo_common::ldk::ln::invoice_utils::create_invoice_from_channelmanager;
+use lampo_common::ldk::ln::channelmanager::{
+    Bolt11InvoiceParameters, PaymentId, RecipientOnionFields, Retry,
+};
 use lampo_common::ldk::offers::offer::Amount;
 use lampo_common::ldk::offers::offer::Offer;
-use lampo_common::ldk::routing::router::{PaymentParameters, RouteParameters};
+use lampo_common::ldk::routing::router::{PaymentParameters, RouteParameters, RouteParametersConfig};
 use lampo_common::ldk::sign::EntropySource;
 use lampo_common::ldk::types::payment::{PaymentHash, PaymentPreimage};
 
@@ -68,14 +68,17 @@ impl OffchainManager {
         description: &str,
         expiring_in: u32,
     ) -> error::Result<ldk::invoice::Bolt11Invoice> {
-        let invoice = ldk::ln::invoice_utils::create_invoice_from_channelmanager(
-            &self.channel_manager.manager(),
-            amount_msat,
-            description.to_string(),
-            expiring_in,
-            None,
-        )
-        .map_err(|err| error::anyhow!(err))?;
+        let desc = ldk::invoice::Description::new(description.to_string())
+            .map_err(|err| error::anyhow!("{:?}", err))?;
+        let params = Bolt11InvoiceParameters {
+            amount_msats: amount_msat,
+            description: ldk::invoice::Bolt11InvoiceDescription::Direct(desc),
+            invoice_expiry_delta_secs: Some(expiring_in),
+            ..Default::default()
+        };
+        let invoice = self.channel_manager.manager()
+            .create_bolt11_invoice(params)
+            .map_err(|err| error::anyhow!("{:?}", err))?;
         Ok(invoice)
     }
 
@@ -106,49 +109,46 @@ impl OffchainManager {
         let offer = Offer::from_str(offer_str).map_err(|err| error::anyhow!("{:?}", err))?;
 
         let amount = match offer.amount() {
-            Some(Amount::Bitcoin { amount_msats }) => amount_msats.clone(),
+            Some(Amount::Bitcoin { amount_msats }) => {
+                // Offer already specifies amount; pass None to let LDK use it,
+                // but allow the caller to override with a different amount.
+                amount_msat.or(Some(amount_msats.clone()))
+            },
             Some(_) => error::bail!(
                 "Cannot process non-Bitcoin-denominated offer value {:?}",
                 offer.amount()
             ),
-            None => amount_msat.ok_or(error::anyhow!("An amount need to be specified"))?,
+            None => Some(amount_msat.ok_or(error::anyhow!("An amount need to be specified"))?),
         };
 
-        log::debug!(target: "lampo::offchain", "paying offer with amount `{}msat` & payer_note: `{}`", amount, payer_note.as_ref().unwrap_or(&"".to_string()));
+        log::debug!(target: "lampo::offchain", "paying offer with amount `{:?}msat` & payer_note: `{}`", amount, payer_note.as_ref().unwrap_or(&"".to_string()));
         self.channel_manager
             .manager()
             .pay_for_offer(
                 &offer,
-                None,
-                Some(amount),
-                payer_note,
+                amount,
                 payment_id,
-                Retry::Timeout(std::time::Duration::from_secs(1)),
-                None,
+                ldk::ln::channelmanager::OptionalOfferPaymentParams {
+                    payer_note,
+                    ..Default::default()
+                },
             )
             .map_err(|err| error::anyhow!("{:?}", err))?;
         Ok(())
     }
 
     pub fn pay_invoice(&self, invoice_str: &str, amount_msat: Option<u64>) -> error::Result<()> {
-        // check if it is an invoice or an offer
         let invoice = self.decode_invoice(invoice_str)?;
         let payment_id = PaymentId((*invoice.payment_hash()).to_byte_array());
-        let (payment_hash, onion, route) = if invoice.amount_milli_satoshis().is_none() {
-            ldk::ln::bolt11_payment::payment_parameters_from_variable_amount_invoice(
-                &invoice,
-                amount_msat.ok_or(error::anyhow!(
-                    "invoice with no amount, and amount must be specified"
-                ))?,
-            )
-            .map_err(|err| error::anyhow!("{:?}", err))?
-        } else {
-            ldk::ln::bolt11_payment::payment_parameters_from_invoice(&invoice)
-                .map_err(|err| error::anyhow!("{:?}", err))?
-        };
         self.channel_manager
             .manager()
-            .send_payment(payment_hash, onion, payment_id, route, Retry::Attempts(10))
+            .pay_for_bolt11_invoice(
+                &invoice,
+                payment_id,
+                amount_msat,
+                RouteParametersConfig::default(),
+                Retry::Attempts(10),
+            )
             .map_err(|err| error::anyhow!("{:?}", err))?;
         Ok(())
     }

--- a/lampod/src/ln/peer_manager.rs
+++ b/lampod/src/ln/peer_manager.rs
@@ -4,8 +4,6 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, SystemTime};
 
-use async_trait::async_trait;
-
 use lampo_common::conf::LampoConf;
 use lampo_common::error;
 use lampo_common::keys::LampoKeysManager;
@@ -20,7 +18,6 @@ use lampo_common::ldk::routing::gossip::{NetworkGraph, P2PGossipSync};
 use lampo_common::types::NodeId;
 use lampo_common::types::{LampoArcChannelManager, LampoChainMonitor, LampoGraph};
 
-use crate::async_run;
 use crate::chain::{LampoChainManager, WalletManager};
 use crate::ln::LampoChannelManager;
 use crate::utils::logger::LampoLogger;
@@ -45,6 +42,7 @@ pub type SimpleArcPeerManager<M, T, L> = PeerManager<
     Arc<L>,
     IgnoringMessageHandler,
     Arc<LampoKeysManager>,
+    IgnoringMessageHandler,
 >;
 
 type InnerLampoPeerManager =
@@ -114,6 +112,7 @@ impl LampoPeerManager {
             onion_message_handler: onion_messenger.clone(),
             route_handler: gossip_sync,
             custom_message_handler: IgnoringMessageHandler {},
+            send_only_message_handler: IgnoringMessageHandler {},
         };
 
         let peer_manager = InnerLampoPeerManager::new(


### PR DESCRIPTION
## Summary
- Upgrade all LDK/rust-lightning dependencies from 0.1.x to 0.2.x (lightning 0.2.2, companion crates 0.2.0)
- Adapt codebase to all breaking API changes including new ChainMonitor params, NodeSigner/SignerProvider trait changes, removed `create_invoice_from_channelmanager` / `bolt11_payment` module, new `process_events_async_with_kv_store_sync`, and updated event variants
- Clean up unused imports and fix deprecated `txid()` → `compute_txid()` calls

## Notable breaking changes handled
- `InMemorySigner::new` is now private — custom channel keys (`set_channels_keys`) are stored but not applied (documented with FIXME)
- `PendingHTLCsForwardable` event removed (LDK now auto-forwards)
- No output sweeper configured yet (FIXME added) — force-closed channel outputs need manual claiming
- `UserConfig` no longer implements `Copy` — switched to `.clone()`

## Test plan
- [x] `cargo check` passes with zero errors
- [x] `cargo test --no-run` compiles all test targets successfully
- [ ] Run integration tests against regtest to verify channel open/close, invoice generation, bolt11/bolt12 payments, and keysend

🤖 Generated with [Claude Code](https://claude.com/claude-code)