### PR TITLE
BLIP-0056: Point-of-Sale payment notifications

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1748,7 +1748,7 @@ dependencies = [
  "clightningrpc-conf",
  "colored",
  "hex",
- "lightning 0.1.5",
+ "lightning",
  "lightning-background-processor",
  "lightning-block-sync",
  "lightning-net-tokio",
@@ -1799,6 +1799,7 @@ version = "0.0.1"
 dependencies = [
  "async-trait",
  "futures",
+ "hex",
  "lampo-common",
  "log",
  "once_cell",
@@ -1893,25 +1894,8 @@ dependencies = [
  "dnssec-prover",
  "hashbrown 0.13.2",
  "libm",
- "lightning-invoice 0.33.2",
- "lightning-types 0.2.0",
- "possiblyrandom",
-]
-
-[[package]]
-name = "lightning"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c90397b635e3ece6b9a723fb470a46cb9b3592f217d72e40540a5fada00289d"
-dependencies = [
- "bech32",
- "bitcoin",
- "dnssec-prover",
- "hashbrown 0.13.2",
- "libm",
- "lightning-invoice 0.34.0",
- "lightning-macros",
- "lightning-types 0.3.1",
+ "lightning-invoice",
+ "lightning-types",
  "possiblyrandom",
 ]
 
@@ -1924,7 +1908,7 @@ dependencies = [
  "bitcoin",
  "bitcoin-io",
  "bitcoin_hashes 0.14.0",
- "lightning 0.1.5",
+ "lightning",
  "lightning-rapid-gossip-sync",
 ]
 
@@ -1936,7 +1920,7 @@ checksum = "baab5bdee174a2047d939a4ca0dc2e1c23caa0f8cab0b4380aed77a20e116f1e"
 dependencies = [
  "bitcoin",
  "chunked_transfer",
- "lightning 0.1.5",
+ "lightning",
  "serde_json",
 ]
 
@@ -1948,29 +1932,7 @@ checksum = "11209f386879b97198b2bfc9e9c1e5d42870825c6bd4376f17f95357244d6600"
 dependencies = [
  "bech32",
  "bitcoin",
- "lightning-types 0.2.0",
-]
-
-[[package]]
-name = "lightning-invoice"
-version = "0.34.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b85e5e14bcdb30d746e9785b04f27938292e8944f78f26517e01e91691f6b3f2"
-dependencies = [
- "bech32",
- "bitcoin",
- "lightning-types 0.3.1",
-]
-
-[[package]]
-name = "lightning-macros"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4c717494cdc2c8bb85bee7113031248f5f6c64f8802b33c1c9e2d98e594aa71"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.100",
+ "lightning-types",
 ]
 
 [[package]]
@@ -1980,18 +1942,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb6a6c93b1e592f1d46bb24233cac4a33b4015c99488ee229927a81d16226e45"
 dependencies = [
  "bitcoin",
- "lightning 0.1.5",
+ "lightning",
  "tokio",
 ]
 
 [[package]]
 name = "lightning-persister"
-version = "0.2.0"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6d78990de56ca75c5535c3f8e6f86b183a1aa8f521eb32afb9e8181f3bd91d7"
+checksum = "d80558dc398eb4609b1079044d8eb5760a58724627ff57c6d7c194c78906e026"
 dependencies = [
  "bitcoin",
- "lightning 0.2.2",
+ "lightning",
  "windows-sys 0.48.0",
 ]
 
@@ -2004,7 +1966,7 @@ dependencies = [
  "bitcoin",
  "bitcoin-io",
  "bitcoin_hashes 0.14.0",
- "lightning 0.1.5",
+ "lightning",
 ]
 
 [[package]]
@@ -2012,15 +1974,6 @@ name = "lightning-types"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2cd84d4e71472035903e43caded8ecc123066ce466329ccd5ae537a8d5488c7"
-dependencies = [
- "bitcoin",
-]
-
-[[package]]
-name = "lightning-types"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb1aac93f22f2c2eac8a0ee83bb1a1ea58673caa2c82847302710b83364d04e6"
 dependencies = [
  "bitcoin",
 ]

--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,53 @@
+# BLIP-0056 — PoS payment notifications: status & deferred LDK work
+
+Spec: https://github.com/vincenzopalazzo/blips/blob/blip-0056-bolt12-pos-notifications/blip-0056.md
+
+## Implemented
+
+- `payment_notification` / `notification_ack` / `notification_nack` custom onion
+  messages (`lampod/src/ln/pos.rs`), with `OnionMessenger` wiring replacing the
+  default `IgnoringMessageHandler`.
+- `PosOnionHandler`: verifies `sha256(preimage) == payment_hash`, replies
+  `ack`/`nack`, and emits `LightningEvent::PosPaymentNotified` /
+  `PosNotificationAck`.
+- `sendpaymentnotification` JSON-RPC (merchant send primitive).
+- End-to-end lampo-to-lampo integration test
+  (`tests/tests/src/lampo_tests.rs::pos_payment_notification_roundtrip`).
+
+## Pending implementation (tracked, not yet wired)
+
+- PoS-built notification `BlindedMessagePath` carrying the order context
+  (`MessageContext::Custom`), order store, and amount verification against the
+  decrypted context.
+- Merchant auto-send from the `PaymentClaimed` event, correlated by `offer_id`
+  (`Bolt12OfferContext`), plus per-order offer construction.
+- "v1 bridge" RPC: PoS registers `{offer_id -> notification_path}` with the
+  merchant over their peer link (stands in for TODO-1/TODO-2 below).
+- Lite `pos_mode` boot (no chain backend / no channels / no gossip).
+
+## Deferred — blocked on LDK (lightning 0.1.8)
+
+### TODO-1: `notification_path` as an experimental offer TLV (range 1e9..2e9)
+
+LDK exposes no PUBLIC builder/reader for experimental offer TLVs — only the
+test-only `pub(super) fn experimental_foo` (`offers/offer.rs`). The experimental
+range IS round-tripped on parse, so the gap is API-only. This is identical in
+lightning 0.1.8 and 0.2.2, so bumping does not unlock it.
+
+- Needs: an upstream LDK change exposing a public experimental-TLV setter +
+  reader on `OfferBuilder` / `Offer` / `InvoiceRequest`.
+- v1 plan: the PoS registers its notification path directly with the merchant,
+  keyed by `offer_id`, instead of embedding it in an offer TLV.
+- Spec ref: §Per-Order Offer Construction.
+
+### TODO-2: embed `notification_path` in the invoice payment-path `path_id`
+
+`ChannelManager`'s automatic offer -> `invoice_request` -> invoice responder
+owns the `path_id`; there is no public hook to inject custom path context for
+offer-inbound payments.
+
+- Needs: an upstream LDK hook for custom path context in the offers responder,
+  OR a manual reimplementation of the offer-inbound flow in lampo.
+- v1 plan: correlate the notification via `offer_id` + the PoS-built
+  notification path's `MessageContext`, not `path_id` round-tripping.
+- Spec ref: §Seven-Step Payment Flow, steps 3 & 5.

--- a/docs/brainstorms/2026-05-30-blip-0056-pos-notifications.md
+++ b/docs/brainstorms/2026-05-30-blip-0056-pos-notifications.md
@@ -1,0 +1,218 @@
+# BLIP-0056 — BOLT12 Point-of-Sale Payment Notifications
+
+**Date:** 2026-05-30
+**Status:** Plan (pre-implementation)
+**Spec:** [blip-0056.md](https://github.com/vincenzopalazzo/blips/blob/blip-0056-bolt12-pos-notifications/blip-0056.md) (authored by the repo owner)
+**Target LDK:** stock `lightning 0.1.8` (pinned `0.1.5` in `lampo-common/Cargo.toml`) — **no fork**
+
+---
+
+## Goal
+
+Implement the BLIP-0056 **Point-of-Sale (PoS)** role plus the **merchant-side
+notification sender** in lampo, running the PoS in a new **lite daemon mode**
+that boots onion messaging *without* channels, chain sync, or gossip. Validate
+end-to-end with a lampo-to-lampo integration test.
+
+Target full spec fidelity for the **message types and 7-step flow**; the two
+wire-format pieces that stock LDK cannot express yet are **deferred to a tracked
+`TODO.md`** rather than forked or hacked around.
+
+---
+
+## Decisions (resolved during brainstorm)
+
+| Fork | Decision | Why |
+|------|----------|-----|
+| "Without a full node" | **Lite mode inside `lampod`** | Reuses lampo's already-working `OnionMessenger`/`DefaultMessageRouter`/offers wiring; fastest to a working PoS. |
+| Scope | **PoS receiver + merchant sender** | The PoS can't be exercised without a node that emits `payment_notification`; both are needed for an in-repo E2E test. |
+| Validation | **lampo-to-lampo integration test** | Reuses the existing `tests/tests` harness; strongest in-repo proof. |
+| Approach | **A — full spec fidelity** | Owner's call: implement the real flow/message types, not a shortcut. |
+| LDK strategy | **Stock LDK; document gaps in `TODO.md`** | No fork, no byte-splice. Build what LDK supports; record the rest as upstream TODOs. |
+
+---
+
+## Key findings that shape the plan
+
+1. **Onion messaging is already wired** — `OnionMessenger::new(...)` at
+   `lampod/src/ln/peer_manager.rs:94`, with `DefaultMessageRouter` and BOLT12
+   offers (`create_offer_builder`, `pay_for_offer`).
+2. **Custom onion messages are dropped today** — the handler is hard-wired to
+   `IgnoringMessageHandler` at `lampod/src/ln/peer_manager.rs:102-103`. The
+   BLIP-0056 `payment_notification` is a *custom* onion message, so lampo
+   currently cannot receive it. This is the central change.
+3. **No public LDK API for custom offer TLVs** — in `0.1.8` *and* `0.2.2`. The
+   experimental offer TLV range `1_000_000_000..2_000_000_000` is reserved and
+   round-tripped on parse, but the only builder method is the test-only
+   `pub(super) fn experimental_foo` (`offers/offer.rs:487`). Bumping to 0.2 does
+   **not** help → **TODO-1**.
+4. **No public hook to set the invoice payment-path `path_id`** for
+   offer-inbound payments — `ChannelManager`'s automatic offer responder owns
+   it → **TODO-2**.
+5. **Daemon boots as one unit** — `LampoDaemon::init` (`lampod/src/lib.rs:203-261`)
+   wires chain backend → channel manager → peer manager → gossip together. A
+   reduced boot path is new.
+
+---
+
+## Architecture (v1)
+
+**Actors (lite mode):**
+- **PoS** — lampo in lite mode: `LampoKeysManager` + `OnionMessenger` +
+  `PeerManager` (with `ErroringMessageHandler` as the channel handler, i.e. no
+  `ChannelManager`), no chain backend, no gossip. Connects to the merchant as
+  its onion-message **introduction peer**.
+- **Merchant** — a normal full lampo node with channels/liquidity.
+- **Customer** — any node that can pay a BOLT12 offer (a second full lampo node
+  in the test).
+
+**v1 flow** (faithful to the spec's message types; the offer-TLV/`path_id`
+mechanisms of spec steps 3 & 5 are bridged — see TODO-1/2):
+
+```
+1. PoS builds a per-order BOLT12 offer via the merchant
+   (offer points to the merchant for invoice_request; offer_id known to PoS).
+2. PoS builds a notification BlindedMessagePath back to itself, embedding the
+   order context (order_id + expected amount_msat) as MessageContext::Custom.
+3. [v1 BRIDGE] PoS registers {offer_id -> notification_path} with the merchant
+   over their peer link via a new RPC. (Spec: this travels in an offer TLV +
+   invoice path_id; deferred to TODO-1/2.)
+4. Customer pays the offer -> merchant receives PaymentClaimed with
+   PaymentPurpose::Bolt12OfferPayment { payment_context.offer_id, preimage, .. }.
+5. Merchant looks up the notification_path by offer_id and sends a
+   `payment_notification` { payment_hash, preimage, amount_msat } custom onion
+   message on it, with a reply path.
+6. PoS receives the message; LDK hands back the decrypted MessageContext
+   (order_id + expected amount). PoS verifies amount_msat == expected and
+   sha256(preimage) == payment_hash, then replies `notification_ack`
+   (or `notification_nack`) on the reply path, and emits a "paid" event.
+```
+
+The **v1 bridge** (step 3) uses only data stock LDK exposes (`offer_id` is
+present at `PaymentClaimed`) and is the documented stand-in for TODO-1/2.
+
+---
+
+## Build now — supported by stock LDK 0.1.8
+
+| # | Piece | Location | Key LDK API |
+|---|-------|----------|-------------|
+| 1 | Lite boot mode | `lampo-common/src/conf.rs:10` (flag), `lampod/src/lib.rs:203-261` (reduced `init`) | `ErroringMessageHandler` (`ln::peer_handler`) |
+| 2 | BLIP-0056 message codec + `CustomOnionMessageHandler` (replaces `IgnoringMessageHandler`) | `lampod/src/ln/peer_manager.rs:102-103`, new `lampod/src/ln/pos.rs` | `OnionMessageContents`, `CustomOnionMessageHandler`, `Responder` |
+| 3 | PoS notification blinded path + order store + amount/preimage verify + ack/nack | new `lampod/src/ln/pos.rs` | `BlindedMessagePath`, `MessageContext::Custom` |
+| 4 | v1 bridge: PoS→merchant notification-path registration RPC + per-order offer build | new RPC in `lampod/src/jsonrpc/`, `lampod/src/jsonrpc/offchain.rs:35` | `create_offer_builder`, `OfferId` |
+| 5 | Merchant sender on payment, keyed by `offer_id` | `lampod/src/actions/handler.rs:313` (`PaymentClaimed`) | `OnionMessenger::send_onion_message`, `Bolt12OfferContext::offer_id` |
+| 6 | New `LightningEvent` (`PosPaymentNotified`) + RPC/HTTP surface | `lampo-common/src/event/ln.rs`, `lampo-httpd/src/lib.rs` | — |
+| 7 | lampo-to-lampo integration test | `tests/tests/src/lampo_tests.rs` | existing test harness |
+| 8 | `TODO.md` (LDK gaps) + docs note | repo root / `docs/` | — |
+
+**Receiving mechanism note:** when the merchant sends the notification on the
+PoS-built blinded path, LDK decrypts the path and hands the PoS its own
+`MessageContext` bytes via `CustomOnionMessageHandler::handle_custom_message(msg,
+context, responder)`. That is how the order context (order_id + expected amount)
+round-trips without `path_id`. The `Responder` carries the merchant's reply path
+for `notification_ack`/`notification_nack`.
+
+---
+
+## Implementation phases (one self-contained commit each)
+
+Each commit must pass `make fmt` + `make check` independently (CLAUDE.md).
+
+- **C0 — Spike (de-risk first).** Lite boot mode (#1) + minimal
+  `CustomOnionMessageHandler` (#2) that round-trips a **hardcoded**
+  `payment_notification` → `notification_ack` between two lite nodes. Goal:
+  confirm `ErroringMessageHandler` satisfies the `PeerManager` bound and that
+  `DefaultMessageRouter` builds a blinded path for an unannounced, channel-less
+  node using the connected peer as introduction node. **Gate the rest on this.**
+- **C1 — Lite boot mode.** `pos_mode` config flag + reduced `init` path; connect
+  to a configured introduction/merchant peer. Test: node boots in pos mode,
+  connects, has no channels/chain/gossip.
+- **C2 — BLIP-0056 codec + custom onion handler.** `payment_notification`,
+  `notification_ack`, `notification_nack` as `OnionMessageContents`; a handler
+  that dispatches by TLV type; replace both `IgnoringMessageHandler`s. Unit
+  tests for encode/decode round-trips.
+- **C3 — PoS notification path + verification.** Build notification
+  `BlindedMessagePath` with `MessageContext::Custom`; order store; verify
+  `amount_msat` + `sha256(preimage) == payment_hash`; emit ack/nack +
+  `PosPaymentNotified` event.
+- **C4 — v1 bridge + offer construction.** New RPC for the PoS to register
+  `{offer_id -> notification_path}` with the merchant; per-order offer build
+  wiring. (Documents TODO-1/2 as the eventual replacement.)
+- **C5 — Merchant sender.** In the `PaymentClaimed` arm
+  (`lampod/src/actions/handler.rs:313`, currently only logs), look up the
+  notification path by `offer_id` and send `payment_notification`.
+- **C6 — RPC/HTTP surface.** Expose PoS order state / "paid" notifications to a
+  client (extend `lampo-httpd`).
+- **C7 — Integration test.** `tests/tests/src/lampo_tests.rs`: merchant + lite
+  PoS + payer; full flow asserts a `notification_ack` and a paid event.
+- **C8 — `TODO.md` + docs.** Land the LDK-gaps doc (below) and a short README
+  note on pos mode.
+
+---
+
+## Test plan
+
+- **Unit:** codec round-trips (C2); preimage/amount verification incl. the
+  `notification_nack` mismatch path (C3).
+- **Integration (C7):** boot merchant + lite PoS + payer in `tests/tests`; PoS
+  builds offer + registers notification path; payer pays; assert merchant sends
+  `payment_notification`, PoS verifies + replies `notification_ack`, and the PoS
+  emits `PosPaymentNotified` with the right order_id/amount. Add a negative case
+  (tampered amount → `notification_nack`).
+
+---
+
+## `TODO.md` contents (LDK gaps — to be created at implementation time)
+
+```markdown
+# BLIP-0056 — deferred items blocked on LDK (lightning 0.1.8)
+
+## TODO-1: `notification_path` as an experimental offer TLV (range 1e9..2e9)
+LDK has no PUBLIC builder/reader for experimental offer TLVs — only the
+test-only `pub(super) fn experimental_foo` (offers/offer.rs:487). The
+experimental range IS round-tripped on parse, so the gap is API-only.
+- Needs: upstream LDK PR exposing a public experimental-TLV setter + reader
+  on OfferBuilder / Offer / InvoiceRequest.
+- v1 workaround in use: PoS registers its notification path directly with the
+  merchant over their peer link, keyed by offer_id (see lampod/src/ln/pos.rs).
+- Spec ref: §Per-Order Offer Construction.
+
+## TODO-2: embed notification_path in invoice payment-path `path_id`
+ChannelManager's automatic offer→invoice_request→invoice responder controls
+`path_id`; no public hook to inject custom path context for offer-inbound
+payments.
+- Needs: upstream LDK PR for a custom path-context hook in the offers
+  responder, OR a manual offer-inbound reimplementation in lampo.
+- v1 workaround in use: notification correlated via offer_id + the PoS-built
+  notification path's MessageContext, not path_id round-tripping.
+- Spec ref: §Seven-Step Payment Flow, steps 3 & 5.
+```
+
+Suggested location: top-level `TODO.md`, or `docs/blip-0056-ldk-gaps.md` if
+scoped naming is preferred.
+
+---
+
+## Risks / open questions
+
+- **`ErroringMessageHandler` as `PeerManager` chan handler** — confirm it
+  satisfies the trait bound in 0.1.8 so the PoS carries no `ChannelManager`.
+  Fallback: a zero-channel `ChannelManager` with stub chain components.
+  (Resolve in C0.)
+- **Blinded-path creation for an unannounced, channel-less node** — confirm
+  `DefaultMessageRouter` uses the connected merchant peer as the introduction
+  node when the network graph is empty. (Resolve in C0.)
+- **`offer_id` availability at `PaymentClaimed`** — relies on
+  `PaymentPurpose::Bolt12OfferPayment { payment_context: Bolt12OfferContext {
+  offer_id, .. } }`. Verify the field is exposed in 0.1.8.
+- **`MessageContext` size** — keep order context minimal (order_id + amount);
+  the spec warns about onion `path_id` space.
+
+---
+
+## Out of scope (v1)
+
+Optional `payment_proof` (spec step 7), Appendix B pre-payment validation,
+CLN/external-wallet interop, cross-restart persistence of orders/payments, and
+the two deferred LDK pieces (TODO-1/2) beyond their v1 bridge.

--- a/lampo-common/Cargo.toml
+++ b/lampo-common/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 [dependencies]
 lightning = { version = "0.1.5", features = [] }
 lightning-block-sync = { version = "0.1.0" }
-lightning-persister = { version = "0.2.0" }
+lightning-persister = { version = "0.1.0" }
 lightning-background-processor = { version = "0.1", features = ["futures"] }
 lightning-net-tokio = { version = "0.1.0" }
 lightning-rapid-gossip-sync = { version = "0.1.0" }

--- a/lampo-common/src/event/ln.rs
+++ b/lampo-common/src/event/ln.rs
@@ -48,4 +48,17 @@ pub enum LightningEvent {
         counterparty_node_id: Option<String>,
         funding_utxo: Option<String>,
     },
+    /// BLIP-0056: a PoS node received and verified a `payment_notification`.
+    PosPaymentNotified {
+        payment_hash: String,
+        amount_msat: u64,
+        /// `true` if `sha256(preimage) == payment_hash`.
+        verified: bool,
+    },
+    /// BLIP-0056: a merchant received a `notification_ack`/`notification_nack`.
+    PosNotificationAck {
+        payment_hash: String,
+        /// `true` for an ack, `false` for a nack.
+        acked: bool,
+    },
 }

--- a/lampo-common/src/model.rs
+++ b/lampo-common/src/model.rs
@@ -7,6 +7,7 @@ mod network;
 mod new_addr;
 mod on_chain;
 mod open_channel;
+mod pos;
 
 pub use connect::Connect;
 pub use getinfo::GetInfo;
@@ -22,6 +23,7 @@ pub mod request {
     #[allow(unused_imports)]
     pub use crate::model::on_chain::request::*;
     pub use crate::model::open_channel::request::*;
+    pub use crate::model::pos::request::*;
 }
 
 pub mod response {
@@ -34,4 +36,5 @@ pub mod response {
     pub use crate::model::new_addr::response::*;
     pub use crate::model::on_chain::response::*;
     pub use crate::model::open_channel::response::*;
+    pub use crate::model::pos::response::*;
 }

--- a/lampo-common/src/model/pos.rs
+++ b/lampo-common/src/model/pos.rs
@@ -1,0 +1,32 @@
+//! BLIP-0056 Point-of-Sale models.
+
+pub mod request {
+    use bitcoin::secp256k1::PublicKey;
+    use serde::{Deserialize, Serialize};
+
+    /// Send a `payment_notification` onion message to a PoS node.
+    ///
+    /// This is the merchant-side send primitive. `payment_hash` and `preimage`
+    /// are hex-encoded 32-byte values.
+    ///
+    /// NOTE: no `Apiv2Schema` derive because `PublicKey` does not implement it;
+    /// the httpd `post!` macro deserializes the request from a generic JSON
+    /// body, so only the response type needs the schema.
+    #[derive(Serialize, Deserialize, Debug)]
+    pub struct SendPaymentNotification {
+        pub node_id: PublicKey,
+        pub payment_hash: String,
+        pub preimage: String,
+        pub amount_msat: u64,
+    }
+}
+
+pub mod response {
+    use paperclip::actix::Apiv2Schema;
+    use serde::{Deserialize, Serialize};
+
+    #[derive(Serialize, Deserialize, Debug, Apiv2Schema)]
+    pub struct SendPaymentNotification {
+        pub status: String,
+    }
+}

--- a/lampo-httpd/src/commands/offchain.rs
+++ b/lampo-httpd/src/commands/offchain.rs
@@ -5,7 +5,9 @@ use paste::paste;
 
 use lampo_common::json;
 use lampo_common::model::{request, response};
-use lampod::jsonrpc::offchain::{json_decode, json_invoice, json_offer, json_pay};
+use lampod::jsonrpc::offchain::{
+    json_decode, json_invoice, json_offer, json_pay, json_sendpaymentnotification,
+};
 
 use crate::{post, AppState, ResultJson};
 
@@ -14,3 +16,8 @@ post!(offer, request: request::GenerateOffer, response: response::Offer);
 // FIXME(vincenzopalazzo): the decode should be generic over any kind of string
 post!(decode, request: request::DecodeInvoice, response: response::Decode);
 post!(pay, request: request::Pay, response: response::PayResult);
+post!(
+    sendpaymentnotification,
+    request: request::SendPaymentNotification,
+    response: response::SendPaymentNotification
+);

--- a/lampo-httpd/src/lib.rs
+++ b/lampo-httpd/src/lib.rs
@@ -15,7 +15,7 @@ use lampod::LampoDaemon;
 
 use commands::daemon::rest_stop;
 use commands::inventory::{rest_funds, rest_getinfo, rest_networkchannels};
-use commands::offchain::{rest_decode, rest_invoice, rest_pay};
+use commands::offchain::{rest_decode, rest_invoice, rest_pay, rest_sendpaymentnotification};
 use commands::onchain::rest_new_addr;
 use commands::peer::{rest_channels, rest_close, rest_connect, rest_fundchannel};
 
@@ -127,6 +127,7 @@ pub async fn run<T: ToSocketAddrs + Display>(
             .service(rest_offer)
             .service(rest_decode)
             .service(rest_pay)
+            .service(rest_sendpaymentnotification)
             .service(rest_funds)
             .service(rest_new_addr)
             .service(rest_stop)

--- a/lampod/Cargo.toml
+++ b/lampod/Cargo.toml
@@ -6,10 +6,11 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-tokio = { version = "^1.50.0", features = ["rt-multi-thread", "parking_lot"] }
+tokio = { version = "^1.50.0", features = ["rt-multi-thread", "parking_lot", "macros", "time", "net"] }
 lampo-common = { path = "../lampo-common" }
 log = "0.4.17"
 time = "0.3.43"
 futures = "0.3.28"
 once_cell = "1.21.1"
 async-trait = "0.1.89"
+hex = "0.4.3"

--- a/lampod/src/actions/handler.rs
+++ b/lampod/src/actions/handler.rs
@@ -41,7 +41,7 @@ pub struct LampoHandler {
 
 impl LampoHandler {
     pub(crate) fn new(lampod: &LampoDaemon) -> Self {
-        let emitter = Emitter::default();
+        let emitter = lampod.emitter();
         let subscriber = emitter.subscriber();
         Self {
             channel_manager: lampod.channel_manager(),

--- a/lampod/src/jsonrpc/offchain.rs
+++ b/lampod/src/jsonrpc/offchain.rs
@@ -6,16 +6,20 @@ use lampo_common::event::Event;
 use lampo_common::handler::Handler;
 use lampo_common::jsonrpc::{Error, RpcError};
 use lampo_common::ldk;
+use lampo_common::ldk::blinded_path::message::MessageContext;
 use lampo_common::ldk::offers::offer;
+use lampo_common::ldk::onion_message::messenger::{Destination, MessageSendInstructions};
 use lampo_common::model::request::GenerateInvoice;
 use lampo_common::model::request::GenerateOffer;
 use lampo_common::model::request::KeySend;
 use lampo_common::model::request::Pay;
+use lampo_common::model::request::SendPaymentNotification;
 use lampo_common::model::response::PayResult;
 use lampo_common::model::response::{self, Decode};
 use lampo_common::model::response::{Bolt11InvoiceInfo, Bolt12InvoiceInfo, Invoice};
 use lampo_common::{json, model::request::DecodeInvoice};
 
+use crate::ln::PosMessage;
 use crate::LampoDaemon;
 
 pub async fn json_invoice(ctx: &LampoDaemon, request: &json::Value) -> Result<json::Value, Error> {
@@ -143,4 +147,48 @@ pub async fn json_keysend(ctx: &LampoDaemon, request: &json::Value) -> Result<js
         .keysend(request.destination, request.amount_msat)?;
     // FIXME: return a better response
     Ok(json::json!({}))
+}
+
+/// BLIP-0056: merchant-side primitive that sends a `payment_notification`
+/// onion message to a PoS node and asks the messenger to build a reply path so
+/// the PoS can respond with `notification_ack`/`notification_nack`.
+pub async fn json_sendpaymentnotification(
+    ctx: &LampoDaemon,
+    request: &json::Value,
+) -> Result<json::Value, Error> {
+    log::info!(
+        "call for `sendpaymentnotification` with request `{:?}`",
+        request
+    );
+    let request: SendPaymentNotification = json::from_value(request.clone())?;
+    let payment_hash = decode_hash32(&request.payment_hash)?;
+    let preimage = decode_hash32(&request.preimage)?;
+    let message = PosMessage::PaymentNotification {
+        payment_hash,
+        preimage,
+        amount_msat: request.amount_msat,
+    };
+    // The empty MessageContext is replaced by the encrypted order context once
+    // the PoS-built notification path is wired (see `TODO.md`, TODO-2).
+    let instructions = MessageSendInstructions::WithReplyPath {
+        destination: Destination::Node(request.node_id),
+        context: MessageContext::Custom(Vec::new()),
+    };
+    ctx.peer_manager()
+        .pos_handler()
+        .enqueue(message, instructions);
+    // Nudge the peer manager so the queued message is flushed promptly rather
+    // than waiting for the next background processor tick.
+    ctx.peer_manager().manager().process_events();
+    Ok(json::to_value(response::SendPaymentNotification {
+        status: "queued".to_string(),
+    })?)
+}
+
+fn decode_hash32(value: &str) -> Result<[u8; 32], Error> {
+    let bytes =
+        hex::decode(value).map_err(|err| crate::rpc_error!("invalid hex `{value}`: {err}"))?;
+    bytes
+        .try_into()
+        .map_err(|_| crate::rpc_error!("expected 32 bytes for `{value}`"))
 }

--- a/lampod/src/jsonrpc/offchain.rs
+++ b/lampod/src/jsonrpc/offchain.rs
@@ -156,10 +156,7 @@ pub async fn json_sendpaymentnotification(
     ctx: &LampoDaemon,
     request: &json::Value,
 ) -> Result<json::Value, Error> {
-    log::info!(
-        "call for `sendpaymentnotification` with request `{:?}`",
-        request
-    );
+    log::info!("call for sendpaymentnotification");
     let request: SendPaymentNotification = json::from_value(request.clone())?;
     let payment_hash = decode_hash32(&request.payment_hash)?;
     let preimage = decode_hash32(&request.preimage)?;

--- a/lampod/src/lib.rs
+++ b/lampod/src/lib.rs
@@ -26,6 +26,7 @@ use tokio::task::JoinHandle;
 
 use lampo_common::backend::Backend;
 use lampo_common::conf::LampoConf;
+use lampo_common::event::Emitter;
 use lampo_common::handler::ExternalHandler;
 use lampo_common::json;
 use lampo_common::ldk::events::{Event, ReplayEvent};
@@ -69,6 +70,9 @@ pub struct LampoDaemon {
     persister: Arc<LampoPersistence>,
     handler: Option<Arc<LampoHandler>>,
     shutdown: Arc<AtomicBool>,
+    /// Shared event emitter, cloned into the handler and the PoS onion handler
+    /// so every component publishes to the same set of subscribers.
+    emitter: Emitter<lampo_common::event::Event>,
 }
 
 impl LampoDaemon {
@@ -86,6 +90,7 @@ impl LampoDaemon {
             offchain_manager: None,
             handler: None,
             shutdown: Arc::new(AtomicBool::new(false)),
+            emitter: Emitter::default(),
         }
     }
 
@@ -158,6 +163,7 @@ impl LampoDaemon {
             self.onchain_manager(),
             self.wallet_manager.clone(),
             self.channel_manager(),
+            self.emitter.clone(),
         )?;
         self.peer_manager = Some(Arc::new(peer_manager));
         Ok(())
@@ -194,6 +200,11 @@ impl LampoDaemon {
 
     pub fn handler(&self) -> Arc<LampoHandler> {
         self.handler.clone().unwrap()
+    }
+
+    /// The shared event emitter used by all node components.
+    pub(crate) fn emitter(&self) -> Emitter<lampo_common::event::Event> {
+        self.emitter.clone()
     }
 
     pub fn init_reactor(&mut self) -> error::Result<()> {

--- a/lampod/src/ln/mod.rs
+++ b/lampod/src/ln/mod.rs
@@ -3,6 +3,7 @@ mod channel_manager;
 mod inventory_manager;
 mod offchain_manager;
 mod peer_manager;
+pub mod pos;
 
 pub mod peer_event;
 
@@ -10,3 +11,4 @@ pub use channel_manager::LampoChannelManager;
 pub use inventory_manager::LampoInventoryManager;
 pub use offchain_manager::OffchainManager;
 pub use peer_manager::LampoPeerManager;
+pub use pos::{PosMessage, PosOnionHandler};

--- a/lampod/src/ln/peer_manager.rs
+++ b/lampod/src/ln/peer_manager.rs
@@ -8,6 +8,7 @@ use async_trait::async_trait;
 
 use lampo_common::conf::LampoConf;
 use lampo_common::error;
+use lampo_common::event::{Emitter, Event};
 use lampo_common::keys::LampoKeysManager;
 use lampo_common::ldk;
 use lampo_common::ldk::blinded_path::EmptyNodeIdLookUp;
@@ -22,6 +23,7 @@ use lampo_common::types::{LampoArcChannelManager, LampoChainMonitor, LampoGraph}
 
 use crate::async_run;
 use crate::chain::{LampoChainManager, WalletManager};
+use crate::ln::pos::PosOnionHandler;
 use crate::ln::LampoChannelManager;
 use crate::utils::logger::LampoLogger;
 
@@ -34,7 +36,7 @@ pub type LampoArcOnionMessenger<L> = OnionMessenger<
     Arc<LampoArcChannelManager<LampoChainMonitor, L>>,
     IgnoringMessageHandler,
     IgnoringMessageHandler,
-    IgnoringMessageHandler,
+    Arc<PosOnionHandler>,
 >;
 
 pub type SimpleArcPeerManager<M, T, L> = PeerManager<
@@ -56,6 +58,7 @@ pub struct LampoPeerManager {
     conf: LampoConf,
     logger: Arc<LampoLogger>,
     onion_messenger: Option<Arc<LampoArcOnionMessenger<LampoLogger>>>,
+    pos_handler: Option<Arc<PosOnionHandler>>,
 }
 
 impl LampoPeerManager {
@@ -66,6 +69,7 @@ impl LampoPeerManager {
             logger,
             channel_manager: None,
             onion_messenger: None,
+            pos_handler: None,
         }
     }
 
@@ -77,11 +81,17 @@ impl LampoPeerManager {
         self.onion_messenger.clone().unwrap()
     }
 
+    /// The BLIP-0056 PoS custom onion message handler.
+    pub fn pos_handler(&self) -> Arc<PosOnionHandler> {
+        self.pos_handler.clone().unwrap()
+    }
+
     pub fn init(
         &mut self,
         _onchain_manager: Arc<LampoChainManager>,
         wallet_manager: Arc<dyn WalletManager>,
         channel_manager: Arc<LampoChannelManager>,
+        emitter: Emitter<Event>,
     ) -> error::Result<()> {
         let ephemeral_bytes = [0; 32];
         let current_time = SystemTime::now()
@@ -91,6 +101,9 @@ impl LampoPeerManager {
 
         let keys = wallet_manager.ldk_keys().keys_manager.clone();
         let graph = channel_manager.graph();
+        // BLIP-0056: plug the PoS custom onion message handler into the
+        // messenger so `payment_notification`/`ack`/`nack` are processed.
+        let pos_handler = Arc::new(PosOnionHandler::new(emitter, self.logger.clone()));
         let onion_messenger = Arc::new(OnionMessenger::new(
             keys.clone(),
             keys.clone(),
@@ -99,8 +112,8 @@ impl LampoPeerManager {
             Arc::new(DefaultMessageRouter::new(graph.clone(), keys.clone())),
             channel_manager.manager(), // Use channel manager for offers message handler
             IgnoringMessageHandler {}, // async_payments_message_handler
-            IgnoringMessageHandler {}, // custom_onion_message_handler
-            IgnoringMessageHandler {}, // custom_onion_message_contents
+            IgnoringMessageHandler {}, // dns_resolver_message_handler
+            pos_handler.clone(),       // custom_onion_message_handler (BLIP-0056)
         ));
 
         let gossip_sync = Arc::new(P2PGossipSync::new(
@@ -126,6 +139,7 @@ impl LampoPeerManager {
         self.peer_manager = Some(Arc::new(peer_manager));
         self.channel_manager = Some(channel_manager.clone());
         self.onion_messenger = Some(onion_messenger);
+        self.pos_handler = Some(pos_handler);
         Ok(())
     }
 

--- a/lampod/src/ln/pos.rs
+++ b/lampod/src/ln/pos.rs
@@ -1,0 +1,298 @@
+//! BLIP-0056 Point-of-Sale payment notifications.
+//!
+//! This module implements the custom onion messages defined by BLIP-0056 so
+//! that a Point-of-Sale (PoS) node can receive `payment_notification` messages
+//! from a merchant and reply with `notification_ack`/`notification_nack`, and
+//! so that a merchant can send those notifications.
+//!
+//! The custom message handler is plugged into the LDK [`OnionMessenger`] in
+//! place of the default `IgnoringMessageHandler`, see
+//! [`crate::ln::peer_manager`].
+//!
+//! Author: Vincenzo Palazzo <vincenzopalazzo@member.fsf.org>
+//!
+//! NOTE: the TLV type numbers below are provisional. BLIP-0056 does not yet
+//! assign final values; see `TODO.md` (TODO-1).
+use std::sync::Arc;
+use std::sync::Mutex;
+
+use lampo_common::bitcoin::hashes::sha256::Hash as Sha256;
+use lampo_common::bitcoin::hashes::Hash;
+use lampo_common::event::ln::LightningEvent;
+use lampo_common::event::{Emitter, Event};
+use lampo_common::ldk::io;
+use lampo_common::ldk::ln::msgs::DecodeError;
+use lampo_common::ldk::onion_message::messenger::{
+    CustomOnionMessageHandler, MessageSendInstructions, Responder, ResponseInstruction,
+};
+use lampo_common::ldk::onion_message::packet::OnionMessageContents;
+use lampo_common::ldk::util::ser::{Readable, Writeable, Writer};
+
+use crate::utils::logger::LampoLogger;
+
+/// Provisional onion-message TLV type for `payment_notification`.
+pub const POS_PAYMENT_NOTIFICATION_TYPE: u64 = 60_061;
+/// Provisional onion-message TLV type for `notification_ack`.
+pub const POS_NOTIFICATION_ACK_TYPE: u64 = 60_063;
+/// Provisional onion-message TLV type for `notification_nack`.
+pub const POS_NOTIFICATION_NACK_TYPE: u64 = 60_065;
+
+/// The BLIP-0056 custom onion messages.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum PosMessage {
+    /// Merchant -> PoS: a payment for an order has been received.
+    PaymentNotification {
+        payment_hash: [u8; 32],
+        preimage: [u8; 32],
+        amount_msat: u64,
+    },
+    /// PoS -> Merchant: positive acknowledgement of a notification.
+    ///
+    /// BLIP-0056 leaves the ack payload unspecified; we carry the
+    /// `payment_hash` so the merchant can correlate the reply. See `TODO.md`.
+    NotificationAck { payment_hash: [u8; 32] },
+    /// PoS -> Merchant: negative acknowledgement (verification failed).
+    NotificationNack { payment_hash: [u8; 32] },
+}
+
+impl OnionMessageContents for PosMessage {
+    fn tlv_type(&self) -> u64 {
+        match self {
+            PosMessage::PaymentNotification { .. } => POS_PAYMENT_NOTIFICATION_TYPE,
+            PosMessage::NotificationAck { .. } => POS_NOTIFICATION_ACK_TYPE,
+            PosMessage::NotificationNack { .. } => POS_NOTIFICATION_NACK_TYPE,
+        }
+    }
+
+    fn msg_type(&self) -> &'static str {
+        match self {
+            PosMessage::PaymentNotification { .. } => "pos_payment_notification",
+            PosMessage::NotificationAck { .. } => "pos_notification_ack",
+            PosMessage::NotificationNack { .. } => "pos_notification_nack",
+        }
+    }
+}
+
+impl Writeable for PosMessage {
+    fn write<W: Writer>(&self, w: &mut W) -> Result<(), io::Error> {
+        match self {
+            PosMessage::PaymentNotification {
+                payment_hash,
+                preimage,
+                amount_msat,
+            } => {
+                payment_hash.write(w)?;
+                preimage.write(w)?;
+                amount_msat.write(w)?;
+            }
+            PosMessage::NotificationAck { payment_hash }
+            | PosMessage::NotificationNack { payment_hash } => {
+                payment_hash.write(w)?;
+            }
+        }
+        Ok(())
+    }
+}
+
+impl PosMessage {
+    /// Read a `PosMessage` body of the given TLV `message_type` from `buffer`.
+    ///
+    /// Returns `Ok(None)` for unknown types so the messenger can ignore them.
+    pub fn read<R: io::Read>(
+        message_type: u64,
+        buffer: &mut R,
+    ) -> Result<Option<Self>, DecodeError> {
+        match message_type {
+            POS_PAYMENT_NOTIFICATION_TYPE => {
+                let payment_hash: [u8; 32] = Readable::read(buffer)?;
+                let preimage: [u8; 32] = Readable::read(buffer)?;
+                let amount_msat: u64 = Readable::read(buffer)?;
+                Ok(Some(PosMessage::PaymentNotification {
+                    payment_hash,
+                    preimage,
+                    amount_msat,
+                }))
+            }
+            POS_NOTIFICATION_ACK_TYPE => {
+                let payment_hash: [u8; 32] = Readable::read(buffer)?;
+                Ok(Some(PosMessage::NotificationAck { payment_hash }))
+            }
+            POS_NOTIFICATION_NACK_TYPE => {
+                let payment_hash: [u8; 32] = Readable::read(buffer)?;
+                Ok(Some(PosMessage::NotificationNack { payment_hash }))
+            }
+            _ => Ok(None),
+        }
+    }
+}
+
+/// `true` if `sha256(preimage) == payment_hash`.
+pub fn verify_preimage(payment_hash: &[u8; 32], preimage: &[u8; 32]) -> bool {
+    Sha256::hash(preimage).to_byte_array() == *payment_hash
+}
+
+/// Custom onion-message handler implementing the BLIP-0056 PoS role.
+///
+/// On the PoS side it verifies incoming `payment_notification`s and replies
+/// with `notification_ack`/`notification_nack`. On the merchant side, messages
+/// queued via [`PosOnionHandler::enqueue`] are drained by the
+/// [`OnionMessenger`] through [`CustomOnionMessageHandler::release_pending_custom_messages`].
+pub struct PosOnionHandler {
+    emitter: Emitter<Event>,
+    #[allow(dead_code)]
+    logger: Arc<LampoLogger>,
+    /// Outbound messages waiting to be sent by the messenger (merchant side).
+    pending: Mutex<Vec<(PosMessage, MessageSendInstructions)>>,
+}
+
+impl PosOnionHandler {
+    pub fn new(emitter: Emitter<Event>, logger: Arc<LampoLogger>) -> Self {
+        Self {
+            emitter,
+            logger,
+            pending: Mutex::new(Vec::new()),
+        }
+    }
+
+    /// Queue a message to be sent on the next messenger processing cycle.
+    pub fn enqueue(&self, message: PosMessage, instructions: MessageSendInstructions) {
+        // SAFETY: the mutex is only held for the push, no panics in between.
+        self.pending.lock().unwrap().push((message, instructions));
+    }
+}
+
+impl CustomOnionMessageHandler for PosOnionHandler {
+    type CustomMessage = PosMessage;
+
+    fn handle_custom_message(
+        &self,
+        msg: PosMessage,
+        _context: Option<Vec<u8>>,
+        responder: Option<Responder>,
+    ) -> Option<(PosMessage, ResponseInstruction)> {
+        match msg {
+            PosMessage::PaymentNotification {
+                payment_hash,
+                preimage,
+                amount_msat,
+            } => {
+                // FIXME(TODO-2): the expected amount/order id will be read from
+                // `_context` (the PoS-only MessageContext) in a follow-up.
+                let verified = verify_preimage(&payment_hash, &preimage);
+                log::info!(
+                    target: "lampo::pos",
+                    "received payment_notification hash={} amount={}msat verified={}",
+                    hex::encode(payment_hash), amount_msat, verified
+                );
+                self.emitter
+                    .emit(Event::Lightning(LightningEvent::PosPaymentNotified {
+                        payment_hash: hex::encode(payment_hash),
+                        amount_msat,
+                        verified,
+                    }));
+                match responder {
+                    Some(responder) => {
+                        let reply = if verified {
+                            PosMessage::NotificationAck { payment_hash }
+                        } else {
+                            PosMessage::NotificationNack { payment_hash }
+                        };
+                        Some((reply, responder.respond()))
+                    }
+                    None => {
+                        log::warn!(
+                            target: "lampo::pos",
+                            "payment_notification had no reply path, cannot ack"
+                        );
+                        None
+                    }
+                }
+            }
+            PosMessage::NotificationAck { payment_hash } => {
+                log::info!(
+                    target: "lampo::pos",
+                    "merchant received notification_ack for {}", hex::encode(payment_hash)
+                );
+                self.emitter
+                    .emit(Event::Lightning(LightningEvent::PosNotificationAck {
+                        payment_hash: hex::encode(payment_hash),
+                        acked: true,
+                    }));
+                None
+            }
+            PosMessage::NotificationNack { payment_hash } => {
+                log::warn!(
+                    target: "lampo::pos",
+                    "merchant received notification_nack for {}", hex::encode(payment_hash)
+                );
+                self.emitter
+                    .emit(Event::Lightning(LightningEvent::PosNotificationAck {
+                        payment_hash: hex::encode(payment_hash),
+                        acked: false,
+                    }));
+                None
+            }
+        }
+    }
+
+    fn read_custom_message<R: io::Read>(
+        &self,
+        message_type: u64,
+        buffer: &mut R,
+    ) -> Result<Option<PosMessage>, DecodeError> {
+        PosMessage::read(message_type, buffer)
+    }
+
+    fn release_pending_custom_messages(&self) -> Vec<(PosMessage, MessageSendInstructions)> {
+        let mut pending = self.pending.lock().unwrap();
+        std::mem::take(&mut *pending)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use lampo_common::ldk::util::ser::Writeable;
+
+    fn roundtrip(msg: PosMessage) {
+        let bytes = msg.encode();
+        let mut cursor = io::Cursor::new(&bytes);
+        let decoded = PosMessage::read(msg.tlv_type(), &mut cursor)
+            .expect("decode ok")
+            .expect("known type");
+        assert_eq!(msg, decoded);
+    }
+
+    #[test]
+    fn payment_notification_roundtrip() {
+        roundtrip(PosMessage::PaymentNotification {
+            payment_hash: [7u8; 32],
+            preimage: [9u8; 32],
+            amount_msat: 123_456,
+        });
+    }
+
+    #[test]
+    fn ack_nack_roundtrip() {
+        roundtrip(PosMessage::NotificationAck {
+            payment_hash: [1u8; 32],
+        });
+        roundtrip(PosMessage::NotificationNack {
+            payment_hash: [2u8; 32],
+        });
+    }
+
+    #[test]
+    fn unknown_type_is_none() {
+        let mut cursor = io::Cursor::new(vec![0u8; 32]);
+        assert!(PosMessage::read(42, &mut cursor).unwrap().is_none());
+    }
+
+    #[test]
+    fn preimage_verification() {
+        let preimage = [3u8; 32];
+        let hash = Sha256::hash(&preimage).to_byte_array();
+        assert!(verify_preimage(&hash, &preimage));
+        assert!(!verify_preimage(&[0u8; 32], &preimage));
+    }
+}

--- a/tests/tests/src/lampo_tests.rs
+++ b/tests/tests/src/lampo_tests.rs
@@ -3,6 +3,7 @@
 //! Author: Vincenzo Palazzo <vincenzopalazzo@member.fsf.org>
 use std::sync::Arc;
 
+use lampo_common::bitcoin::hashes::{sha256, Hash};
 use lampo_common::error;
 use lampo_common::event::ln::LightningEvent;
 use lampo_common::event::Event;
@@ -99,6 +100,87 @@ pub async fn fund_a_simple_channel_from() -> error::Result<()> {
             }
 
             if channels.channels.first().unwrap().ready {
+                return Ok(());
+            }
+        }
+        Err(())
+    });
+    Ok(())
+}
+
+/// BLIP-0056: a merchant sends a `payment_notification` onion message to a PoS
+/// node; the PoS verifies the preimage, emits `PosPaymentNotified`, and replies
+/// with `notification_ack`, which the merchant surfaces as `PosNotificationAck`.
+#[tokio_test_shutdown_timeout::test(60)]
+pub async fn pos_payment_notification_roundtrip() -> error::Result<()> {
+    init();
+    let merchant = LampoTesting::tmp().await?;
+    let pos = LampoTesting::new(merchant.btc.clone()).await?;
+
+    // The PoS connects to the merchant so they become onion-message peers; the
+    // merchant uses that connection as the introduction node for routing.
+    let _: response::Connect = pos
+        .lampod()
+        .call(
+            "connect",
+            request::Connect {
+                node_id: merchant.info.node_id.clone(),
+                addr: "127.0.0.1".to_owned(),
+                port: merchant.port,
+            },
+        )
+        .await
+        .unwrap();
+
+    // Derive a preimage/hash pair. A sha256::Hash prints as hex via Display, so
+    // we avoid pulling in a hex dependency just for the test vectors.
+    let preimage_hash = sha256::Hash::hash(b"blip-0056 pos preimage");
+    let preimage = preimage_hash.to_byte_array();
+    let preimage_hex = preimage_hash.to_string();
+    let payment_hash_hex = sha256::Hash::hash(&preimage).to_string();
+    let amount_msat = 50_000u64;
+
+    let mut pos_events = pos.lampod().events();
+    let mut merchant_events = merchant.lampod().events();
+
+    let _: json::Value = merchant
+        .lampod()
+        .call(
+            "sendpaymentnotification",
+            json::json!({
+                "node_id": pos.info.node_id,
+                "payment_hash": payment_hash_hex,
+                "preimage": preimage_hex,
+                "amount_msat": amount_msat,
+            }),
+        )
+        .await
+        .unwrap();
+
+    // The PoS receives and verifies the notification.
+    async_wait!(async {
+        while let Some(event) = pos_events.recv().await {
+            log::info!(target: "tests", "pos event {:?}", event);
+            if let Event::Lightning(LightningEvent::PosPaymentNotified {
+                amount_msat: amt,
+                verified,
+                ..
+            }) = event
+            {
+                assert!(verified, "preimage must verify against the payment hash");
+                assert_eq!(amt, amount_msat);
+                return Ok(());
+            }
+        }
+        Err(())
+    });
+
+    // The merchant receives the PoS acknowledgement.
+    async_wait!(async {
+        while let Some(event) = merchant_events.recv().await {
+            log::info!(target: "tests", "merchant event {:?}", event);
+            if let Event::Lightning(LightningEvent::PosNotificationAck { acked, .. }) = event {
+                assert!(acked, "the PoS must ack a valid notification");
                 return Ok(());
             }
         }


### PR DESCRIPTION
## Summary

First installment of BLIP-0056 (BOLT12 PoS payment notifications). Lands the build fix plus the proven protocol foundation; the remaining protocol wiring and the lite `pos_mode` boot are tracked in `TODO.md` and will land as further commits on this branch (everything in one PR).

- `build: restore compiling workspace` — `main` does not currently compile: the dependabot bump of `lightning-persister` to `0.2.0` pulls in `lightning 0.2.x`, incompatible with the pinned `lightning 0.1.5` (`FilesystemStore` no longer satisfies the `Persist`/`KVStore` bound `ChainMonitor` requires). Reverted to `0.1.0`. Also declared the `tokio` features `lampod` uses directly (`macros`, `time`, `net`) instead of relying on sibling feature unification.
- `payment_notification` / `notification_ack` / `notification_nack` as `OnionMessageContents` (`lampod/src/ln/pos.rs`), handled by `PosOnionHandler` wired into the `OnionMessenger` in place of the default `IgnoringMessageHandler`.
- `PosOnionHandler` verifies `sha256(preimage) == payment_hash`, replies ack/nack via the `Responder`, and emits `LightningEvent::PosPaymentNotified` / `PosNotificationAck` on an emitter shared with the event handler.
- `sendpaymentnotification` JSON-RPC — merchant send primitive.

### Pending (tracked in `TODO.md`)

- PoS-built notification `BlindedMessagePath` + `MessageContext` order context + amount verification.
- Merchant auto-send on `PaymentClaimed` (keyed by `offer_id`) + per-order offer + the `offer_id` -> notification-path bridge RPC.
- Lite `pos_mode` boot (no chain backend / channels / gossip).
- Two LDK gaps block strict spec-wire fidelity (no public experimental offer TLV API; no invoice `path_id` hook) — documented in `TODO.md`.

## Test plan

- `cargo test -p lampod --lib pos::` — 4 codec/verification unit tests.
- `tests/tests/src/lampo_tests.rs::pos_payment_notification_roundtrip` — end-to-end lampo-to-lampo: merchant sends `payment_notification`, PoS verifies and emits `PosPaymentNotified`, replies ack, merchant gets `PosNotificationAck`. Passes in ~3.3s.
- Full `lampo_tests::` module green serially (`--test-threads=1`, 8/8 in ~35s). NB: these integration tests flake under parallel execution (bitcoind/port contention) — pre-existing, not from this PR.
- `cargo fmt --all -- --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)