### PR TITLE
Upgrade LDK stack to 0.3

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,3 +57,34 @@ jobs:
         with:
           command: fmt
           args: --all -- --check
+
+  deps:
+    name: Dependency hygiene
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Install stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+
+      # Guards against the failure mode in #537: a bump of a single LDK crate
+      # pulling in a second, incompatible `lightning` version. Every `lightning*`
+      # crate must resolve to one version across the workspace.
+      - name: Ensure a single LDK (lightning*) version
+        run: |
+          set -euo pipefail
+          tree=$(cargo tree --workspace --duplicates --edges normal)
+          dupes=$(printf '%s\n' "$tree" | grep -E '^lightning[a-z-]* v' | sort -u || true)
+          if [ -n "$dupes" ]; then
+            echo "::error::Multiple versions of LDK (lightning*) crates detected:"
+            echo "$dupes"
+            echo "Bump every lightning* crate together so the stack stays on one version."
+            exit 1
+          fi
+          echo "OK: each lightning* crate resolves to a single version."

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -429,6 +429,7 @@ dependencies = [
  "bitcoin-io",
  "bitcoin-units",
  "bitcoin_hashes 0.14.0",
+ "bitcoinconsensus",
  "hex-conservative 0.2.1",
  "hex_lit",
  "secp256k1",
@@ -488,6 +489,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "bitcoinconsensus"
+version = "0.105.0+25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f260ac8fb2c621329013fc0ed371c940fcc512552dcbcb9095ed0179098c9e18"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "bitcoincore-rpc"
 version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -522,6 +532,12 @@ name = "bitflags"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
+
+[[package]]
+name = "bitreq"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b65c2e1ab98050c93cc9ada070d5070e014329c65196d03f6f8f1f75c2666f37"
 
 [[package]]
 name = "block-buffer"
@@ -604,6 +620,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "chacha20-poly1305"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bad28386ab70dd960294556a76aaab6da2994fec47d650fd725b3012f062052a"
+
+[[package]]
 name = "chrono"
 version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -612,6 +634,7 @@ dependencies = [
  "iana-time-zone",
  "js-sys",
  "num-traits",
+ "serde",
  "wasm-bindgen",
  "windows-link 0.2.1",
 ]
@@ -625,12 +648,6 @@ dependencies = [
  "chrono",
  "phf",
 ]
-
-[[package]]
-name = "chunked_transfer"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e4de3bc4ea267985becf712dc6d9eed8b04c953b3fcfb339ebc87acd9804901"
 
 [[package]]
 name = "clap"
@@ -1748,7 +1765,7 @@ dependencies = [
  "clightningrpc-conf",
  "colored",
  "hex",
- "lightning 0.1.5",
+ "lightning",
  "lightning-background-processor",
  "lightning-block-sync",
  "lightning-net-tokio",
@@ -1884,89 +1901,78 @@ dependencies = [
 
 [[package]]
 name = "lightning"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e540fcb289a76826c9c0b078d3dd1f05691972c5a53fb4d3120540862040a147"
+version = "0.3.0+git"
+source = "git+https://github.com/lightningdevkit/rust-lightning?rev=84605cf08d34b8db731ee4a4356a95125a8b02af#84605cf08d34b8db731ee4a4356a95125a8b02af"
 dependencies = [
  "bech32",
  "bitcoin",
+ "chacha20-poly1305",
  "dnssec-prover",
  "hashbrown 0.13.2",
  "libm",
- "lightning-invoice 0.33.2",
- "lightning-types 0.2.0",
- "possiblyrandom",
-]
-
-[[package]]
-name = "lightning"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c90397b635e3ece6b9a723fb470a46cb9b3592f217d72e40540a5fada00289d"
-dependencies = [
- "bech32",
- "bitcoin",
- "dnssec-prover",
- "hashbrown 0.13.2",
- "libm",
- "lightning-invoice 0.34.0",
+ "lightning-invoice",
  "lightning-macros",
- "lightning-types 0.3.1",
+ "lightning-types",
  "possiblyrandom",
+ "regex",
 ]
 
 [[package]]
 name = "lightning-background-processor"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04231b97fd7509d73ce9857a416eb1477a55d076d4e22cbf26c649a772bde909"
+version = "0.3.0+git"
+source = "git+https://github.com/lightningdevkit/rust-lightning?rev=84605cf08d34b8db731ee4a4356a95125a8b02af#84605cf08d34b8db731ee4a4356a95125a8b02af"
 dependencies = [
  "bitcoin",
  "bitcoin-io",
  "bitcoin_hashes 0.14.0",
- "lightning 0.1.5",
+ "lightning",
+ "lightning-liquidity",
  "lightning-rapid-gossip-sync",
+ "possiblyrandom",
 ]
 
 [[package]]
 name = "lightning-block-sync"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baab5bdee174a2047d939a4ca0dc2e1c23caa0f8cab0b4380aed77a20e116f1e"
+version = "0.3.0+git"
+source = "git+https://github.com/lightningdevkit/rust-lightning?rev=84605cf08d34b8db731ee4a4356a95125a8b02af#84605cf08d34b8db731ee4a4356a95125a8b02af"
 dependencies = [
  "bitcoin",
- "chunked_transfer",
- "lightning 0.1.5",
+ "bitreq",
+ "lightning",
  "serde_json",
 ]
 
 [[package]]
 name = "lightning-invoice"
-version = "0.33.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11209f386879b97198b2bfc9e9c1e5d42870825c6bd4376f17f95357244d6600"
+version = "0.35.0+git"
+source = "git+https://github.com/lightningdevkit/rust-lightning?rev=84605cf08d34b8db731ee4a4356a95125a8b02af#84605cf08d34b8db731ee4a4356a95125a8b02af"
 dependencies = [
  "bech32",
  "bitcoin",
- "lightning-types 0.2.0",
+ "lightning-types",
+ "serde",
 ]
 
 [[package]]
-name = "lightning-invoice"
-version = "0.34.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b85e5e14bcdb30d746e9785b04f27938292e8944f78f26517e01e91691f6b3f2"
+name = "lightning-liquidity"
+version = "0.3.0+git"
+source = "git+https://github.com/lightningdevkit/rust-lightning?rev=84605cf08d34b8db731ee4a4356a95125a8b02af#84605cf08d34b8db731ee4a4356a95125a8b02af"
 dependencies = [
- "bech32",
  "bitcoin",
- "lightning-types 0.3.1",
+ "bitreq",
+ "chrono",
+ "lightning",
+ "lightning-invoice",
+ "lightning-macros",
+ "lightning-types",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
 name = "lightning-macros"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4c717494cdc2c8bb85bee7113031248f5f6c64f8802b33c1c9e2d98e594aa71"
+version = "0.2.2+git"
+source = "git+https://github.com/lightningdevkit/rust-lightning?rev=84605cf08d34b8db731ee4a4356a95125a8b02af#84605cf08d34b8db731ee4a4356a95125a8b02af"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1975,52 +1981,40 @@ dependencies = [
 
 [[package]]
 name = "lightning-net-tokio"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb6a6c93b1e592f1d46bb24233cac4a33b4015c99488ee229927a81d16226e45"
+version = "0.3.0+git"
+source = "git+https://github.com/lightningdevkit/rust-lightning?rev=84605cf08d34b8db731ee4a4356a95125a8b02af#84605cf08d34b8db731ee4a4356a95125a8b02af"
 dependencies = [
  "bitcoin",
- "lightning 0.1.5",
+ "lightning",
  "tokio",
 ]
 
 [[package]]
 name = "lightning-persister"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6d78990de56ca75c5535c3f8e6f86b183a1aa8f521eb32afb9e8181f3bd91d7"
+version = "0.3.0+git"
+source = "git+https://github.com/lightningdevkit/rust-lightning?rev=84605cf08d34b8db731ee4a4356a95125a8b02af#84605cf08d34b8db731ee4a4356a95125a8b02af"
 dependencies = [
  "bitcoin",
- "lightning 0.2.2",
+ "lightning",
+ "tokio",
  "windows-sys 0.48.0",
 ]
 
 [[package]]
 name = "lightning-rapid-gossip-sync"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78dacdef3e2f5d727754f902f4e6bbc43bfc886fec8e71f36757711060916ebe"
+version = "0.3.0+git"
+source = "git+https://github.com/lightningdevkit/rust-lightning?rev=84605cf08d34b8db731ee4a4356a95125a8b02af#84605cf08d34b8db731ee4a4356a95125a8b02af"
 dependencies = [
  "bitcoin",
  "bitcoin-io",
  "bitcoin_hashes 0.14.0",
- "lightning 0.1.5",
+ "lightning",
 ]
 
 [[package]]
 name = "lightning-types"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2cd84d4e71472035903e43caded8ecc123066ce466329ccd5ae537a8d5488c7"
-dependencies = [
- "bitcoin",
-]
-
-[[package]]
-name = "lightning-types"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb1aac93f22f2c2eac8a0ee83bb1a1ea58673caa2c82847302710b83364d04e6"
+version = "0.4.0+git"
+source = "git+https://github.com/lightningdevkit/rust-lightning?rev=84605cf08d34b8db731ee4a4356a95125a8b02af#84605cf08d34b8db731ee4a4356a95125a8b02af"
 dependencies = [
  "bitcoin",
 ]
@@ -2419,8 +2413,7 @@ dependencies = [
 [[package]]
 name = "possiblyrandom"
 version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b122a615d72104fb3d8b26523fdf9232cd8ee06949fb37e4ce3ff964d15dffd"
+source = "git+https://github.com/lightningdevkit/rust-lightning?rev=84605cf08d34b8db731ee4a4356a95125a8b02af#84605cf08d34b8db731ee4a4356a95125a8b02af"
 dependencies = [
  "getrandom 0.2.16",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,3 +21,14 @@ default-members = [
         "lampo-bdk-wallet"
 ]
 resolver = "2"
+
+# LDK 0.3 is not yet published to crates.io; track the upstream `0.3` branch,
+# pinned to a commit for reproducible builds. Bump every lightning* crate
+# together so the stack stays on one version (see issue #537).
+[workspace.dependencies]
+lightning = { git = "https://github.com/lightningdevkit/rust-lightning", rev = "84605cf08d34b8db731ee4a4356a95125a8b02af" }
+lightning-block-sync = { git = "https://github.com/lightningdevkit/rust-lightning", rev = "84605cf08d34b8db731ee4a4356a95125a8b02af" }
+lightning-persister = { git = "https://github.com/lightningdevkit/rust-lightning", rev = "84605cf08d34b8db731ee4a4356a95125a8b02af", features = ["tokio"] }
+lightning-background-processor = { git = "https://github.com/lightningdevkit/rust-lightning", rev = "84605cf08d34b8db731ee4a4356a95125a8b02af" }
+lightning-net-tokio = { git = "https://github.com/lightningdevkit/rust-lightning", rev = "84605cf08d34b8db731ee4a4356a95125a8b02af" }
+lightning-rapid-gossip-sync = { git = "https://github.com/lightningdevkit/rust-lightning", rev = "84605cf08d34b8db731ee4a4356a95125a8b02af" }

--- a/lampo-bdk-wallet/Cargo.toml
+++ b/lampo-bdk-wallet/Cargo.toml
@@ -3,6 +3,10 @@ name = "lampo-bdk-wallet"
 version = "0.1.0"
 edition = "2021"
 
+[features]
+# Forward LDK's deterministic test-only channel keys (testing only).
+unsafe_channel_keys = ["lampo-common/unsafe_channel_keys"]
+
 [dependencies]
 lampo-common = { path = "../lampo-common" }
 bdk_wallet = { version = "2.3", features = ["rusqlite", "keys-bip39"] }

--- a/lampo-bdk-wallet/src/lib.rs
+++ b/lampo-bdk-wallet/src/lib.rs
@@ -107,10 +107,17 @@ impl BDKWalletManager {
         xprv: PrivateKey,
         channel_keys: Option<String>,
     ) -> error::Result<(PersistedWallet<Connection>, Connection, LampoKeys)> {
-        let ldk_keys = if channel_keys.is_some() {
-            LampoKeys::with_channel_keys(xprv.inner.secret_bytes(), channel_keys.unwrap())
-        } else {
-            LampoKeys::new(xprv.inner.secret_bytes())
+        let ldk_keys = match channel_keys {
+            #[cfg(feature = "unsafe_channel_keys")]
+            Some(keys) => LampoKeys::with_channel_keys(xprv.inner.secret_bytes(), keys),
+            #[cfg(not(feature = "unsafe_channel_keys"))]
+            Some(_) => {
+                log::warn!(
+                    "`channel_keys` is set but this build lacks the `unsafe_channel_keys` feature; using random keys"
+                );
+                LampoKeys::new(xprv.inner.secret_bytes())
+            }
+            None => LampoKeys::new(xprv.inner.secret_bytes()),
         };
 
         let mut db = Connection::open_in_memory()?;

--- a/lampo-chain/Cargo.toml
+++ b/lampo-chain/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 [dependencies]
 lampo-common = { path = "../lampo-common" }
 lampod = { path = "../lampod" }
-lightning-block-sync = { version = "0.1", features = [ "rpc-client" ] }
+lightning-block-sync = { workspace = true, features = [ "rpc-client" ] }
 log = "0.4.17"
 tokio ={ version = "*"}
 base64 = "*"

--- a/lampo-chain/src/lib.rs
+++ b/lampo-chain/src/lib.rs
@@ -2,10 +2,9 @@ use std::sync::{Arc, OnceLock};
 
 use lampo_common::event::onchain::OnChainEvent;
 use lampo_common::event::Event;
-use lightning_block_sync::http::HttpEndpoint;
 use lightning_block_sync::init;
 use lightning_block_sync::rpc::RpcClient;
-use lightning_block_sync::{poll, AsyncBlockSourceResult, BlockHeaderData, UnboundedCache};
+use lightning_block_sync::{poll, BlockHeaderData, BlockSourceResult};
 use lightning_block_sync::{BlockSource, SpvClient};
 
 use lampo_common::async_trait;
@@ -49,10 +48,10 @@ impl LampoChainSync {
 
         log::debug!("Connecting to core at: {:?} - {host}", url_parts);
 
-        let http_endpoint = HttpEndpoint::for_host(host.to_owned()).with_port(port);
+        let base_url = format!("http://{host}:{port}");
         let rpc_credentials = base64::encode(format!("{}:{}", core_user, core_pass));
 
-        let rpc = RpcClient::new(&rpc_credentials, http_endpoint);
+        let rpc = RpcClient::new(&rpc_credentials, base_url);
 
         Ok(Self {
             config: conf,
@@ -95,19 +94,22 @@ impl BlockSource for LampoChainSync {
         &'a self,
         header_hash: &'a BlockHash,
         height_hint: Option<u32>,
-    ) -> AsyncBlockSourceResult<'a, BlockHeaderData> {
-        Box::pin(async move { self.rpc_client.get_header(header_hash, height_hint).await })
+    ) -> impl std::future::Future<Output = BlockSourceResult<BlockHeaderData>> + Send + 'a {
+        async move { self.rpc_client.get_header(header_hash, height_hint).await }
     }
 
     fn get_block<'a>(
         &'a self,
         header_hash: &'a BlockHash,
-    ) -> AsyncBlockSourceResult<'a, BlockData> {
-        Box::pin(async move { self.rpc_client.get_block(header_hash).await })
+    ) -> impl std::future::Future<Output = BlockSourceResult<BlockData>> + Send + 'a {
+        async move { self.rpc_client.get_block(header_hash).await }
     }
 
-    fn get_best_block<'a>(&'a self) -> AsyncBlockSourceResult<(BlockHash, Option<u32>)> {
-        Box::pin(async move { self.rpc_client.get_best_block().await })
+    fn get_best_block<'a>(
+        &'a self,
+    ) -> impl std::future::Future<Output = BlockSourceResult<(BlockHash, Option<u32>)>> + Send + 'a
+    {
+        async move { self.rpc_client.get_best_block().await }
     }
 }
 
@@ -115,6 +117,10 @@ impl BlockSource for LampoChainSync {
 impl Backend for LampoChainSync {
     fn kind(&self) -> lampo_common::backend::BackendKind {
         lampo_common::backend::BackendKind::Core
+    }
+
+    async fn get_best_block(&self) -> BlockSourceResult<(BlockHash, Option<u32>)> {
+        self.rpc_client.get_best_block().await
     }
 
     async fn brodcast_tx(&self, tx: &lampo_common::bitcoin::Transaction) {
@@ -214,7 +220,6 @@ impl Backend for LampoChainSync {
     }
 
     async fn listen(self: Arc<Self>) -> lampo_common::error::Result<()> {
-        let mut cache = UnboundedCache::new();
         let channel_manager = self.channel_manager();
         let chain_monitor = self.chain_monitor();
 
@@ -226,13 +231,13 @@ impl Backend for LampoChainSync {
         // N+M+1 to the ChannelManager which still thinks it's at block N,
         // causing a "Blocks must be connected in chain-order" assertion.
         let manager_best = channel_manager.current_best_block();
-        let chain_listeners: Vec<(BlockHash, &(dyn chain::Listen + Send + Sync))> = vec![
+        let chain_listeners: Vec<(chain::BlockLocator, &(dyn chain::Listen + Send + Sync))> = vec![
             (
-                manager_best.block_hash,
+                manager_best.clone(),
                 &*channel_manager as &(dyn chain::Listen + Send + Sync),
             ),
             (
-                manager_best.block_hash,
+                manager_best.clone(),
                 &*chain_monitor as &(dyn chain::Listen + Send + Sync),
             ),
         ];
@@ -244,27 +249,16 @@ impl Backend for LampoChainSync {
             manager_best.height
         );
 
-        let synced_chain_tip = init::synchronize_listeners(
-            self.as_ref(),
-            self.config.network,
-            &mut cache,
-            chain_listeners,
-        )
-        .await
-        .map_err(|e| error::anyhow!("Failed to synchronize chain listeners: {:?}", e))?;
+        let (cache, synced_chain_tip) =
+            init::synchronize_listeners(self.as_ref(), self.config.network, chain_listeners)
+                .await
+                .map_err(|e| error::anyhow!("Failed to synchronize chain listeners: {:?}", e))?;
 
-        let synced_best = synced_chain_tip.to_best_block();
-        log::info!(
-            target: "lampo-chain",
-            "Chain listeners synced to block {} (height {})",
-            synced_best.block_hash,
-            synced_best.height
-        );
+        log::info!(target: "lampo-chain", "Chain listeners synced to current tip");
 
         let chain_listener = (chain_monitor, channel_manager);
         let chain_poller = poll::ChainPoller::new(self.as_ref(), self.config.network);
-        let mut spv_client =
-            SpvClient::new(synced_chain_tip, chain_poller, &mut cache, &chain_listener);
+        let mut spv_client = SpvClient::new(synced_chain_tip, chain_poller, cache, &chain_listener);
         log::info!(target: "lampo-chain", "Start Backend ...");
         loop {
             if let Err(err) = spv_client.poll_best_tip().await {

--- a/lampo-common/Cargo.toml
+++ b/lampo-common/Cargo.toml
@@ -5,13 +5,18 @@ edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[features]
+# Deterministic channel keys for testing only. Enables LDK's test-only
+# InMemorySigner constructor; never enable in production builds.
+unsafe_channel_keys = ["lightning/_test_utils"]
+
 [dependencies]
-lightning = { version = "0.1.5", features = [] }
-lightning-block-sync = { version = "0.1.0" }
-lightning-persister = { version = "0.2.0" }
-lightning-background-processor = { version = "0.1", features = ["futures"] }
-lightning-net-tokio = { version = "0.1.0" }
-lightning-rapid-gossip-sync = { version = "0.1.0" }
+lightning = { workspace = true, features = [] }
+lightning-block-sync = { workspace = true }
+lightning-persister = { workspace = true }
+lightning-background-processor = { workspace = true }
+lightning-net-tokio = { workspace = true }
+lightning-rapid-gossip-sync = { workspace = true }
 
 async-trait = "0.1"
 bitcoin = { version = "0.32", features = ["serde"] }

--- a/lampo-common/src/backend.rs
+++ b/lampo-common/src/backend.rs
@@ -10,10 +10,7 @@ pub use bitcoin::consensus::{deserialize, serialize};
 pub use bitcoin::{Block, BlockHash, Script, Transaction, Txid};
 pub use lightning::chain::WatchedOutput;
 pub use lightning::routing::utxo::UtxoResult;
-use lightning_block_sync::BlockSource;
-pub use lightning_block_sync::{
-    AsyncBlockSourceResult, BlockData, BlockHeaderData, BlockSourceResult,
-};
+pub use lightning_block_sync::{BlockData, BlockHeaderData, BlockSourceResult};
 use serde::{Deserialize, Serialize};
 
 use crate::error;
@@ -35,9 +32,16 @@ pub enum BackendKind {
 // FIXME: add the BlockSource trait for this
 /// Bakend Trait specification
 #[async_trait]
-pub trait Backend: BlockSource + Send + Sync {
+pub trait Backend: Send + Sync {
     /// Return the kind of backend
     fn kind(&self) -> BackendKind;
+
+    /// Return the hash of the best block and, optionally, its height.
+    ///
+    /// LDK 0.3's `BlockSource` is no longer object-safe (it returns `impl
+    /// Future`), so `Backend` exposes this as an object-safe async method and
+    /// concrete backends implement `BlockSource` separately for chain sync.
+    async fn get_best_block(&self) -> BlockSourceResult<(BlockHash, Option<u32>)>;
 
     /// Fetch feerate give a number of blocks
     ///

--- a/lampo-common/src/keys.rs
+++ b/lampo-common/src/keys.rs
@@ -1,6 +1,7 @@
 use std::{sync::Arc, time::SystemTime};
 
-use bitcoin::secp256k1::{Secp256k1, SecretKey};
+#[cfg(feature = "unsafe_channel_keys")]
+use bitcoin::secp256k1::SecretKey;
 use lightning::bolt11_invoice;
 use lightning::sign::{InMemorySigner, NodeSigner, OutputSpender, SignerProvider};
 
@@ -27,7 +28,7 @@ impl LampoKeys {
         }
     }
 
-    // FIXME: add this under a feature flag
+    #[cfg(feature = "unsafe_channel_keys")]
     pub fn with_channel_keys(seed: [u8; 32], channels_keys: String) -> Self {
         // Fill in random_32_bytes with secure random data, or, on restart, reload the seed from disk.
         let start_time = SystemTime::now()
@@ -59,29 +60,43 @@ impl LampoKeys {
 pub struct LampoKeysManager {
     pub(crate) inner: KeysManager,
 
+    #[cfg(feature = "unsafe_channel_keys")]
     funding_key: Option<SecretKey>,
+    #[cfg(feature = "unsafe_channel_keys")]
     revocation_base_secret: Option<SecretKey>,
+    #[cfg(feature = "unsafe_channel_keys")]
     payment_base_secret: Option<SecretKey>,
+    #[cfg(feature = "unsafe_channel_keys")]
     delayed_payment_base_secret: Option<SecretKey>,
+    #[cfg(feature = "unsafe_channel_keys")]
     htlc_base_secret: Option<SecretKey>,
+    #[cfg(feature = "unsafe_channel_keys")]
     shachain_seed: Option<[u8; 32]>,
 }
 
 impl LampoKeysManager {
     pub fn new(seed: &[u8; 32], starting_time_secs: u64, starting_time_nanos: u32) -> Self {
-        let inner = KeysManager::new(seed, starting_time_secs, starting_time_nanos);
+        // `false` keeps the pre-0.3 (v1) channel key derivation so existing
+        // channels keep deriving the same keys after the LDK upgrade.
+        let inner = KeysManager::new(seed, starting_time_secs, starting_time_nanos, false);
         Self {
             inner,
+            #[cfg(feature = "unsafe_channel_keys")]
             funding_key: None,
+            #[cfg(feature = "unsafe_channel_keys")]
             revocation_base_secret: None,
+            #[cfg(feature = "unsafe_channel_keys")]
             payment_base_secret: None,
+            #[cfg(feature = "unsafe_channel_keys")]
             delayed_payment_base_secret: None,
+            #[cfg(feature = "unsafe_channel_keys")]
             htlc_base_secret: None,
+            #[cfg(feature = "unsafe_channel_keys")]
             shachain_seed: None,
         }
     }
 
-    // FIXME: put this under a debug a feature flag like `unsafe_channel_keys`
+    #[cfg(feature = "unsafe_channel_keys")]
     pub fn set_channels_keys(
         &mut self,
         funding_key: String,
@@ -110,6 +125,18 @@ impl EntropySource for LampoKeysManager {
 }
 
 impl NodeSigner for LampoKeysManager {
+    fn get_expanded_key(&self) -> lightning::ln::inbound_payment::ExpandedKey {
+        self.inner.get_expanded_key()
+    }
+
+    fn get_peer_storage_key(&self) -> lightning::sign::PeerStorageKey {
+        self.inner.get_peer_storage_key()
+    }
+
+    fn get_receive_auth_key(&self) -> lightning::sign::ReceiveAuthKey {
+        self.inner.get_receive_auth_key()
+    }
+
     fn ecdh(
         &self,
         recipient: lightning::sign::Recipient,
@@ -117,10 +144,6 @@ impl NodeSigner for LampoKeysManager {
         tweak: Option<&bitcoin::secp256k1::Scalar>,
     ) -> Result<bitcoin::secp256k1::ecdh::SharedSecret, ()> {
         self.inner.ecdh(recipient, other_key, tweak)
-    }
-
-    fn get_inbound_payment_key(&self) -> lightning::ln::inbound_payment::ExpandedKey {
-        self.inner.get_inbound_payment_key()
     }
 
     fn get_node_id(
@@ -151,17 +174,21 @@ impl NodeSigner for LampoKeysManager {
     ) -> Result<bitcoin::secp256k1::ecdsa::RecoverableSignature, ()> {
         self.inner.sign_invoice(invoice, recipient)
     }
+
+    fn sign_message(&self, msg: &[u8]) -> Result<String, ()> {
+        self.inner.sign_message(msg)
+    }
 }
 
 impl OutputSpender for LampoKeysManager {
-    fn spend_spendable_outputs<C: bitcoin::secp256k1::Signing>(
+    fn spend_spendable_outputs(
         &self,
         descriptors: &[&lightning::sign::SpendableOutputDescriptor],
         outputs: Vec<bitcoin::TxOut>,
         change_destination_script: bitcoin::ScriptBuf,
         feerate_sat_per_1000_weight: u32,
         locktime: Option<bitcoin::absolute::LockTime>,
-        secp_ctx: &bitcoin::secp256k1::Secp256k1<C>,
+        secp_ctx: &bitcoin::secp256k1::Secp256k1<bitcoin::secp256k1::All>,
     ) -> Result<bitcoin::Transaction, ()> {
         self.inner.spend_spendable_outputs(
             descriptors,
@@ -178,42 +205,35 @@ impl SignerProvider for LampoKeysManager {
     // FIXME: this should be the same of the inner
     type EcdsaSigner = InMemorySigner;
 
-    fn derive_channel_signer(
-        &self,
-        channel_value_satoshis: u64,
-        channel_keys_id: [u8; 32],
-    ) -> Self::EcdsaSigner {
+    fn derive_channel_signer(&self, channel_keys_id: [u8; 32]) -> Self::EcdsaSigner {
+        #[cfg(feature = "unsafe_channel_keys")]
         if self.funding_key.is_some() {
             // FIXME(vincenzopalazzo): make this a general
             let commitment_seed = [
                 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
                 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
             ];
+            // LDK 0.3 split the payment key into v1/v2; with v2 derivation
+            // disabled the v1 key is the one in use, so reuse it for both.
             return InMemorySigner::new(
-                &Secp256k1::new(),
                 self.funding_key.unwrap(),
                 self.revocation_base_secret.unwrap(),
                 self.payment_base_secret.unwrap(),
+                self.payment_base_secret.unwrap(),
+                false,
                 self.delayed_payment_base_secret.unwrap(),
                 self.htlc_base_secret.unwrap(),
                 commitment_seed,
-                channel_value_satoshis,
                 channel_keys_id,
                 self.shachain_seed.unwrap(),
             );
         }
-        self.inner
-            .derive_channel_signer(channel_value_satoshis, channel_keys_id)
+        self.inner.derive_channel_signer(channel_keys_id)
     }
 
-    fn generate_channel_keys_id(
-        &self,
-        inbound: bool,
-        channel_value_satoshis: u64,
-        user_channel_id: u128,
-    ) -> [u8; 32] {
+    fn generate_channel_keys_id(&self, inbound: bool, user_channel_id: u128) -> [u8; 32] {
         self.inner
-            .generate_channel_keys_id(inbound, channel_value_satoshis, user_channel_id)
+            .generate_channel_keys_id(inbound, user_channel_id)
     }
 
     fn get_destination_script(&self, channel_keys_id: [u8; 32]) -> Result<bitcoin::ScriptBuf, ()> {
@@ -222,12 +242,5 @@ impl SignerProvider for LampoKeysManager {
 
     fn get_shutdown_scriptpubkey(&self) -> Result<lightning::ln::script::ShutdownScript, ()> {
         self.inner.get_shutdown_scriptpubkey()
-    }
-
-    fn read_chan_signer(
-        &self,
-        reader: &[u8],
-    ) -> Result<Self::EcdsaSigner, lightning::ln::msgs::DecodeError> {
-        self.inner.read_chan_signer(reader)
     }
 }

--- a/lampo-common/src/types.rs
+++ b/lampo-common/src/types.rs
@@ -8,7 +8,7 @@ use crate::bitcoin::secp256k1::PublicKey;
 use crate::ldk::chain::chainmonitor::ChainMonitor;
 use crate::ldk::chain::Filter;
 use crate::ldk::ln::channelmanager::ChannelManager;
-use crate::ldk::persister::fs_store::FilesystemStore;
+use crate::ldk::persister::fs_store::v1::FilesystemStore;
 use crate::ldk::routing::gossip::NetworkGraph;
 use crate::ldk::routing::router::DefaultRouter;
 use crate::ldk::routing::scoring::{ProbabilisticScorer, ProbabilisticScoringFeeParameters};
@@ -27,6 +27,7 @@ pub type LampoChainMonitor = ChainMonitor<
     Arc<dyn FeeEstimator + Send + Sync>,
     Arc<LampoLogger>,
     Arc<FilesystemStore>,
+    Arc<LampoKeysManager>,
 >;
 
 pub type LampoArcChannelManager<M, L> = ChannelManager<

--- a/lampod/Cargo.toml
+++ b/lampod/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-tokio = { version = "^1.50.0", features = ["rt-multi-thread", "parking_lot"] }
+tokio = { version = "^1.50.0", features = ["rt-multi-thread", "parking_lot", "macros"] }
 lampo-common = { path = "../lampo-common" }
 log = "0.4.17"
 time = "0.3.43"

--- a/lampod/src/actions/handler.rs
+++ b/lampod/src/actions/handler.rs
@@ -119,19 +119,27 @@ impl Handler for LampoHandler {
             ldk::events::Event::OpenChannelRequest {
                 temporary_channel_id,
                 counterparty_node_id,
-                funding_satoshis,
-                channel_type,
-                channel_negotiation_type: _,
-                is_announced: _,
-                params: _
+                ..
             } => {
-                Err(error::anyhow!("Request for open a channel received, unfortunatly we do not support this feature yet."))
+                // LDK 0.3 removed `manually_accept_inbound_channels`; inbound
+                // channels are now always surfaced here and must be accepted
+                // explicitly. Auto-accept to preserve the previous behaviour.
+                log::info!(
+                    target: "lampod",
+                    "accepting inbound channel request from `{counterparty_node_id}`"
+                );
+                self.channel_manager
+                    .manager()
+                    .accept_inbound_channel(&temporary_channel_id, &counterparty_node_id, 0, None)
+                    .map_err(|err| error::anyhow!("{:?}", err))?;
+                Ok(())
             }
             ldk::events::Event::ChannelReady {
                 channel_id,
                 user_channel_id,
                 counterparty_node_id,
                 channel_type,
+                ..
             } => {
                 log::info!("channel ready with node `{counterparty_node_id}`, and channel type {channel_type}");
                 self.emit(Event::Lightning(LightningEvent::ChannelReady {
@@ -140,7 +148,7 @@ impl Handler for LampoHandler {
                     channel_type,
                 }));
                 Ok(())
-            },
+            }
             ldk::events::Event::ChannelClosed {
                 channel_id,
                 user_channel_id,
@@ -156,53 +164,68 @@ impl Handler for LampoHandler {
                 // Provide detailed closure reason based on the ClosureReason enum
                 let detailed_reason = match reason {
                     ldk::events::ClosureReason::CounterpartyForceClosed { peer_msg } => {
-                        format!("Counterparty force-closed the channel. Peer message: {}", peer_msg)
-                    },
-                    ldk::events::ClosureReason::HolderForceClosed { broadcasted_latest_txn } => {
+                        format!(
+                            "Counterparty force-closed the channel. Peer message: {}",
+                            peer_msg
+                        )
+                    }
+                    ldk::events::ClosureReason::HolderForceClosed {
+                        broadcasted_latest_txn,
+                        ..
+                    } => {
                         let broadcast_status = match broadcasted_latest_txn {
                             Some(true) => "with broadcasting latest transaction",
                             Some(false) => "without broadcasting latest transaction",
-                            None => "broadcast status unknown"
+                            None => "broadcast status unknown",
                         };
                         format!("We force-closed the channel {}", broadcast_status)
-                    },
+                    }
                     ldk::events::ClosureReason::LegacyCooperativeClosure => {
                         "Channel closed cooperatively (legacy closure)".to_string()
-                    },
+                    }
                     ldk::events::ClosureReason::CounterpartyInitiatedCooperativeClosure => {
                         "Counterparty initiated cooperative channel closure".to_string()
-                    },
+                    }
                     ldk::events::ClosureReason::LocallyInitiatedCooperativeClosure => {
                         "We initiated cooperative channel closure".to_string()
-                    },
+                    }
                     ldk::events::ClosureReason::CommitmentTxConfirmed => {
-                        "Channel closed due to commitment transaction confirmation on-chain".to_string()
-                    },
+                        "Channel closed due to commitment transaction confirmation on-chain"
+                            .to_string()
+                    }
                     ldk::events::ClosureReason::FundingTimedOut => {
                         "Channel funding transaction failed to confirm in time".to_string()
-                    },
+                    }
                     ldk::events::ClosureReason::ProcessingError { err } => {
                         format!("Channel closed due to processing error: {}", err)
-                    },
+                    }
                     ldk::events::ClosureReason::DisconnectedPeer => {
                         "Peer disconnected before funding completed, channel forgotten".to_string()
-                    },
+                    }
                     ldk::events::ClosureReason::OutdatedChannelManager => {
-                        "Channel closed due to outdated ChannelManager (ChannelMonitor is newer)".to_string()
-                    },
+                        "Channel closed due to outdated ChannelManager (ChannelMonitor is newer)"
+                            .to_string()
+                    }
                     ldk::events::ClosureReason::CounterpartyCoopClosedUnfundedChannel => {
                         "Counterparty requested cooperative close of unfunded channel".to_string()
-                    },
+                    }
+                    ldk::events::ClosureReason::LocallyCoopClosedUnfundedChannel => {
+                        "We requested cooperative close of an unfunded channel".to_string()
+                    }
                     ldk::events::ClosureReason::FundingBatchClosure => {
-                        "Channel closed because another channel in the same funding batch closed".to_string()
-                    },
-                    ldk::events::ClosureReason::HTLCsTimedOut => {
+                        "Channel closed because another channel in the same funding batch closed"
+                            .to_string()
+                    }
+                    ldk::events::ClosureReason::HTLCsTimedOut { .. } => {
                         "Channel closed due to HTLC timeout".to_string()
-                    },
-                    ldk::events::ClosureReason::PeerFeerateTooLow { peer_feerate_sat_per_kw, required_feerate_sat_per_kw } => {
+                    }
+                    ldk::events::ClosureReason::PeerFeerateTooLow {
+                        peer_feerate_sat_per_kw,
+                        required_feerate_sat_per_kw,
+                    } => {
                         format!("Channel closed due to peer's feerate too low. Peer feerate: {} sat/kw, Required: {} sat/kw",
                                peer_feerate_sat_per_kw, required_feerate_sat_per_kw)
-                    },
+                    }
                 };
 
                 let node_id = counterparty_node_id.map(|id| id.to_string());
@@ -211,7 +234,7 @@ impl Handler for LampoHandler {
                     channel_id: channel_id.to_string(),
                     message: detailed_reason.clone(),
                     counterparty_node_id: node_id,
-                    funding_utxo: txo
+                    funding_utxo: txo,
                 }));
                 log::info!("channel `{user_channel_id}` closed: {}", detailed_reason);
                 Ok(())
@@ -231,22 +254,36 @@ impl Handler for LampoHandler {
 
                 log::info!("propagate funding transaction for open a channel with `{counterparty_node_id}`");
                 // FIXME: estimate the fee rate with a callback
-                let fee = self.chain_manager.backend.fee_rate_estimation(6).await.map_err(|err| {
-                    let msg = format!("Channel Opening Error: {err}");
-                    self.emit(Event::Lightning(LightningEvent::ChannelEvent { state: "error".to_owned(), message : msg}));
-                    err
-                })?;
+                let fee = self
+                    .chain_manager
+                    .backend
+                    .fee_rate_estimation(6)
+                    .await
+                    .map_err(|err| {
+                        let msg = format!("Channel Opening Error: {err}");
+                        self.emit(Event::Lightning(LightningEvent::ChannelEvent {
+                            state: "error".to_owned(),
+                            message: msg,
+                        }));
+                        err
+                    })?;
                 log::info!("fee estimated {:?} sats", fee);
 
                 let best_block = self.channel_manager.manager().current_best_block().height;
-                let transaction = self.wallet_manager.create_transaction(
-                    output_script,
-                    Amount::from_sat(channel_value_satoshis),
-                    FeeRate::from_sat_per_vb_unchecked(fee as u64),
-                    // FIXME: remove unwrap
-                    Height::from_consensus(best_block).unwrap(),
-                ).await?;
-                log::info!("funding transaction created `{}`", transaction.compute_txid());
+                let transaction = self
+                    .wallet_manager
+                    .create_transaction(
+                        output_script,
+                        Amount::from_sat(channel_value_satoshis),
+                        FeeRate::from_sat_per_vb_unchecked(fee as u64),
+                        // FIXME: remove unwrap
+                        Height::from_consensus(best_block).unwrap(),
+                    )
+                    .await?;
+                log::info!(
+                    "funding transaction created `{}`",
+                    transaction.compute_txid()
+                );
                 log::info!(
                     "transaction hex `{}`",
                     lampo_common::bitcoin::consensus::encode::serialize_hex(&transaction)
@@ -276,13 +313,10 @@ impl Handler for LampoHandler {
                     "channel pending with node `{}` with funding `{funding_txo}`",
                     counterparty_node_id.to_string()
                 );
-                self.emit(Event::Lightning(LightningEvent::ChannelPending { counterparty_node_id, funding_transaction: funding_txo }));
-                Ok(())
-            }
-            ldk::events::Event::PendingHTLCsForwardable { time_forwardable } => {
-                self.channel_manager
-                    .manager()
-                    .process_pending_htlc_forwards();
+                self.emit(Event::Lightning(LightningEvent::ChannelPending {
+                    counterparty_node_id,
+                    funding_transaction: funding_txo,
+                }));
                 Ok(())
             }
             ldk::events::Event::PaymentClaimable {
@@ -292,17 +326,20 @@ impl Handler for LampoHandler {
                 amount_msat,
                 counterparty_skimmed_fee_msat,
                 purpose,
-                via_channel_id,
-                via_user_channel_id,
                 claim_deadline,
                 payment_id: _,
+                ..
             } => {
                 let preimage = match purpose {
-                    ldk::events::PaymentPurpose::Bolt11InvoicePayment  {
+                    ldk::events::PaymentPurpose::Bolt11InvoicePayment {
                         payment_preimage, ..
                     } => payment_preimage,
-                    ldk::events::PaymentPurpose::Bolt12OfferPayment { payment_preimage, .. } => payment_preimage,
-                    ldk::events::PaymentPurpose::Bolt12RefundPayment { payment_preimage, .. } => payment_preimage,
+                    ldk::events::PaymentPurpose::Bolt12OfferPayment {
+                        payment_preimage, ..
+                    } => payment_preimage,
+                    ldk::events::PaymentPurpose::Bolt12RefundPayment {
+                        payment_preimage, ..
+                    } => payment_preimage,
                     ldk::events::PaymentPurpose::SpontaneousPayment(preimage) => Some(preimage),
                 };
                 self.channel_manager
@@ -323,9 +360,19 @@ impl Handler for LampoHandler {
                         payment_secret,
                         ..
                     } => (payment_preimage, Some(payment_secret)),
-                    ldk::events::PaymentPurpose::Bolt12OfferPayment { payment_preimage, payment_secret, .. } => (payment_preimage, Some(payment_secret)),
-                    ldk::events::PaymentPurpose::Bolt12RefundPayment { payment_preimage, payment_secret, .. } => (payment_preimage, Some(payment_secret)),
-                    ldk::events::PaymentPurpose::SpontaneousPayment(preimage) => (Some(preimage), None),
+                    ldk::events::PaymentPurpose::Bolt12OfferPayment {
+                        payment_preimage,
+                        payment_secret,
+                        ..
+                    } => (payment_preimage, Some(payment_secret)),
+                    ldk::events::PaymentPurpose::Bolt12RefundPayment {
+                        payment_preimage,
+                        payment_secret,
+                        ..
+                    } => (payment_preimage, Some(payment_secret)),
+                    ldk::events::PaymentPurpose::SpontaneousPayment(preimage) => {
+                        (Some(preimage), None)
+                    }
                 };
                 log::warn!("please note the payments are not make persistent for the moment");
                 // FIXME: make peristent these information
@@ -334,14 +381,29 @@ impl Handler for LampoHandler {
             ldk::events::Event::PaymentSent { .. } => {
                 log::info!("payment sent: `{:?}`", event);
                 Ok(())
-            },
-            ldk::events::Event::PaymentPathSuccessful { payment_hash, path, .. } => {
-                let path = path.hops.iter().map(|hop| PaymentHop::from(hop.clone())).collect::<Vec<PaymentHop>>();
-                let hop = LightningEvent::PaymentEvent { state: PaymentState::Success, payment_hash: payment_hash.map(|hash| hash.to_string()), path, reason: None };
+            }
+            ldk::events::Event::PaymentPathSuccessful {
+                payment_hash, path, ..
+            } => {
+                let path = path
+                    .hops
+                    .iter()
+                    .map(|hop| PaymentHop::from(hop.clone()))
+                    .collect::<Vec<PaymentHop>>();
+                let hop = LightningEvent::PaymentEvent {
+                    state: PaymentState::Success,
+                    payment_hash: payment_hash.map(|hash| hash.to_string()),
+                    path,
+                    reason: None,
+                };
                 self.emit(Event::Lightning(hop));
                 Ok(())
-            },
-            ldk::events::Event::PaymentFailed { payment_id, payment_hash, reason } => {
+            }
+            ldk::events::Event::PaymentFailed {
+                payment_id,
+                payment_hash,
+                reason,
+            } => {
                 log::error!("payment failed: {:?} with reason: {:?}", payment_id, reason);
 
                 // Provide detailed failure reason based on PaymentFailureReason enum
@@ -387,15 +449,15 @@ impl Handler for LampoHandler {
                     state: PaymentState::Failure,
                     payment_hash: payment_hash.map(|hash| hash.to_string()),
                     path: vec![],
-                    reason: Some(detailed_reason)
+                    reason: Some(detailed_reason),
                 };
                 self.emit(Event::Lightning(hop));
                 Ok(())
-            },
+            }
             _ => {
                 log::warn!(target: "lampo::handler", "unhandled ldk event: {:?}", event);
                 Ok(())
-            },
+            }
         }
     }
 }

--- a/lampod/src/chain/blockchain.rs
+++ b/lampod/src/chain/blockchain.rs
@@ -7,15 +7,12 @@ use lampo_common::bitcoin;
 use lampo_common::bitcoin::blockdata::constants::ChainHash;
 use lampo_common::bitcoin::Transaction;
 use lampo_common::error;
-use lampo_common::ldk;
-use lampo_common::ldk::block_sync::BlockSource;
 use lampo_common::ldk::chain::chaininterface::{
-    BroadcasterInterface, ConfirmationTarget, FeeEstimator,
+    BroadcasterInterface, ConfirmationTarget, FeeEstimator, TransactionType,
 };
 use lampo_common::ldk::routing::utxo::UtxoLookup;
+use lampo_common::ldk::util::wakers::Notifier;
 use lampo_common::wallet::WalletManager;
-
-use crate::sync;
 
 #[derive(Clone)]
 pub struct LampoChainManager {
@@ -88,11 +85,11 @@ impl FeeEstimator for LampoChainManager {
 
 /// Brodcaster Interface implementation for Lampo.
 impl BroadcasterInterface for LampoChainManager {
-    fn broadcast_transactions(&self, txs: &[&Transaction]) {
+    fn broadcast_transactions(&self, txs: &[(&Transaction, TransactionType)]) {
         // FIXME: support brodcast_txs for multiple tx
         // FIXME: we are missing any error in the brodcast_tx, we should
         // fix that
-        for tx in txs.to_vec() {
+        for (tx, _) in txs.to_vec() {
             let tx = tx.clone();
             let backend = self.backend.clone();
             tokio::spawn(async move {
@@ -103,31 +100,13 @@ impl BroadcasterInterface for LampoChainManager {
     }
 }
 
-impl BlockSource for LampoChainManager {
-    fn get_best_block<'a>(
-        &'a self,
-    ) -> ldk::block_sync::AsyncBlockSourceResult<(bitcoin::BlockHash, Option<u32>)> {
-        sync!(self.backend.get_best_block().await)
-    }
-
-    fn get_block<'a>(
-        &'a self,
-        header_hash: &'a bitcoin::BlockHash,
-    ) -> ldk::block_sync::AsyncBlockSourceResult<'a, ldk::block_sync::BlockData> {
-        sync!(self.backend.get_block(header_hash).await)
-    }
-
-    fn get_header<'a>(
-        &'a self,
-        header_hash: &'a bitcoin::BlockHash,
-        height_hint: Option<u32>,
-    ) -> ldk::block_sync::AsyncBlockSourceResult<'a, ldk::block_sync::BlockHeaderData> {
-        sync!(self.backend.get_header(header_hash, height_hint).await)
-    }
-}
-
 impl UtxoLookup for LampoChainManager {
-    fn get_utxo(&self, _: &ChainHash, _: u64) -> lampo_common::backend::UtxoResult {
+    fn get_utxo(
+        &self,
+        _: &ChainHash,
+        _: u64,
+        _: Arc<Notifier>,
+    ) -> lampo_common::backend::UtxoResult {
         unimplemented!()
     }
 }
@@ -167,6 +146,12 @@ impl Backend for LampoChainManager {
 
     fn kind(&self) -> lampo_common::backend::BackendKind {
         self.backend.kind()
+    }
+
+    async fn get_best_block(
+        &self,
+    ) -> lampo_common::backend::BlockSourceResult<(bitcoin::BlockHash, Option<u32>)> {
+        self.backend.get_best_block().await
     }
 
     async fn listen(self: Arc<Self>) -> lampo_common::error::Result<()> {

--- a/lampod/src/jsonrpc/offchain.rs
+++ b/lampod/src/jsonrpc/offchain.rs
@@ -37,7 +37,7 @@ pub async fn json_offer(ctx: &LampoDaemon, request: &json::Value) -> Result<json
     let request: GenerateOffer = json::from_value(request.clone())?;
     let manager = ctx.channel_manager().manager();
     let mut offer_builder = manager
-        .create_offer_builder(None)
+        .create_offer_builder()
         .map_err(|err| crate::rpc_error!("{:?}", err))?;
 
     if let Some(description) = request.description {

--- a/lampod/src/lib.rs
+++ b/lampod/src/lib.rs
@@ -28,9 +28,10 @@ use lampo_common::backend::Backend;
 use lampo_common::conf::LampoConf;
 use lampo_common::handler::ExternalHandler;
 use lampo_common::json;
+use lampo_common::keys::LampoKeysManager;
 use lampo_common::ldk::events::{Event, ReplayEvent};
 use lampo_common::ldk::io;
-use lampo_common::ldk::processor::{process_events_async, GossipSync};
+use lampo_common::ldk::processor::{process_events_async, GossipSync, NO_LIQUIDITY_MANAGER};
 use lampo_common::types::LampoGraph;
 use lampo_common::utils;
 use lampo_common::wallet::WalletManager;
@@ -46,6 +47,34 @@ use crate::utils::logger::LampoLogger;
 
 pub(crate) type P2PGossipSync =
     ldk::routing::gossip::P2PGossipSync<Arc<LampoGraph>, Arc<LampoChainManager>, Arc<LampoLogger>>;
+
+/// No-op [`ChangeDestinationSource`] used only to *name* the `OutputSweeper`
+/// type when passing `sweeper: None` to the background processor. Lampo does
+/// not run an output sweeper, so this is never constructed or called.
+///
+/// [`ChangeDestinationSource`]: lampo_common::ldk::sign::ChangeDestinationSource
+struct NoChangeDestinationSource;
+
+impl ldk::sign::ChangeDestinationSource for NoChangeDestinationSource {
+    fn get_change_destination_script<'a>(
+        &'a self,
+    ) -> impl std::future::Future<Output = Result<lampo_common::bitcoin::ScriptBuf, ()>> + Send + 'a
+    {
+        std::future::ready(Err(()))
+    }
+}
+
+/// Concrete `OutputSweeper` type matching lampo's chain-monitor wiring, used
+/// solely to type the `None` sweeper argument to [`process_events_async`].
+type LampoSweeper = ldk::util::sweep::OutputSweeper<
+    Arc<dyn ldk::chain::chaininterface::BroadcasterInterface + Send + Sync>,
+    Arc<NoChangeDestinationSource>,
+    Arc<dyn ldk::chain::chaininterface::FeeEstimator + Send + Sync>,
+    Arc<dyn ldk::chain::Filter + Send + Sync>,
+    Arc<LampoPersistence>,
+    Arc<LampoLogger>,
+    LampoKeysManager,
+>;
 
 /// LampoDaemon is the main data structure that uses the facade
 /// pattern to hide the complexity of the LDK library. You can interact
@@ -257,6 +286,8 @@ impl LampoDaemon {
                 Some(self.peer_manager().onion_messager()),
                 GossipSync::p2p(gossip_sync),
                 self.peer_manager().manager(),
+                NO_LIQUIDITY_MANAGER,
+                None::<Arc<LampoSweeper>>,
                 self.logger.clone(),
                 Some(self.channel_manager().scorer()),
                 |d| {

--- a/lampod/src/ln/channel_manager.rs
+++ b/lampod/src/ln/channel_manager.rs
@@ -5,6 +5,7 @@ use std::path::Path;
 use std::sync::{Arc, Mutex, OnceLock};
 use std::time::SystemTime;
 
+use lampo_common::backend::Backend;
 use lampo_common::bitcoin::{BlockHash, Transaction};
 use lampo_common::conf::LampoConf;
 use lampo_common::error;
@@ -17,7 +18,7 @@ use lampo_common::ldk::block_sync::BlockSource;
 use lampo_common::ldk::chain::chaininterface::{BroadcasterInterface, FeeEstimator};
 use lampo_common::ldk::chain::chainmonitor::ChainMonitor;
 use lampo_common::ldk::chain::channelmonitor::ChannelMonitor;
-use lampo_common::ldk::chain::BestBlock;
+use lampo_common::ldk::chain::BlockLocator;
 use lampo_common::ldk::ln::channelmanager::{ChainParameters, ChannelManagerReadArgs};
 use lampo_common::ldk::onion_message::messenger::DefaultMessageRouter;
 use lampo_common::ldk::routing::gossip::NetworkGraph;
@@ -25,7 +26,7 @@ use lampo_common::ldk::routing::router::DefaultRouter;
 use lampo_common::ldk::routing::scoring::{
     ProbabilisticScorer, ProbabilisticScoringDecayParameters, ProbabilisticScoringFeeParameters,
 };
-use lampo_common::ldk::sign::InMemorySigner;
+use lampo_common::ldk::sign::{InMemorySigner, NodeSigner};
 use lampo_common::ldk::util::persist::read_channel_monitors;
 use lampo_common::ldk::util::ser::ReadableArgs;
 use lampo_common::model::request;
@@ -100,6 +101,7 @@ impl LampoChannelManager {
     }
 
     fn build_channel_monitor(&self) -> LampoChainMonitor {
+        let keys = self.wallet_manager.ldk_keys().keys_manager.clone();
         ChainMonitor::new(
             // FIXME: this is needed when use esplora or electrum
             None,
@@ -107,6 +109,10 @@ impl LampoChannelManager {
             self.logger.clone(),
             self.onchain.clone(),
             self.persister.clone(),
+            keys.clone(),
+            keys.get_peer_storage_key(),
+            // `deferred`: lampo uses synchronous filesystem persistence.
+            false,
         )
     }
 
@@ -245,7 +251,7 @@ impl LampoChannelManager {
                 0,
                 0,
                 None,
-                Some(self.conf.ldk_conf),
+                Some(self.conf.ldk_conf.clone()),
             )
             .map_err(|err| error::anyhow!("{:?}", err))?;
 
@@ -320,12 +326,12 @@ impl LampoChannelManager {
             self.router.get().expect("router not initialized").clone(),
             default_message_router,
             self.logger.clone(),
-            self.conf.ldk_conf,
+            self.conf.ldk_conf.clone(),
             monitors,
         );
         let mut channel_manager_file = File::open(format!("{}/manager", self.conf.path()))?;
         let (_, channel_manager) =
-            <(BlockHash, LampoChannel)>::read(&mut channel_manager_file, read_args)
+            <(BlockLocator, LampoChannel)>::read(&mut channel_manager_file, read_args)
                 .map_err(|err| error::anyhow!("{err}"))?;
         self.channeld
             .set(Arc::new(channel_manager))
@@ -338,11 +344,8 @@ impl LampoChannelManager {
         .map_err(|err| error::anyhow!("Failed to connect to bitcoind: {:?}. Please ensure bitcoind is running and accessible.", err))?;
         let chain_params = ChainParameters {
             network: self.conf.network,
-            best_block: BestBlock {
-                block_hash: block_hash,
-                // FIXME: the default could be dangerus here
-                height: block_height.unwrap_or_default(),
-            },
+            // FIXME: the default height could be dangerous here
+            best_block: BlockLocator::new(block_hash, block_height.unwrap_or_default()),
         };
 
         let now = SystemTime::now().duration_since(SystemTime::UNIX_EPOCH)?;
@@ -370,7 +373,7 @@ impl LampoChannelManager {
             keymanagers.clone(),
             keymanagers.clone(),
             keymanagers,
-            self.conf.ldk_conf,
+            self.conf.ldk_conf.clone(),
             chain_params,
             now.as_secs() as u32,
         ));

--- a/lampod/src/ln/offchain_manager.rs
+++ b/lampod/src/ln/offchain_manager.rs
@@ -21,9 +21,10 @@ use lampo_common::conf::LampoConf;
 use lampo_common::error;
 use lampo_common::keys::LampoKeysManager;
 use lampo_common::ldk;
-use lampo_common::ldk::ln::channelmanager::Retry;
-use lampo_common::ldk::ln::channelmanager::{PaymentId, RecipientOnionFields};
-use lampo_common::ldk::ln::invoice_utils::create_invoice_from_channelmanager;
+use lampo_common::ldk::ln::channelmanager::{
+    Bolt11InvoiceParameters, OptionalBolt11PaymentParams, OptionalOfferPaymentParams, PaymentId,
+};
+use lampo_common::ldk::ln::outbound_payment::{RecipientOnionFields, Retry};
 use lampo_common::ldk::offers::offer::Amount;
 use lampo_common::ldk::offers::offer::Offer;
 use lampo_common::ldk::routing::router::{PaymentParameters, RouteParameters};
@@ -68,14 +69,20 @@ impl OffchainManager {
         description: &str,
         expiring_in: u32,
     ) -> error::Result<ldk::invoice::Bolt11Invoice> {
-        let invoice = ldk::ln::invoice_utils::create_invoice_from_channelmanager(
-            &self.channel_manager.manager(),
-            amount_msat,
-            description.to_string(),
-            expiring_in,
-            None,
-        )
-        .map_err(|err| error::anyhow!(err))?;
+        let description = ldk::invoice::Bolt11InvoiceDescription::Direct(
+            ldk::invoice::Description::new(description.to_string())
+                .map_err(|err| error::anyhow!("{:?}", err))?,
+        );
+        let invoice = self
+            .channel_manager
+            .manager()
+            .create_bolt11_invoice(Bolt11InvoiceParameters {
+                amount_msats: amount_msat,
+                description,
+                invoice_expiry_delta_secs: Some(expiring_in),
+                ..Default::default()
+            })
+            .map_err(|err| error::anyhow!("{:?}", err))?;
         Ok(invoice)
     }
 
@@ -119,12 +126,13 @@ impl OffchainManager {
             .manager()
             .pay_for_offer(
                 &offer,
-                None,
                 Some(amount),
-                payer_note,
                 payment_id,
-                Retry::Timeout(std::time::Duration::from_secs(1)),
-                None,
+                OptionalOfferPaymentParams {
+                    payer_note,
+                    retry_strategy: Retry::Timeout(std::time::Duration::from_secs(1)),
+                    ..Default::default()
+                },
             )
             .map_err(|err| error::anyhow!("{:?}", err))?;
         Ok(())
@@ -133,22 +141,26 @@ impl OffchainManager {
     pub fn pay_invoice(&self, invoice_str: &str, amount_msat: Option<u64>) -> error::Result<()> {
         // check if it is an invoice or an offer
         let invoice = self.decode_invoice(invoice_str)?;
-        let payment_id = PaymentId((*invoice.payment_hash()).to_byte_array());
-        let (payment_hash, onion, route) = if invoice.amount_milli_satoshis().is_none() {
-            ldk::ln::bolt11_payment::payment_parameters_from_variable_amount_invoice(
-                &invoice,
-                amount_msat.ok_or(error::anyhow!(
-                    "invoice with no amount, and amount must be specified"
-                ))?,
-            )
-            .map_err(|err| error::anyhow!("{:?}", err))?
+        let payment_id = PaymentId(invoice.payment_hash().0);
+        // Only forward a caller-supplied amount for zero-amount invoices. For a
+        // fixed-amount invoice LDK treats `amount_msat` as an overpayment, so
+        // drop it (matching the pre-0.3 `payment_parameters_from_invoice`).
+        let amount_msat = if invoice.amount_milli_satoshis().is_some() {
+            None
         } else {
-            ldk::ln::bolt11_payment::payment_parameters_from_invoice(&invoice)
-                .map_err(|err| error::anyhow!("{:?}", err))?
+            amount_msat
         };
         self.channel_manager
             .manager()
-            .send_payment(payment_hash, onion, payment_id, route, Retry::Attempts(10))
+            .pay_for_bolt11_invoice(
+                &invoice,
+                payment_id,
+                amount_msat,
+                OptionalBolt11PaymentParams {
+                    retry_strategy: Retry::Attempts(10),
+                    ..Default::default()
+                },
+            )
             .map_err(|err| error::anyhow!("{:?}", err))?;
         Ok(())
     }
@@ -177,7 +189,7 @@ impl OffchainManager {
             .manager()
             .send_spontaneous_payment(
                 Some(payment_preimage),
-                RecipientOnionFields::spontaneous_empty(),
+                RecipientOnionFields::spontaneous_empty(amount_msat),
                 PaymentId(payment_hash.0),
                 route_params,
                 Retry::Timeout(Duration::from_secs(10)),

--- a/lampod/src/ln/peer_manager.rs
+++ b/lampod/src/ln/peer_manager.rs
@@ -10,7 +10,6 @@ use lampo_common::conf::LampoConf;
 use lampo_common::error;
 use lampo_common::keys::LampoKeysManager;
 use lampo_common::ldk;
-use lampo_common::ldk::blinded_path::EmptyNodeIdLookUp;
 use lampo_common::ldk::ln::peer_handler::MessageHandler;
 use lampo_common::ldk::ln::peer_handler::{IgnoringMessageHandler, PeerManager};
 use lampo_common::ldk::net;
@@ -29,7 +28,7 @@ pub type LampoArcOnionMessenger<L> = OnionMessenger<
     Arc<LampoKeysManager>,
     Arc<LampoKeysManager>,
     Arc<L>,
-    Arc<EmptyNodeIdLookUp>,
+    Arc<LampoArcChannelManager<LampoChainMonitor, L>>,
     Arc<DefaultMessageRouter<Arc<LampoGraph>, Arc<L>, Arc<LampoKeysManager>>>,
     Arc<LampoArcChannelManager<LampoChainMonitor, L>>,
     IgnoringMessageHandler,
@@ -45,6 +44,7 @@ pub type SimpleArcPeerManager<M, T, L> = PeerManager<
     Arc<L>,
     IgnoringMessageHandler,
     Arc<LampoKeysManager>,
+    IgnoringMessageHandler,
 >;
 
 type InnerLampoPeerManager =
@@ -95,7 +95,9 @@ impl LampoPeerManager {
             keys.clone(),
             keys.clone(),
             self.logger.clone(),
-            Arc::new(EmptyNodeIdLookUp {}),
+            // ChannelManager implements NodeIdLookUp; use it (not EmptyNodeIdLookUp)
+            // so the messenger can resolve hops when advancing offer blinded paths.
+            channel_manager.manager(),
             Arc::new(DefaultMessageRouter::new(graph.clone(), keys.clone())),
             channel_manager.manager(), // Use channel manager for offers message handler
             IgnoringMessageHandler {}, // async_payments_message_handler
@@ -114,6 +116,7 @@ impl LampoPeerManager {
             onion_message_handler: onion_messenger.clone(),
             route_handler: gossip_sync,
             custom_message_handler: IgnoringMessageHandler {},
+            send_only_message_handler: IgnoringMessageHandler {},
         };
 
         let peer_manager = InnerLampoPeerManager::new(

--- a/lampod/src/persistence/mod.rs
+++ b/lampod/src/persistence/mod.rs
@@ -3,7 +3,7 @@
 //! N.B: This is an experimental version of the persistence,
 //! please do not use it in production you can lost funds, or
 //! in others words you WILL lost funds, do not trush me!
-use lampo_common::ldk::persister::fs_store::FilesystemStore;
+use lampo_common::ldk::persister::fs_store::v1::FilesystemStore;
 
 /// Lampo Persistence implementation.
 // FIME: it is a simple wrapper around the ldk file persister


### PR DESCRIPTION
## Summary

Upgrades the entire LDK stack from `0.1.5` to **0.3**, replacing the
earlier stop-gap revert. LDK 0.3 is not yet on crates.io, so every
`lightning*` crate is pinned to the upstream `0.3` branch (rev
`84605cf`) via `[workspace.dependencies]`. Fixes #537.

## Key changes

- **Signer**: `NodeSigner`/`SignerProvider`/`OutputSpender` reworked.
  `LampoKeysManager` delegates the new methods to the inner `KeysManager`;
  `KeysManager::new` gains `v2_remote_key_derivation` (set `false` to keep
  existing channels' key derivation).
- **Backend/BlockSource decouple**: `BlockSource` is now RPITIT (not
  object-safe). `Backend` exposes an object-safe `get_best_block` instead
  of extending `BlockSource`, preserving `Arc<dyn Backend>` and removing a
  dead impl.
- **Inbound channels**: 0.3 removed `manually_accept_inbound_channels`, so
  inbound channels are always surfaced via `OpenChannelRequest`; the
  handler now calls `accept_inbound_channel` (auto-accept as before).
- **Offers/onion messages**: use the `ChannelManager` as the
  `NodeIdLookUp` (not `EmptyNodeIdLookUp`) so blinded reply paths advance —
  required for BOLT12 offer payments.
- ChainMonitor (7th generic + new args), events (`PaymentClaimable`
  fields, `PendingHTLCsForwardable` removed, new `ClosureReason` variants),
  **BestBlock → BlockLocator**, **FilesystemStore** async `KVStore` via the
  persister `tokio` feature.
- **Payments** rewritten onto `create_bolt11_invoice`,
  `pay_for_bolt11_invoice`, `pay_for_offer`.
- **lightning-block-sync**: `RpcClient`/`SpvClient`/`synchronize_listeners`
  changes in `lampo-chain`.
- **process_events_async**: liquidity/sweeper passed as `None` —
  `NO_LIQUIDITY_MANAGER` (no new dependency) plus a no-op
  `ChangeDestinationSource`. lampo runs neither, so behaviour is unchanged.
- New **`unsafe_channel_keys`** feature gates the deterministic test-only
  channel-keys path (enables `lightning/_test_utils`); off by default.
- CI: a `Dependency hygiene` job fails if more than one `lightning*`
  version is ever in the graph.

## Test plan

- [x] `cargo check --workspace`
- [x] `cargo test` (unit) + `cargo build --release`
- [x] `cargo fmt --all -- --check`
- [x] `cargo tree` shows a single `lightning` version
- [x] **Docker integration tests (bitcoind + cln) — all green** (channel
      open/close, BOLT11 payments, keysend, BOLT12 offers)

## Notes

- Pinned to an **unreleased** `0.3` branch commit. Worth a deliberate look
  before merge given it's funds-handling code; swap to a tag once 0.3 is
  released.
- Some pre-existing unused-variable warnings remain in the event handler
  (it destructures fields it doesn't use); left untouched to keep the diff
  focused.
