### PR TITLE
Group LDK crates in Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,11 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly" # See documentation for possible values
+    # Keep the LDK crate family on a single version: bump every lightning*
+    # crate together in one PR so an isolated bump can't split `lightning`
+    # across versions and break the build (see #537).
+    groups:
+      ldk:
+        patterns:
+          - "lightning"
+          - "lightning-*"


### PR DESCRIPTION
## Summary

`.github/dependabot.yml` had no `groups:` configuration, so Dependabot
bumped LDK crates one at a time. PR #531 bumped only `lightning-persister`
to 0.2.0, which dragged in `lightning` 0.2.x while the rest of the stack
stayed on 0.1.5 — breaking the build with a `FilesystemStore: KVStore`
conflict (#537).

This adds a `groups: ldk` entry matching `lightning` and `lightning-*`
so the whole LDK crate family (lightning, lightning-block-sync,
lightning-persister, lightning-background-processor, lightning-net-tokio,
lightning-rapid-gossip-sync, and any lightning-invoice/types/macros)
version-bumps together in a single PR.

## Test plan

- [x] `.github/dependabot.yml` parses as valid YAML
- [x] `groups.ldk.patterns` resolves to `["lightning", "lightning-*"]`

## Note

Config-only change. The Rust build/test CI on this PR fails because `main`
is currently broken by #537 itself — that build break is fixed separately
by the LDK upgrade in #538, independent of this Dependabot config.
