### PR TITLE
Fix(sync): wire chain-sync coordinator into the on-chain manager

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -88,3 +88,8 @@ jobs:
             exit 1
           fi
           echo "OK: each lightning* crate resolves to a single version."
+
+      # Guards the unified-chain-sync invariant (#545): the on-chain wallet
+      # crate must stay free of LDK so it remains independently replaceable.
+      - name: Ensure the on-chain wallet stays free of LDK
+        run: ./tools/check-wallet-decoupling.sh

--- a/docs/designs/unified-chain-sync.md
+++ b/docs/designs/unified-chain-sync.md
@@ -1,17 +1,39 @@
-# Unified Chain Sync: Align Lampo with ldk-node
+# Unified Chain Sync: Align Lampo with ldk-node *without losing backend/wallet pluggability*
 
 | Field | Value |
 |-------|--------|
-| Status | Draft |
-| Author | Vincenzo Palazzo (with Grok-assisted analysis) |
+| Status | Draft (rev. 2 — decoupled) |
+| Author | Vincenzo Palazzo (with Grok-assisted analysis; rev. 2 decoupling pass) |
 | Date | 2026-06-03 |
-| Related issues | [#540](https://github.com/vincenzopalazzo/lampo.rs/issues/540) (fast sync), [#444](https://github.com/vincenzopalazzo/lampo.rs/issues/444) (`reindex` semantics) |
+| Related issues | [#545](https://github.com/vincenzopalazzo/lampo.rs/issues/545), [#540](https://github.com/vincenzopalazzo/lampo.rs/issues/540) (fast sync), [#444](https://github.com/vincenzopalazzo/lampo.rs/issues/444) (`reindex` semantics) |
 
 ## Summary
 
-Lampo currently runs **two independent, competing chain-sync pipelines** over the same Bitcoin Core RPC backend: LDK `synchronize_listeners` (channel manager + chain monitor) and a separate BDK `Emitter` full-block scan (on-chain wallet). Production on Ocean Signet (~307k blocks) shows multi-day catch-up, RPC saturation, and LDK listener sync that never logs completion while the BDK path dominates `getblock` traffic.
+Lampo currently runs **two independent, competing chain-sync pipelines** — over **two separate Bitcoin Core RPC clients**: LDK `synchronize_listeners` (channel manager + chain monitor, via `lightning-block-sync`'s `RpcClient`) and a separate BDK `Emitter` full-block scan (on-chain wallet, via `bdk_bitcoind_rpc::bitcoincore_rpc::Client`). Production on Ocean Signet (~307k blocks) shows multi-day catch-up, RPC saturation, and LDK listener sync that never logs completion while the BDK path dominates `getblock` traffic.
 
-**ldk-node** (used by **ldk-server**) solves this by registering the on-chain BDK wallet as an LDK `Listen` target and driving **one** `synchronize_listeners` pass, then a unified poll loop. This document proposes converging Lampo toward that model while preserving Lampo’s modular crates and optional checkpoint/fast-sync for signet/dev.
+**ldk-node** (used by **ldk-server**) solves the efficiency problem by registering the on-chain BDK wallet as an LDK `Listen` target and driving **one** `synchronize_listeners` pass, then a unified poll loop.
+
+This document proposes converging Lampo toward that **outcome** (one RPC stream, observable completion, no duplicate scan) **while explicitly preserving Lampo's modular design**, where the Lightning side and the Bitcoin side live behind traits and can be replaced independently. Concretely we **diverge from ldk-node in one place**: we do **not** implement LDK's `Listen` on the wallet. Instead the unavoidable LDK↔wallet coupling is **confined to the bitcoind backend crate (`lampo-chain`)** via a thin adapter, and unified sync is expressed as a **backend-agnostic** responsibility coordinated through `lampo-common`. This keeps the chain `Backend` swappable (Esplora/Electrum next) and the on-chain wallet swappable, with neither side leaking into the other.
+
+## Design principle: backend-confined coupling (the three seams)
+
+Lampo's replaceability rests on three trait seams. The whole point of this design is to keep them intact.
+
+| Seam | Trait / type | Today's impl | What it abstracts |
+|------|--------------|--------------|-------------------|
+| Chain source | `Backend` (`lampo-common/src/backend.rs`) | `LampoChainSync` (`lampo-chain`) | How blocks/txs are fetched and how consumers are driven to tip |
+| On-chain wallet | `WalletManager` (`lampo-common/src/wallet.rs`) | `BDKWalletManager` (`lampo-bdk-wallet`) | Keys, addresses, UTXOs, on-chain tx construction |
+| Composition | `LampoChainManager` (`lampod/src/chain/blockchain.rs`) | holds `Arc<dyn Backend>` + `Arc<dyn WalletManager>` | Glues LN ↔ BTC; implements LDK `FeeEstimator`/`Broadcaster`/`UtxoLookup` |
+
+**Invariant (hard):**
+
+> The on-chain wallet crate must not depend on LDK chain-sync types. Any coupling that LDK's `Listen`/`synchronize_listeners` requires lives **inside the concrete `Backend` implementation** (e.g. `lampo-chain` for bitcoind), never in the wallet and never as a cross-crate contract.
+
+**Corollary (backend swap is the priority axis):**
+
+> Unified sync is a property of the `Backend`, coordinated by a backend-agnostic `ChainSyncCoordinator`. The bitcoind backend implements it with `synchronize_listeners` + a local `Listen` adapter. A future Esplora/Electrum backend implements the *same* contract with transaction-based sync (`Confirm`). The wallet and the LN consumers are unaware of which backend is in use.
+
+This is the central revision relative to the original draft (and to ldk-node): the wallet exposes only **lampo-native** block/tx application; the bitcoind-specific `Listen` adapter is an implementation detail of `lampo-chain`.
 
 ## Problem statement
 
@@ -25,24 +47,36 @@ Lampo currently runs **two independent, competing chain-sync pipelines** over th
 - **Logs:** 0 ERROR/WARN; benign lock skip messages every 2 min.
 - **Anomaly:** no `Applied block` INFO lines and `bdk-wallet.db` mtime frozen while RPC scan advances (needs investigation during implementation).
 
+### Root cause
+
+Two pipelines, two RPC clients, no coordination:
+
+- `lampo-chain` (`LampoChainSync`) holds its own `lightning_block_sync::rpc::RpcClient` and runs `synchronize_listeners` (CM + ChainMonitor only) then `SpvClient::poll_best_tip()`.
+- `lampo-bdk-wallet` (`BDKWalletManager`) holds a **separate** `bdk_bitcoind_rpc::bitcoincore_rpc::Client` and runs an `Emitter` full-block scan on a `tokio-cron-scheduler` (every 2 min + 5s one-shot), independent of the LDK path.
+
+They contend for the same bitcoind, redundantly download the 190k→tip overlap, and starve each other. Neither knows the other's progress.
+
 ### User impact
 
-- Node appears “up” (`blockheight` = tip) but **Lightning chain listeners may not be caught up** and **on-chain wallet is not ready** for balances/UTXOs.
+- Node appears "up" (`blockheight` = tip) but **Lightning chain listeners may not be caught up** and **on-chain wallet is not ready** for balances/UTXOs.
 - Duplicate block downloads waste RPC bandwidth and wall-clock time.
-- Operators cannot distinguish “syncing” vs “ready” from `getinfo` alone.
+- Operators cannot distinguish "syncing" vs "ready" from `getinfo` alone.
 
 ## Goals
 
-1. **Single coordinated chain sync** for all LDK `Listen` targets including the on-chain wallet (ldk-node parity for bitcoind backend).
-2. **Serialize or prioritize** initial sync so LDK listener sync completes and is observable before/alongside wallet catch-up.
-3. **Expose sync progress** in `getinfo` (and logs): listener sync done, wallet scan height, percent/ETA optional.
-4. **Optional fast-sync / checkpoint jump** for signet and empty wallets (extends [#540](https://github.com/vincenzopalazzo/lampo.rs/issues/540)).
-5. **Retry/backoff** on transient RPC failures during `synchronize_listeners` (ldk-node pattern).
+1. **Single coordinated chain sync** that drives all chain consumers (LN channel manager, chain monitor, on-chain wallet) to tip over **one** RPC client.
+2. **Serialize / make observable** initial sync so listener sync completes (and is logged) before/alongside wallet catch-up.
+3. **Expose sync progress** in `getinfo` and logs.
+4. **Preserve the three trait seams** — wallet stays LDK-free; `Backend` stays swappable; coupling confined to the concrete backend crate. *(New, load-bearing goal.)*
+5. **Be ready for tx-based backends** (Esplora/Electrum) without touching the wallet. *(New.)*
+6. **Optional fast-sync / checkpoint jump** for signet and empty wallets (extends [#540](https://github.com/vincenzopalazzo/lampo.rs/issues/540)).
+7. **Retry/backoff** on transient RPC failures during sync (ldk-node pattern).
 
 ## Non-goals (this design)
 
 - Replacing Lampo with ldk-node or ldk-server.
-- Esplora/Electrum chain sources in the first PR (can follow; ldk-node tx-based sync is a separate follow-up).
+- **Implementing LDK `Listen`/`Confirm` directly on the wallet** (explicitly rejected — see Alternatives).
+- Building the Esplora/Electrum backend now (only making the seam ready).
 - Changing LDK persistence format for channel manager.
 - Mainnet policy for fast-sync defaults (must remain opt-in / safe).
 
@@ -53,42 +87,42 @@ sequenceDiagram
     participant CLI as lampod-cli
     participant W as lampo-bdk-wallet
     participant C as lampo-chain
-    participant RPC as Bitcoind RPC
+    participant RPC1 as bitcoind RPC (BDK client)
+    participant RPC2 as bitcoind RPC (LDK client)
 
     CLI->>W: wallet.listen() (cron + 5s oneshot)
-    CLI->>CLI: lampod.init()
+    CLI->>CLI: lampod.init(client)
     CLI->>CLI: lampod.listen()
     CLI->>C: spawn backend.listen()
 
-    par BDK path
-        W->>RPC: Emitter getblock loop (from wallet checkpoint)
-    and LDK path
-        C->>RPC: synchronize_listeners (CM + ChainMonitor only)
+    par BDK path (own client)
+        W->>RPC1: Emitter getblock loop (from wallet checkpoint ~21k)
+    and LDK path (own client)
+        C->>RPC2: synchronize_listeners (CM + ChainMonitor, from ~190k)
         Note over C: SpvClient poll after sync completes
     end
 ```
 
 ### LDK path (`lampo-chain/src/lib.rs`)
 
-- `listen()` spawns async task.
-- `synchronize_listeners` for **channel manager** and **chain monitor** only (not BDK wallet).
-- On success: log + `SpvClient::poll_best_tip()` loop.
-- Starting block: `channel_manager.current_best_block()` (e.g. 190537).
+- `LampoChainSync` owns an `Arc<RpcClient>` and implements both `BlockSource` and the lampo `Backend` trait.
+- `set_channel_manager` / `set_chain_monitor` inject the LDK objects via `OnceLock` (the wallet is **not** injected today).
+- `Backend::listen()` runs `synchronize_listeners` for **channel manager + chain monitor** from `channel_manager.current_best_block()` (e.g. 190537), logs, then runs an `SpvClient::poll_best_tip()` loop.
 
 ### On-chain path (`lampo-bdk-wallet/src/lib.rs`)
 
-- `sync()` uses `bdk_bitcoind_rpc::Emitter` from `wallet.latest_checkpoint()`.
+- `sync()` uses `bdk_bitcoind_rpc::Emitter` from `wallet.latest_checkpoint()` over a **separate** `bitcoincore_rpc::Client`.
 - Per-block `apply_block_connected_to` + `persist`.
-- Scheduled via `tokio-cron-scheduler` (every 2 min + 5s initial); holds `guard` for entire `sync()`.
+- Scheduled via `tokio-cron-scheduler` (every 2 min + 5s one-shot); holds a `guard` mutex for the entire `sync()`.
 - `reindex_from` only when `start_height == 0` or explicit `conf.reindex` forward jump ([#444](https://github.com/vincenzopalazzo/lampo.rs/issues/444)).
 
 ### Startup order (`lampod-cli/src/main.rs`)
 
-1. `wallet.listen().await?` — runs job scheduler (blocks until scheduler stops).
-2. `lampod.init()` — includes `channel_manager.listen()` (start CM, not chain backend).
-3. `run_httpd`, then `lampod.listen()` — spawns `onchain_manager().listen()` → chain backend.
+1. `wallet.listen().await?` — starts the job scheduler.
+2. `lampod.init(client)` — wires onchaind/channeld/etc., injects handler + CM + chain monitor into the backend.
+3. `run_httpd`, then `lampod.listen()` — spawns `onchain_manager().listen()` → `Backend::listen()`.
 
-**Issue:** wallet scheduler can start BDK full scan **before or in parallel with** chain `synchronize_listeners`, both hammering the same RPC client.
+**Issue:** wallet scheduler can start the BDK full scan **before or in parallel with** the LDK `synchronize_listeners`, both hammering bitcoind over distinct clients.
 
 ## Reference architecture (ldk-node / ldk-server)
 
@@ -96,60 +130,73 @@ ldk-server is a gRPC wrapper; chain behavior is defined in **ldk-node** (`src/ch
 
 ### Bitcoind initial sync
 
-1. `node.start()` starts chain source, updates fee estimates (blocking once).
-2. Background task `continuously_sync_wallets`:
+1. `node.start()` starts chain source, updates fee estimates.
+2. Background `continuously_sync_wallets`:
    - Builds `chain_listeners` vec: **on-chain `Wallet`**, **channel manager**, **output sweeper**, **chain monitor** (worst monitor block).
-   - Single `synchronize_listeners(...).await`.
-   - On success: log `Finished synchronizing listeners in Nms`, update metrics timestamps, then enter poll loop.
-   - On failure: retry with exponential backoff (transient vs persistent).
+   - Single `synchronize_listeners(...).await`; on success logs `Finished synchronizing listeners in Nms`, updates metric timestamps, enters poll loop; on failure retries with backoff.
 
 ### On-chain wallet during listener sync
 
-- `Wallet` implements `Listen::block_connected`:
-  - `apply_block_events` + `persist` per block (no parallel Emitter loop during initial sync).
-- `filtered_block_connected` is intentionally unsupported (debug_assert in dev); full blocks from disagreement point are sufficient per BDK guidance.
-
-### Ongoing updates
-
-- `poll_and_update_listeners` updates **all** listeners together on new tips.
-- `WalletSyncStatus` prevents overlapping syncs; `sync_wallets()` API waits on completion.
+- ldk-node's `Wallet` implements `Listen::block_connected` (apply + persist per block); `filtered_block_connected` is intentionally unsupported.
 
 ### Alternative chain sources
 
-- Esplora/Electrum: transaction-based `sync_onchain_wallet` + `sync_lightning_wallet` (faster for large histories). Lampo does not implement this today.
+- Esplora/Electrum use **transaction-based** `sync_onchain_wallet` + `sync_lightning_wallet` (LDK `Confirm`), *not* block-by-block `Listen`. This is the key reason Lampo must not hard-code the wallet into `synchronize_listeners`.
+
+### Where Lampo deliberately diverges
+
+ldk-node puts `Listen` **on the wallet**. Lampo will instead put the `Listen` adapter **in the bitcoind backend crate** and have the wallet expose only lampo-native apply methods. Same runtime behavior (wallet participates in the single `synchronize_listeners` pass), but the wallet stays LDK-free and the backend stays swappable.
 
 ## Comparison
 
-| Aspect | Lampo (today) | ldk-node (bitcoind) |
-|--------|---------------|---------------------|
-| Listener set | CM + ChainMonitor | Wallet + CM + Sweeper + ChainMonitor |
-| Block delivery to BDK | BDK `Emitter` / `getblock` | `Listen::block_connected` |
-| RPC passes on restart | 2 (overlapping ranges) | 1 initial + incremental poll |
-| Initial sync completion | Wallet: no API flag; LDK: log line missing in prod | Log + metrics timestamps |
-| RPC error handling | Emitter error logged; listener stall unclear | Retry/backoff on `synchronize_listeners` |
-| Progress in API | `wallet_height` stale during scan | `current_best_block`, sync timestamps |
-| Fast sync | `reindex` / height 0 only | New wallet → tip checkpoint; restored → per-listener best block in one sync |
-| Startup coupling | Wallet cron independent of LDK sync | `start()` coordinates background sync |
+| Aspect | Lampo (today) | ldk-node (bitcoind) | Lampo (this design) |
+|--------|---------------|---------------------|---------------------|
+| Listener set | CM + ChainMonitor | Wallet + CM + Sweeper + ChainMonitor | CM + ChainMonitor + **wallet adapter** (bitcoind backend only) |
+| RPC clients | 2 (separate) | 1 | 1 |
+| Block delivery to wallet | BDK `Emitter` | LDK `Listen` on wallet | lampo-native `WalletManager::apply_block`, driven by backend |
+| Wallet ↔ LDK coupling | none | wallet depends on LDK | **none** (adapter lives in `lampo-chain`) |
+| Backend swap (Esplora) | independent but duplicative | separate tx-path | same `Backend`/coordinator contract, wallet unchanged |
+| Initial sync completion | log line missing in prod | log + metric timestamps | log + `getinfo` fields + coordinator state |
+| RPC error handling | logged; stall unclear | retry/backoff | retry/backoff in backend |
+| Progress in API | `wallet_height` stale | `current_best_block` + timestamps | coordinator state + wallet scan height |
 
 ## Proposed solution
 
-### Phase A — Coordination & observability (low risk)
+Two destinations, shipped incrementally: **Phase A** stops the bleeding while preserving the design exactly (no new coupling). **Phase B** delivers the single-pass efficiency via the backend-confined adapter. **Phase C** adds config/RPC. **Phase D** (future) proves the seam with a tx-based backend.
 
-**A1. Chain sync gate**
+### Phase A — Coordination & observability (low risk, zero new coupling)
 
-- Introduce `ChainSyncCoordinator` (in `lampo-chain` or `lampo-common`):
-  - States: `PendingInitialSync` → `ListenersSynced` → `Running`.
-  - `lampo-chain` sets `ListenersSynced` after `synchronize_listeners` + log.
-  - `lampo-bdk-wallet` **does not** start `Emitter` full scan until `ListenersSynced` **OR** config `wallet_sync_parallel=true` (default `false` on mainnet, `true` on signet optional).
+**A1. `ChainSyncCoordinator` (backend-agnostic, in `lampo-common`)**
 
-**A2. Extend `getinfo`**
+```rust
+// lampo-common: no LDK, no BDK — pure state.
+pub enum SyncState { PendingInitialSync, ListenersSynced, Running }
 
-Add fields (names illustrative):
+pub struct ChainSyncCoordinator { /* atomics / watch channel */ }
+
+impl ChainSyncCoordinator {
+    pub fn state(&self) -> SyncState;
+    pub fn mark_listeners_synced(&self);
+    pub fn mark_running(&self);
+    pub fn wallet_scan_height(&self) -> Option<u32>;
+    pub fn set_wallet_scan_height(&self, h: u32);
+    pub async fn wait_listeners_synced(&self); // for sync_wallets RPC / startup gate
+}
+```
+
+- The concrete `Backend` sets `ListenersSynced` after its sync mechanism completes (for bitcoind: after `synchronize_listeners`).
+- The wallet (or the backend driving it) reports `wallet_scan_height`.
+
+**A2. Gate the BDK Emitter**
+
+- `lampo-bdk-wallet` does **not** start the `Emitter` full scan until the coordinator reports `ListenersSynced`, **unless** `wallet_sync_parallel = true`. This alone removes the "two pipelines at once" contention without any structural change — pure Phase-A safety net, valid even before Phase B lands.
+
+**A3. Extend `getinfo`** (`lampo-common/src/model/getinfo.rs`)
 
 ```rust
 pub struct GetInfo {
-    // existing...
-    pub wallet_height: u64,
+    // existing: node_id, peers, channels, chain, alias, blockheight,
+    //           lampo_dir, address, block_hash, wallet_height ...
     pub wallet_scan_height: Option<u32>,  // live progress during scan
     pub chain_listeners_synced: bool,
     pub initial_sync_complete: bool,
@@ -157,70 +204,146 @@ pub struct GetInfo {
 }
 ```
 
-Populate from coordinator + wallet tip.
+Populated from the coordinator + wallet tip.
 
-**A3. Logging**
+**A4. Logging**
 
-- Ensure `Chain listeners synced` and `Start Backend` are always emitted at INFO.
-- Log wallet progress every N blocks (e.g. 1000) to avoid debug-only visibility.
+- Always emit `Chain listeners synced` and `Start Backend` at INFO.
+- Log wallet progress every N blocks (e.g. 1000) at INFO (not debug-only).
 - Fix typo: `Unable to take the log` → `lock` in `lampo-bdk-wallet`.
 
-**A4. Startup reorder (minimal)**
-
-In `lampod-cli`:
+**A5. Startup reorder (minimal)** in `lampod-cli`:
 
 ```text
-lampod.init(client)           // CM, handlers, etc.
-spawn lampod.listen()         // chain backend + LDK event loop
-await initial_listener_sync() // or block HTTP until listeners synced (config)
-wallet.start_scheduled_sync() // cron only after gate open
+lampod.init(client)            // CM, handlers, inject CM/monitor into backend
+spawn lampod.listen()          // backend sync + LDK event loop
+coordinator.wait_listeners_synced().await   // or report-only, see Open Q1
+wallet.start_scheduled_sync()  // cron only after gate opens (Phase A behavior)
 run_httpd()
 ```
 
-Avoid blocking entire daemon on `wallet.listen().await?` before `init` (current code is confusing and may delay init depending on scheduler behavior).
+Refactor `wallet.listen().await?` (currently blocks on the scheduler before `init`) into a `tokio::spawn`.
 
-### Phase B — Unified listener sync (ldk-node alignment)
+### Phase B — Unified single-pass sync via backend-confined adapter
 
-**B1. `Listen` for BDK wallet**
+This is where we diverge from ldk-node to keep the seams. **No code in `lampo-bdk-wallet` references LDK.**
 
-- Implement `lampo_common::ldk::chain::Listen` for `BDKWalletManager` (wrapper around persisted BDK wallet), mirroring ldk-node `Wallet::block_connected`:
-  - `apply_block_events` / equivalent for BDK 2.x API in use.
-  - `persist` after each block.
-  - Register LDK-relevant tx outputs when needed (funding txs) — defer if no channels yet.
-
-**B2. Register wallet in `synchronize_listeners`**
-
-In `lampo-chain/src/lib.rs`, extend `chain_listeners`:
+**B1. lampo-native apply on `WalletManager`** (`lampo-common`, pure bitcoin types)
 
 ```rust
-let wallet_best = wallet_manager.current_best_block(); // new trait method
-chain_listeners.push((wallet_best.block_hash, wallet_manager.as_listen()));
-// existing CM + chain_monitor entries
+#[async_trait]
+pub trait WalletManager: Send + Sync {
+    // ...existing...
+
+    /// Best block the wallet has applied (for the backend to compute the
+    /// sync start point). Pure bitcoin types.
+    async fn current_best_block(&self) -> error::Result<BlockId>; // { height, hash }
+
+    /// Apply a connected block. Mirrors what `sync()` already does
+    /// internally via `apply_block_connected_to` + `persist`.
+    async fn apply_block(
+        &self,
+        block: &Block,
+        height: u32,
+        connected_to: BlockId,
+    ) -> error::Result<()>;
+
+    /// Handle a disconnected block (reorg). BDK handles this via checkpoints;
+    /// expose it so the backend can drive reorg-safe catch-up.
+    async fn disconnect_block(&self, height: u32) -> error::Result<()>;
+}
 ```
 
-**B3. Deprecate parallel Emitter for initial catch-up**
+`BDKWalletManager` implements these by lifting the body of today's `sync()` loop — it already calls `apply_block_connected_to` + `persist`. No new dependency.
 
-- Keep `Emitter` only for:
-  - `dev_sync` / explicit `full_scan=true`, or
-  - recovery when `Listen` sync detects inconsistency.
-- Default path: wallet advances only via listener sync + SpvClient-driven updates.
+> Forward-compat note (do not build now): a tx-based backend will want
+> `apply_confirmed_txs(...)` / `apply_unconfirmed_txs(...)`. Add it only when
+> Phase D lands. BDK already supports `apply_update` / `apply_unconfirmed_txs`,
+> so the seam is cheap to extend. Keep today's surface minimal (CLAUDE.md:
+> "write for today, not hypothetical futures").
 
-**B4. RPC client sharing**
+**B2. `Listen` adapter inside `lampo-chain`** (the only place LDK meets the wallet)
 
-- Single `Arc<BitcoindRpc>` behind `BlockSource` used by `lampo-chain` only during sync; wallet does not spawn separate emitter concurrently.
-- Optional: mutex around `synchronize_listeners` + poll (ldk-node-style `WalletSyncStatus`).
+```rust
+// lampo-chain — NOT lampo-common, NOT lampo-bdk-wallet.
+struct WalletChainListener {
+    wallet: Arc<dyn WalletManager>,
+    rt: tokio::runtime::Handle, // bridge sync Listen -> async WalletManager
+}
+
+impl lampo_common::ldk::chain::Listen for WalletChainListener {
+    fn block_connected(&self, block: &Block, height: u32) {
+        let connected_to = /* prev BlockId from header */;
+        self.rt.block_on(self.wallet.apply_block(block, height, connected_to))
+            .expect("wallet apply_block");
+    }
+    fn block_disconnected(&self, header: &Header, height: u32) {
+        self.rt.block_on(self.wallet.disconnect_block(height))
+            .expect("wallet disconnect_block");
+    }
+    // filtered_block_connected: unsupported (debug_assert), as in ldk-node.
+}
+```
+
+**B3. Inject the wallet into `lampo-chain` and register the adapter**
+
+`LampoChainSync` already injects CM + chain monitor via `OnceLock`. Add the wallet the same way (`set_wallet_manager(Arc<dyn WalletManager>)`), then build one listener set:
+
+```rust
+let manager_best = channel_manager.current_best_block();
+let wallet_best   = self.wallet().current_best_block().await?; // ~21k
+let wallet_listen = WalletChainListener::new(self.wallet(), handle);
+
+let chain_listeners: Vec<(BlockLocator, &(dyn chain::Listen + Send + Sync))> = vec![
+    (manager_best.clone(), &*channel_manager),
+    (manager_best.clone(), &*chain_monitor),
+    (wallet_best,          &wallet_listen),     // <-- wallet joins, via adapter
+];
+let (cache, tip) = init::synchronize_listeners(self, network, chain_listeners).await?;
+coordinator.mark_listeners_synced();
+// SpvClient poll loop now drives ALL three on new tips.
+```
+
+`synchronize_listeners` already handles listeners at different start heights and reorgs, so the wallet (21k) and CM (190k) converge to tip in one reorg-safe pass over one RPC client.
+
+**B4. Retire the parallel Emitter in unified mode**
+
+- In `sync_mode = "unified"` (default), `lampo-bdk-wallet` does **not** spawn the cron `Emitter`; ongoing updates arrive through the backend's `SpvClient` poll → adapter → `apply_block`.
+- Keep the `Emitter` path under `sync_mode = "legacy"` for fallback and for resuming an in-progress emitter DB.
+
+```mermaid
+sequenceDiagram
+    participant C as lampo-chain (Backend)
+    participant RPC as bitcoind RPC (single client)
+    participant CM as ChannelManager
+    participant CMon as ChainMonitor
+    participant AD as WalletChainListener (adapter, in lampo-chain)
+    participant W as WalletManager (lampo-native)
+
+    C->>RPC: synchronize_listeners (one pass)
+    RPC-->>C: blocks 21k..tip
+    C->>CM: block_connected (from 190k)
+    C->>CMon: block_connected (from 190k)
+    C->>AD: block_connected (from 21k)
+    AD->>W: apply_block(block, height, connected_to)
+    Note over C: mark_listeners_synced(); then SpvClient poll drives all three
+```
 
 ### Phase C — Fast sync & config ([#540](https://github.com/vincenzopalazzo/lampo.rs/issues/540))
 
-**C1. Config**
+**C1. Config** (`lampo.example.conf`)
 
 ```toml
-# lampo.example.conf
-sync_mode = "unified"   # unified | legacy (emitter)
-fast_sync = false       # allow checkpoint jump when safe
-fast_sync_min_height = 0  # only if wallet empty / user opt-in
-reindex = 300000        # documented: forward checkpoint, not backward rescan
+sync_mode = "unified"        # unified | legacy (emitter)
+wallet_sync_parallel = false # Phase-A gate override (mainnet default false)
+fast_sync = false            # allow checkpoint jump when safe
+fast_sync_min_height = 0     # only if wallet empty / user opt-in
+reindex = 300000             # documented: forward checkpoint, not backward rescan
 ```
+
+> `sync_mode` is intentionally about the **sync strategy of the active backend**,
+> not a backend selector. The backend itself stays selected by `conf.node`
+> ("core" today; "esplora"/"electrum" later) — see Phase D.
 
 **C2. Safe fast-sync rules**
 
@@ -229,68 +352,89 @@ reindex = 300000        # documented: forward checkpoint, not backward rescan
 | mainnet | `false` | Manual enable + no UTXOs or explicit CLI flag |
 | signet/testnet | `false` | Opt-in via config for dev |
 
-When enabled: insert wallet checkpoint at `tip - confirmations_margin` before `synchronize_listeners`, same as existing `reindex_from` logic but documented and wired to `fast_sync`.
+When enabled: insert wallet checkpoint at `tip - confirmations_margin` before sync (the existing `reindex_from` logic, documented and wired to `fast_sync`).
 
-**C3. `sync_wallets` JSON-RPC**
+**C3. `sync_wallets` JSON-RPC** — blocks until `coordinator.wait_listeners_synced()`; useful for scripts/CI. Lives in `lampod`/`lampo-httpd`, talks only to the coordinator (backend-agnostic).
 
-- Add `sync_wallets` command (like ldk-node): block until initial unified sync completes; useful for scripts/CI.
+### Phase D — Tx-based backend (future; proves the seam)
+
+Not built now. Sketch only, to validate that the seams hold:
+
+- A new `EsploraBackend` implements the `Backend` trait and the coordinator contract.
+- Internally it uses LDK `Confirm` + BDK tx-based sync. It drives the wallet via the (then-added) `WalletManager::apply_confirmed_txs` — **the same lampo-native trait**, not a new cross-crate LDK contract.
+- `lampo-bdk-wallet` requires **no change** to the existing block path; the `Listen` adapter stays in `lampo-chain` and is never compiled into the Esplora backend.
+
+If Phase D requires *zero* edits to `lampo-bdk-wallet`, the design met its goal.
 
 ## Key decisions
 
 | Decision | Rationale |
 |----------|-----------|
-| Adopt ldk-node **unified `synchronize_listeners`** as default | Eliminates duplicate `getblock` work and RPC starvation; battle-tested in ldk-node. |
-| Keep Lampo crate split (`lampo-chain`, `lampo-bdk-wallet`) | Avoid big-bang merge; integrate via traits (`Listen`, `WalletManager::current_best_block`). |
-| Gate BDK Emitter behind coordinator initially | Low-risk fix for production stall; full `Listen` impl can follow in Phase B. |
+| Unified single-pass sync as the destination | Eliminates duplicate `getblock` work and RPC starvation; battle-tested in ldk-node. |
+| **Wallet stays LDK-free; `Listen` adapter lives in `lampo-chain`** | Preserves the `WalletManager` seam; wallet remains swappable; LDK coupling confined to the bitcoind backend. |
+| **Unified sync is a `Backend` responsibility + backend-agnostic coordinator** | Keeps the `Backend` seam swappable; Esplora/Electrum (tx-based) fit the same contract. |
+| Keep crate split (`lampo-chain`, `lampo-bdk-wallet`) | Integrate via lampo-native traits, not LDK contracts. |
+| Gate BDK Emitter behind coordinator first (Phase A) | Low-risk production fix; full single-pass can follow in Phase B. |
+| Inject `Arc<dyn WalletManager>` into `lampo-chain` via `OnceLock` | Mirrors existing CM/chain-monitor injection; no new dependency direction (already depends on `lampo-common`). |
 | Do not enable fast-sync on mainnet by default | Safety over signet convenience ([#540](https://github.com/vincenzopalazzo/lampo.rs/issues/540)). |
-| Defer Esplora/Electrum to later design | Separate tx-based sync path; reduces scope. |
-| Expose sync state in `getinfo` | Operators need visibility; matches ldk-server `GetNodeInfo` timestamps concept. |
+| Expose sync state in `getinfo` + `sync_wallets` RPC | Operators need visibility; matches ldk-server concept; coordinator is backend-agnostic. |
 
 ## Alternatives considered
 
-1. **Switch Lampo to embed ldk-node** — Rejected: large product/architecture change; loses current Lampo HTTP/LN customization.
-2. **Keep dual sync, only add RPC rate limit** — Rejected: still O(chain) duplicate downloads; does not fix listener starvation.
-3. **BDK Emitter only, drop `synchronize_listeners`** — Rejected: breaks LDK channel/monitor chain order guarantees.
-4. **Esplora for signet first** — Attractive follow-up; does not help current Ocean bitcoind deployment.
+1. **`impl Listen`/`Confirm` directly on the BDK wallet (literal ldk-node parity, original Phase B).**
+   *Rejected.* Couples `lampo-bdk-wallet` to LDK chain-sync types, puncturing the `WalletManager` seam, and hard-codes the block-based path — obstructing the Esplora/Electrum backend swap, which is the priority axis. Also offers no wiring benefit: `lampo-chain` still needs a handle to the wallet either way.
+2. **Switch Lampo to embed ldk-node.** Rejected: large product/architecture change; loses Lampo's HTTP/LN customization and the trait seams entirely.
+3. **Keep dual sync, only add an RPC rate limit.** Rejected: still O(chain) duplicate downloads; does not fix listener starvation.
+4. **BDK Emitter only, drop `synchronize_listeners`.** Rejected: breaks LDK channel/monitor chain-order guarantees.
+5. **Hoist `synchronize_listeners` orchestration up into `lampod`** (instead of injecting the wallet into `lampo-chain`). Viable, but spreads bitcoind-specific LDK glue into the composition layer; keeping it inside the concrete backend keeps `lampod` backend-agnostic. Revisit if a second block-based backend appears.
 
 ## Risks & mitigations
 
 | Risk | Mitigation |
 |------|------------|
-| BDK API mismatch implementing `Listen` | Port ldk-node `Wallet::block_connected` closely; add integration test on signet regtest |
-| Long initial sync still slow on bitcoind | Fast-sync config + signet defaults; document Esplora follow-up |
-| Regression for existing wallets mid-Emitter scan | `sync_mode=legacy` flag; detect in-progress emitter DB and resume |
-| `wallet.listen().await?` blocking CLI | Refactor scheduler spawn to `tokio::spawn` in Phase A |
+| sync `Listen` adapter must bridge to async `WalletManager` | Hold a `tokio::runtime::Handle` and `block_on` the apply; or make the apply path sync internally. Benchmark; document. |
+| Reorg handling for the wallet via adapter | Implement `block_disconnected` → `WalletManager::disconnect_block`; port ldk-node `Wallet::block_disconnected`; integration test reorgs on regtest. |
+| BDK API mismatch lifting `sync()` into `apply_block` | Body already exists in `sync()`; reuse verbatim; signet regtest test. |
+| Long initial sync still slow on bitcoind | Fast-sync config + signet defaults; Esplora follow-up (Phase D). |
+| Regression for wallets mid-Emitter scan | `sync_mode = legacy` flag; detect in-progress emitter DB and resume. |
+| `wallet.listen().await?` blocking CLI | Refactor scheduler spawn to `tokio::spawn` in Phase A. |
+| Coupling creep back into the wallet | Add a CI grep/`cargo-deny`-style check or a doc test asserting `lampo-bdk-wallet` has no `lightning*` dependency. |
 
 ## Testing plan
 
-1. **Unit:** coordinator state transitions; `getinfo` fields.
-2. **Integration:** regtest/signet node with wallet at 21k, CM at 190k, tip 300k+ — assert `Chain listeners synced` within bounded time; assert single RPC stream (count `getblock` before/after).
-3. **Regression:** open channel after sync; verify no “blocks must be connected in chain-order” panic.
-4. **Compare:** run same scenario against ldk-server with bitcoind RPC — document time-to-`Finished synchronizing listeners`.
+1. **Unit:** coordinator state transitions; `getinfo` fields; adapter `block_connected`/`block_disconnected` delegate to `WalletManager`.
+2. **Trait/decoupling guard:** assert `lampo-bdk-wallet`'s dependency tree contains no `lightning*` crate (CI check) — the modularity invariant as a test.
+3. **Integration:** regtest/signet node with wallet at 21k, CM at 190k, tip 300k+ — assert `Chain listeners synced` within bounded time; assert a single RPC stream (count `getblock` before/after; expect ~1× over the overlap, not 2×).
+4. **Reorg:** invalidate/reconsider blocks on regtest; assert wallet + CM converge without "blocks must be connected in chain-order" panic.
+5. **Compare:** same scenario vs ldk-server with bitcoind RPC — document time-to-`Finished synchronizing listeners`.
 
 ## PR Plan
 
 | PR | Title | Scope | Depends on |
 |----|-------|-------|------------|
-| 1 | `feat(sync): add ChainSyncCoordinator and getinfo progress fields` | `lampo-common`, `lampo-chain`, `lampod` inventory JSON | — |
-| 2 | `fix(wallet): gate BDK Emitter until LDK listeners synced` | `lampo-bdk-wallet`, `lampod-cli` startup order | PR 1 |
-| 3 | `feat(wallet): implement Listen for BDK wallet` | `lampo-bdk-wallet`, trait on `WalletManager` | PR 1 |
-| 4 | `feat(chain): include wallet in synchronize_listeners` | `lampo-chain`, remove parallel initial Emitter | PR 3 |
-| 5 | `feat(config): fast_sync and sync_mode + document reindex` | `lampo.example.conf`, CLI flags, README | PR 4 |
-| 6 | `feat(jsonrpc): add sync_wallets endpoint` | `lampod`, `lampo-httpd` | PR 4 |
-| 7 | `test(signet): integration test unified sync` | `lampo-testing` or docker CI | PR 4 |
+| 1 | `feat(sync): add backend-agnostic ChainSyncCoordinator + getinfo progress` | `lampo-common`, `lampod` inventory JSON | — |
+| 2 | `fix(wallet): gate BDK Emitter until listeners synced; startup reorder` | `lampo-bdk-wallet`, `lampod-cli` | PR 1 |
+| 3 | `feat(wallet): add lampo-native apply_block/current_best_block to WalletManager` | `lampo-common`, `lampo-bdk-wallet` (no LDK) | PR 1 |
+| 4 | `feat(chain): wallet Listen adapter + include wallet in synchronize_listeners` | `lampo-chain` only (adapter lives here) | PR 3 |
+| 5 | `feat(chain): retire parallel Emitter in unified mode` | `lampo-bdk-wallet`, `lampo-chain` | PR 4 |
+| 6 | `feat(config): fast_sync + sync_mode + document reindex` | `lampo.example.conf`, CLI, README | PR 4 |
+| 7 | `feat(jsonrpc): add sync_wallets endpoint` | `lampod`, `lampo-httpd` | PR 4 |
+| 8 | `test: decoupling guard + signet unified-sync integration` | `lampo-testing`, CI | PR 4 |
 
 ## Open questions
 
-1. Should HTTP/API bind be delayed until `initial_sync_complete` (ldk-node-style), or only report status?
-2. Investigate missing `Applied block` logs in release builds — logging level vs apply path bug?
-3. Should signet deployments default `fast_sync=true` in example config?
+1. Should the HTTP/API bind be delayed until `initial_sync_complete` (ldk-node-style), or only report status via `getinfo`?
+2. Investigate missing `Applied block` logs in release builds — logging level vs apply-path bug?
+3. Should signet deployments default `fast_sync = true` in the example config?
+4. Adapter bridging: is `block_on` inside `Listen::block_connected` acceptable, or should `WalletManager::apply_block` have a sync sibling to avoid the runtime bridge?
+5. When Phase D lands, does `WalletManager` grow `apply_confirmed_txs`, or do we introduce a separate `TxWalletSync` sub-trait to keep block-based wallets minimal?
 
 ## References
 
 - ldk-node: `src/chain/bitcoind.rs` — `continuously_sync_wallets`, `synchronize_listeners`
-- ldk-node: `src/wallet/mod.rs` — `impl Listen for Wallet`
-- Lampo: `lampo-chain/src/lib.rs` — `listen()`, `synchronize_listeners`
+- ldk-node: `src/wallet/mod.rs` — `impl Listen for Wallet` (the pattern Lampo deliberately re-homes into the backend)
+- Lampo: `lampo-common/src/backend.rs`, `lampo-common/src/wallet.rs` — the two replaceable seams
+- Lampo: `lampo-chain/src/lib.rs` — `LampoChainSync::listen()`, `synchronize_listeners`
 - Lampo: `lampo-bdk-wallet/src/lib.rs` — `sync()`, `Emitter`
+- Lampo: `lampod/src/chain/blockchain.rs` — `LampoChainManager` composition seam
 - Production tracking: [#540](https://github.com/vincenzopalazzo/lampo.rs/issues/540)

--- a/docs/designs/unified-chain-sync.md
+++ b/docs/designs/unified-chain-sync.md
@@ -2,7 +2,7 @@
 
 | Field | Value |
 |-------|--------|
-| Status | Draft (rev. 2 — decoupled) |
+| Status | In progress (rev. 3 — Phases A–C implemented) |
 | Author | Vincenzo Palazzo (with Grok-assisted analysis; rev. 2 decoupling pass) |
 | Date | 2026-06-03 |
 | Related issues | [#545](https://github.com/vincenzopalazzo/lampo.rs/issues/545), [#540](https://github.com/vincenzopalazzo/lampo.rs/issues/540) (fast sync), [#444](https://github.com/vincenzopalazzo/lampo.rs/issues/444) (`reindex` semantics) |
@@ -410,24 +410,51 @@ If Phase D requires *zero* edits to `lampo-bdk-wallet`, the design met its goal.
 
 ## PR Plan
 
-| PR | Title | Scope | Depends on |
-|----|-------|-------|------------|
-| 1 | `feat(sync): add backend-agnostic ChainSyncCoordinator + getinfo progress` | `lampo-common`, `lampod` inventory JSON | — |
-| 2 | `fix(wallet): gate BDK Emitter until listeners synced; startup reorder` | `lampo-bdk-wallet`, `lampod-cli` | PR 1 |
-| 3 | `feat(wallet): add lampo-native apply_block/current_best_block to WalletManager` | `lampo-common`, `lampo-bdk-wallet` (no LDK) | PR 1 |
-| 4 | `feat(chain): wallet Listen adapter + include wallet in synchronize_listeners` | `lampo-chain` only (adapter lives here) | PR 3 |
-| 5 | `feat(chain): retire parallel Emitter in unified mode` | `lampo-bdk-wallet`, `lampo-chain` | PR 4 |
-| 6 | `feat(config): fast_sync + sync_mode + document reindex` | `lampo.example.conf`, CLI, README | PR 4 |
-| 7 | `feat(jsonrpc): add sync_wallets endpoint` | `lampod`, `lampo-httpd` | PR 4 |
-| 8 | `test: decoupling guard + signet unified-sync integration` | `lampo-testing`, CI | PR 4 |
+Implemented as a single branch of self-contained commits (commit subjects use
+the repo's `crate:` prefix convention rather than `feat()`):
 
-## Open questions
+| # | Commit | Scope | Status |
+|---|--------|-------|--------|
+| 1 | `sync: add ChainSyncCoordinator and getinfo fields` | `lampo-common`, `lampod` | Done |
+| 2 | `wallet: gate BDK Emitter on listener sync` | `lampo-bdk-wallet`, `lampo-chain`, `lampod`, `lampod-cli` | Done |
+| 3a | `wallet: add apply_block/current_best_block` | `lampo-common`, `lampo-bdk-wallet` (no LDK) | Done |
+| 3b | `wallet: synchronous chain-state locking` | `lampo-bdk-wallet` (std mutex; fixes guard-shadow bug) | Done |
+| 4 | `chain: drive wallet through synchronize_listeners` | `lampo-chain` adapter + `Backend::set_wallet_manager` | Done |
+| 6 | `config: add sync_mode and fast_sync` | `lampo-common`, `lampo-chain`, `lampo-bdk-wallet`, example conf | Done |
+| 7 | `jsonrpc: add sync_wallets endpoint` | `lampo-common`, `lampod`, `lampo-httpd` | Done |
+| 8 | `ci: guard wallet stays free of LDK` | `tools/`, `build.yml` | Done (decoupling guard) |
+| 5 | retire the Emitter for ongoing updates | `lampo-chain`, `lampo-bdk-wallet` | **Deferred** |
+| 8b | signet unified-sync integration test | `lampo-testing` / docker CI | **Deferred** |
 
-1. Should the HTTP/API bind be delayed until `initial_sync_complete` (ldk-node-style), or only report status via `getinfo`?
-2. Investigate missing `Applied block` logs in release builds — logging level vs apply-path bug?
-3. Should signet deployments default `fast_sync = true` in the example config?
-4. Adapter bridging: is `block_on` inside `Listen::block_connected` acceptable, or should `WalletManager::apply_block` have a sync sibling to avoid the runtime bridge?
-5. When Phase D lands, does `WalletManager` grow `apply_confirmed_txs`, or do we introduce a separate `TxWalletSync` sub-trait to keep block-based wallets minimal?
+**Why PR 5 is deferred:** the production bug (parallel dual full-scan) is already
+fixed — PR 2 gates the Emitter and PR 4 folds the wallet's *initial* catch-up
+into `synchronize_listeners`, so the overlapping range is fetched once. The
+Emitter now only serves cheap *incremental* ongoing polling (gated). Fully
+retiring it requires driving the wallet from the `SpvClient` poll loop, but LDK
+only implements `Listen` for `(T, U)` where both are `Deref` (so a 3-listener
+tuple needs a custom `Listen` impl). That change has real reorg/ongoing-update
+risk and is best landed with the signet integration test (8b) to validate it.
+
+## Open questions — resolved
+
+1. **HTTP bind vs sync:** *report-only* (do not block the bind). `getinfo` exposes
+   the progress fields; the `sync_wallets` RPC (PR 7) is the opt-in blocking wait.
+   Per-command readiness guards for fund-requiring commands are a follow-up.
+2. **Missing `Applied block` logs / frozen db:** root cause was a latent lock bug —
+   `listen()` shadowed the wallet `MutexGuard` and held it across the scheduler
+   `.await`s. Fixed in PR 3b (sync locks + scoped guards). The blocking
+   `Emitter::next_block()` under `tokio::spawn` should move to `spawn_blocking` in
+   the legacy path (follow-up); the unified path (PR 4) avoids the issue.
+3. **signet `fast_sync` default:** code default stays `true` but only ever applies
+   to a *fresh* wallet (height 0, no UTXOs to miss); documented in the example
+   conf. No unsafe history-skipping for funded wallets.
+4. **Adapter bridge:** resolved to a *synchronous wallet core* (PR 3b) — no
+   `block_in_place`/`block_on`, so the adapter drives the wallet from
+   `Listen::block_connected` on any runtime flavor, keeping `LampoDaemon`
+   embeddable. The LDK coupling is confined to `lampo-chain`.
+5. **Phase D tx-based wallet:** introduce a separate `TxWalletSync` sub-trait when
+   Esplora/Electrum lands; keep `apply_block` on `WalletManager` for now (one
+   mode, one impl) per "write for today."
 
 ## References
 

--- a/lampo-bdk-wallet/src/lib.rs
+++ b/lampo-bdk-wallet/src/lib.rs
@@ -28,7 +28,7 @@ use lampo_common::keys::LampoKeys;
 use lampo_common::model::response::NewAddress;
 use lampo_common::model::response::Utxo;
 use lampo_common::secp256k1::SecretKey;
-use lampo_common::wallet::WalletManager;
+use lampo_common::wallet::{BlockRef, WalletManager};
 use lampo_common::{async_trait, error};
 
 pub struct BDKWalletManager {
@@ -391,6 +391,33 @@ impl WalletManager for BDKWalletManager {
         let tip = wallet.latest_checkpoint().height();
         let tip = Height::from_consensus(tip)?;
         Ok(tip)
+    }
+
+    async fn current_best_block(&self) -> error::Result<BlockRef> {
+        let wallet = self.wallet.lock().await;
+        let checkpoint = wallet.latest_checkpoint();
+        Ok(BlockRef {
+            height: checkpoint.height(),
+            hash: checkpoint.hash(),
+        })
+    }
+
+    async fn apply_block(&self, block: &Block, height: u32) -> error::Result<()> {
+        let mut wallet = self.wallet.lock().await;
+        let mut wallet_db = self.wallet_db.lock().await;
+        // Connect to the parent block. During sequential catch-up this is the
+        // previous block, which BDK matches against its checkpoint chain; on a
+        // reorg the differing `prev_blockhash` rolls the wallet chain back.
+        let connected_to = BlockId {
+            height: height.saturating_sub(1),
+            hash: block.header.prev_blockhash,
+        };
+        wallet.apply_block_connected_to(block, height, connected_to)?;
+        wallet.persist(&mut wallet_db)?;
+        if let Some(coordinator) = self.coordinator.get() {
+            coordinator.set_wallet_scan_height(height);
+        }
+        Ok(())
     }
 
     async fn listen(self: Arc<Self>) -> error::Result<()> {

--- a/lampo-bdk-wallet/src/lib.rs
+++ b/lampo-bdk-wallet/src/lib.rs
@@ -1,6 +1,6 @@
 //! Wallet Manager implementation with BDK
 use std::str::FromStr;
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 
 use bdk_bitcoind_rpc::bitcoincore_rpc::{Auth, Client, RpcApi};
 use bdk_bitcoind_rpc::Emitter;
@@ -22,6 +22,7 @@ use lampo_common::bitcoin::bip32::Xpriv;
 use lampo_common::bitcoin::blockdata::locktime::absolute::LockTime;
 use lampo_common::bitcoin::PrivateKey;
 use lampo_common::bitcoin::{Amount, Block, FeeRate, ScriptBuf, Transaction};
+use lampo_common::chainsync::ChainSyncCoordinator;
 use lampo_common::conf::{LampoConf, Network};
 use lampo_common::keys::LampoKeys;
 use lampo_common::model::response::NewAddress;
@@ -40,6 +41,10 @@ pub struct BDKWalletManager {
     pub conf: Arc<LampoConf>,
 
     guard: Mutex<bool>,
+    /// Chain-sync coordinator, when wired in. Gates the Emitter scan on LDK
+    /// listener sync and carries scan progress. `None` (e.g. in tests) leaves
+    /// the wallet syncing immediately, exactly as before.
+    coordinator: OnceLock<Arc<ChainSyncCoordinator>>,
 }
 
 impl BDKWalletManager {
@@ -188,6 +193,7 @@ impl WalletManager for BDKWalletManager {
                 guard: Mutex::new(false),
                 reindex_from: conf.reindex,
                 conf: conf.clone(),
+                coordinator: OnceLock::new(),
             },
             mnemonic_words,
         ))
@@ -206,6 +212,7 @@ impl WalletManager for BDKWalletManager {
             guard: Mutex::new(false),
             reindex_from: conf.reindex,
             conf: conf.clone(),
+            coordinator: OnceLock::new(),
         })
     }
 
@@ -272,6 +279,12 @@ impl WalletManager for BDKWalletManager {
         Ok(txs)
     }
 
+    fn set_coordinator(&self, coordinator: Arc<ChainSyncCoordinator>) {
+        self.coordinator
+            .set(coordinator)
+            .unwrap_or_else(|_| panic!("chain sync coordinator already set"));
+    }
+
     async fn sync(&self) -> error::Result<()> {
         #[derive(Debug)]
         enum Emission {
@@ -327,6 +340,9 @@ impl WalletManager for BDKWalletManager {
                     let start_apply_block = Instant::now();
                     wallet.apply_block_connected_to(&block_emission.block, height, connected_to)?;
                     wallet.persist(&mut wallet_db)?;
+                    if let Some(coordinator) = self.coordinator.get() {
+                        coordinator.set_wallet_scan_height(height);
+                    }
                     let elapsed = start_apply_block.elapsed().as_secs_f32();
                     log::info!(target: "lampo-wallet",
                         "Applied block {} at height {} in {}s",
@@ -359,6 +375,14 @@ impl WalletManager for BDKWalletManager {
             }
             Ok(Ok(())) => {}
         }
+
+        // The wallet has caught up to the chain tip. If the LDK listeners are
+        // also synced, the node's initial sync is complete.
+        if let Some(coordinator) = self.coordinator.get() {
+            if coordinator.chain_listeners_synced() {
+                coordinator.mark_running();
+            }
+        }
         Ok(())
     }
 
@@ -374,6 +398,19 @@ impl WalletManager for BDKWalletManager {
         sched.shutdown_on_ctrl_c();
 
         async fn innet_sync(wallet: Arc<BDKWalletManager>) -> error::Result<()> {
+            // Gate: hold the Emitter scan until the LDK chain listeners have
+            // synced, so the two pipelines don't compete for the same RPC.
+            // Active only when a coordinator is wired in and
+            // `wallet_sync_parallel` is unset; otherwise sync runs as before.
+            let parallel = wallet.conf.wallet_sync_parallel.unwrap_or(false);
+            if !parallel {
+                if let Some(coordinator) = wallet.coordinator.get() {
+                    if !coordinator.chain_listeners_synced() {
+                        log::info!(target: "lampo-wallet", "Waiting for chain listeners to sync before scanning the wallet");
+                        return Ok(());
+                    }
+                }
+            }
             let _is_sync = wallet.guard.lock().await;
             log::debug!(target: "lampo-wallet", "Tick tock, time to check if we need to sync the wallet");
             wallet.sync().await?;

--- a/lampo-bdk-wallet/src/lib.rs
+++ b/lampo-bdk-wallet/src/lib.rs
@@ -1,6 +1,11 @@
 //! Wallet Manager implementation with BDK
 use std::str::FromStr;
-use std::sync::{Arc, OnceLock};
+// The on-chain wallet + its sqlite handle are guarded by a std (blocking)
+// mutex, not a tokio one: their critical sections are short and fully
+// synchronous (BDK apply + rusqlite persist), and a sync lock lets the LDK
+// `Listen` adapter drive `apply_block` without an async runtime. `guard`
+// stays a tokio mutex because it is held across `.await`.
+use std::sync::{Arc, Mutex as StdMutex, OnceLock};
 
 use bdk_bitcoind_rpc::bitcoincore_rpc::{Auth, Client, RpcApi};
 use bdk_bitcoind_rpc::Emitter;
@@ -32,8 +37,8 @@ use lampo_common::wallet::{BlockRef, WalletManager};
 use lampo_common::{async_trait, error};
 
 pub struct BDKWalletManager {
-    pub wallet: Mutex<PersistedWallet<Connection>>,
-    pub wallet_db: Mutex<Connection>,
+    pub wallet: StdMutex<PersistedWallet<Connection>>,
+    pub wallet_db: StdMutex<Connection>,
     pub rpc: Arc<Client>,
     pub keymanager: Arc<LampoKeys>,
     pub network: Network,
@@ -171,6 +176,36 @@ impl BDKWalletManager {
         let client = Client::new(url, Auth::UserPass(user.clone(), pass.clone()))?;
         Ok(client)
     }
+
+    /// Apply a connected block to the wallet, given the BDK `connected_to`
+    /// point. Synchronous: holds the wallet/db locks only for the short BDK
+    /// apply + persist, so callers (including the async `sync` loop and the
+    /// LDK `Listen` adapter) never hold a `MutexGuard` across an `.await`.
+    fn apply_block_inner(
+        &self,
+        block: &Block,
+        height: u32,
+        connected_to: BlockId,
+    ) -> error::Result<()> {
+        let mut wallet = self.wallet.lock().unwrap();
+        let mut wallet_db = self.wallet_db.lock().unwrap();
+        wallet.apply_block_connected_to(block, height, connected_to)?;
+        wallet.persist(&mut wallet_db)?;
+        if let Some(coordinator) = self.coordinator.get() {
+            coordinator.set_wallet_scan_height(height);
+        }
+        Ok(())
+    }
+
+    /// Apply unconfirmed (mempool) transactions to the wallet. Synchronous for
+    /// the same reason as [`Self::apply_block_inner`].
+    fn apply_mempool(&self, txs: Vec<(Arc<Transaction>, u64)>) -> error::Result<()> {
+        let mut wallet = self.wallet.lock().unwrap();
+        let mut wallet_db = self.wallet_db.lock().unwrap();
+        wallet.apply_unconfirmed_txs(txs);
+        wallet.persist(&mut wallet_db)?;
+        Ok(())
+    }
 }
 
 #[async_trait]
@@ -185,8 +220,8 @@ impl WalletManager for BDKWalletManager {
         let client = Self::build_client(conf.clone())?;
         Ok((
             Self {
-                wallet: Mutex::new(wallet),
-                wallet_db: Mutex::new(db),
+                wallet: StdMutex::new(wallet),
+                wallet_db: StdMutex::new(db),
                 keymanager: Arc::new(keymanager),
                 network: conf.network,
                 rpc: Arc::new(client),
@@ -204,8 +239,8 @@ impl WalletManager for BDKWalletManager {
             BDKWalletManager::build_wallet(conf.clone(), mnemonic_words).await?;
         let client = BDKWalletManager::build_client(conf.clone())?;
         Ok(Self {
-            wallet: Mutex::new(wallet),
-            wallet_db: Mutex::new(db),
+            wallet: StdMutex::new(wallet),
+            wallet_db: StdMutex::new(db),
             keymanager: Arc::new(keymanager),
             network: conf.network,
             rpc: Arc::new(client),
@@ -221,8 +256,8 @@ impl WalletManager for BDKWalletManager {
     }
 
     async fn get_onchain_address(&self) -> error::Result<NewAddress> {
-        let mut wallet = self.wallet.lock().await;
-        let mut wallet_db = self.wallet_db.lock().await;
+        let mut wallet = self.wallet.lock().unwrap();
+        let mut wallet_db = self.wallet_db.lock().unwrap();
         let address = wallet.reveal_next_address(KeychainKind::External);
         wallet.persist(&mut wallet_db)?;
         Ok(NewAddress {
@@ -232,7 +267,7 @@ impl WalletManager for BDKWalletManager {
 
     // Return in satoshis
     async fn get_onchain_balance(&self) -> error::Result<u64> {
-        let balance = self.wallet.lock().await.balance();
+        let balance = self.wallet.lock().unwrap().balance();
         log::warn!(target: "lampo-wallet", "balance: {balance:?}");
         Ok(balance.confirmed.to_sat())
     }
@@ -244,7 +279,7 @@ impl WalletManager for BDKWalletManager {
         fee_rate: FeeRate,
         best_block: Height,
     ) -> error::Result<Transaction> {
-        let mut wallet = self.wallet.lock().await;
+        let mut wallet = self.wallet.lock().unwrap();
 
         // We set nLockTime to the current height to discourage fee sniping.
         let locktime =
@@ -264,7 +299,7 @@ impl WalletManager for BDKWalletManager {
 
     async fn list_transactions(&self) -> error::Result<Vec<Utxo>> {
         log::info!("lampo-wallet: list transactions");
-        let wallet = self.wallet.lock().await;
+        let wallet = self.wallet.lock().unwrap();
         log::info!("lampo-wallet: wallet lock taken");
         let txs = wallet
             .list_unspent()
@@ -304,10 +339,14 @@ impl WalletManager for BDKWalletManager {
         });*/
 
         let rpc_client = self.rpc.clone();
-        let wallet = self.wallet.lock().await;
-        let wallet_tip = wallet.latest_checkpoint();
-        let start_height = wallet_tip.height();
-        drop(wallet);
+        // Scope the (std) wallet guard so it is provably released before the
+        // async work below; the checkpoint we return is owned.
+        let (wallet_tip, start_height) = {
+            let wallet = self.wallet.lock().unwrap();
+            let checkpoint = wallet.latest_checkpoint();
+            let height = checkpoint.height();
+            (checkpoint, height)
+        };
 
         let emitter_handle = tokio::spawn(async move {
             let mut emitter = Emitter::new(
@@ -325,9 +364,8 @@ impl WalletManager for BDKWalletManager {
         });
 
         while let Some(emission) = receiver.recv().await {
-            let mut wallet = self.wallet.lock().await;
-            let mut wallet_db = self.wallet_db.lock().await;
-
+            // All wallet locking happens inside the synchronous helpers so no
+            // `MutexGuard` is held across the `.await` above.
             match emission {
                 Emission::SigTerm => {
                     println!("Sigterm received, exiting...");
@@ -338,11 +376,7 @@ impl WalletManager for BDKWalletManager {
                     let hash = block_emission.block_hash();
                     let connected_to = block_emission.connected_to();
                     let start_apply_block = Instant::now();
-                    wallet.apply_block_connected_to(&block_emission.block, height, connected_to)?;
-                    wallet.persist(&mut wallet_db)?;
-                    if let Some(coordinator) = self.coordinator.get() {
-                        coordinator.set_wallet_scan_height(height);
-                    }
+                    self.apply_block_inner(&block_emission.block, height, connected_to)?;
                     let elapsed = start_apply_block.elapsed().as_secs_f32();
                     log::info!(target: "lampo-wallet",
                         "Applied block {} at height {} in {}s",
@@ -352,8 +386,7 @@ impl WalletManager for BDKWalletManager {
                 Emission::Mempool(mempool_emission) => {
                     log::warn!(target: "lampo-wallet", "Mempool emission: {mempool_emission:?}");
                     let start_apply_mempool = Instant::now();
-                    wallet.apply_unconfirmed_txs(mempool_emission);
-                    wallet.persist(&mut wallet_db)?;
+                    self.apply_mempool(mempool_emission)?;
                     log::info!(target: "lampo-wallet",
                         "Applied unconfirmed transactions in {}s",
                         start_apply_mempool.elapsed().as_secs_f32()
@@ -387,14 +420,14 @@ impl WalletManager for BDKWalletManager {
     }
 
     async fn wallet_tips(&self) -> error::Result<Height> {
-        let wallet = self.wallet.lock().await;
+        let wallet = self.wallet.lock().unwrap();
         let tip = wallet.latest_checkpoint().height();
         let tip = Height::from_consensus(tip)?;
         Ok(tip)
     }
 
-    async fn current_best_block(&self) -> error::Result<BlockRef> {
-        let wallet = self.wallet.lock().await;
+    fn current_best_block(&self) -> error::Result<BlockRef> {
+        let wallet = self.wallet.lock().unwrap();
         let checkpoint = wallet.latest_checkpoint();
         Ok(BlockRef {
             height: checkpoint.height(),
@@ -402,9 +435,7 @@ impl WalletManager for BDKWalletManager {
         })
     }
 
-    async fn apply_block(&self, block: &Block, height: u32) -> error::Result<()> {
-        let mut wallet = self.wallet.lock().await;
-        let mut wallet_db = self.wallet_db.lock().await;
+    fn apply_block(&self, block: &Block, height: u32) -> error::Result<()> {
         // Connect to the parent block. During sequential catch-up this is the
         // previous block, which BDK matches against its checkpoint chain; on a
         // reorg the differing `prev_blockhash` rolls the wallet chain back.
@@ -412,12 +443,7 @@ impl WalletManager for BDKWalletManager {
             height: height.saturating_sub(1),
             hash: block.header.prev_blockhash,
         };
-        wallet.apply_block_connected_to(block, height, connected_to)?;
-        wallet.persist(&mut wallet_db)?;
-        if let Some(coordinator) = self.coordinator.get() {
-            coordinator.set_wallet_scan_height(height);
-        }
-        Ok(())
+        self.apply_block_inner(block, height, connected_to)
     }
 
     async fn listen(self: Arc<Self>) -> error::Result<()> {
@@ -444,36 +470,41 @@ impl WalletManager for BDKWalletManager {
             Ok(())
         }
 
-        // we need to modify the bdk wallet state in this position.
-        let rpc_client = self.rpc.clone();
-        let mut wallet = self.wallet.lock().await;
-        let wallet_tip = wallet.latest_checkpoint();
-        let start_height = wallet_tip.height();
+        // Set up the initial wallet checkpoint (reindex / fast-forward). Scoped
+        // so the synchronous wallet guard is released before the async
+        // scheduler work below. Previously this guard was shadowed by
+        // `let wallet = self.clone()` and held across the scheduler `.await`s.
+        {
+            let rpc_client = self.rpc.clone();
+            let mut wallet = self.wallet.lock().unwrap();
+            let wallet_tip = wallet.latest_checkpoint();
+            let start_height = wallet_tip.height();
 
-        let reindex_from = self.reindex_from.or_else(|| {
-            if start_height == 0 {
-                rpc_client.get_blockchain_info().ok().map(|info| {
-                    Height::from_consensus(info.blocks as u32)
-                        .expect("Failed to convert blockchain height to consensus height")
-                })
-            } else {
-                None
-            }
-        });
+            let reindex_from = self.reindex_from.or_else(|| {
+                if start_height == 0 {
+                    rpc_client.get_blockchain_info().ok().map(|info| {
+                        Height::from_consensus(info.blocks as u32)
+                            .expect("Failed to convert blockchain height to consensus height")
+                    })
+                } else {
+                    None
+                }
+            });
 
-        // Instruct the wallet to reindex from the specified height, ensuring it starts scanning the blockchain from this point onward.
-        if let Some(height) = reindex_from {
-            let height = height.to_consensus_u32();
-            if height > wallet_tip.height() {
-                // Insert a checkpoint into the wallet to avoid scanning the entire chain.
-                let hash = rpc_client.get_block_hash(height as u64)?;
-                let block = BlockId { height, hash };
-                let new_tip = wallet_tip.insert(block);
-                let update = bdk_wallet::Update {
-                    chain: Some(new_tip),
-                    ..Default::default()
-                };
-                wallet.apply_update(update)?;
+            // Instruct the wallet to reindex from the specified height, ensuring it starts scanning the blockchain from this point onward.
+            if let Some(height) = reindex_from {
+                let height = height.to_consensus_u32();
+                if height > wallet_tip.height() {
+                    // Insert a checkpoint into the wallet to avoid scanning the entire chain.
+                    let hash = rpc_client.get_block_hash(height as u64)?;
+                    let block = BlockId { height, hash };
+                    let new_tip = wallet_tip.insert(block);
+                    let update = bdk_wallet::Update {
+                        chain: Some(new_tip),
+                        ..Default::default()
+                    };
+                    wallet.apply_update(update)?;
+                }
             }
         }
 

--- a/lampo-bdk-wallet/src/lib.rs
+++ b/lampo-bdk-wallet/src/lib.rs
@@ -480,8 +480,12 @@ impl WalletManager for BDKWalletManager {
             let wallet_tip = wallet.latest_checkpoint();
             let start_height = wallet_tip.height();
 
+            // Fast-sync (default on) jumps an empty wallet's checkpoint to the
+            // chain tip rather than scanning from genesis. Only ever applies to
+            // a fresh wallet (height 0), which has no UTXOs to miss.
+            let fast_sync = self.conf.fast_sync.unwrap_or(true);
             let reindex_from = self.reindex_from.or_else(|| {
-                if start_height == 0 {
+                if start_height == 0 && fast_sync {
                     rpc_client.get_blockchain_info().ok().map(|info| {
                         Height::from_consensus(info.blocks as u32)
                             .expect("Failed to convert blockchain height to consensus height")

--- a/lampo-chain/src/lib.rs
+++ b/lampo-chain/src/lib.rs
@@ -10,7 +10,7 @@ use lightning_block_sync::{BlockSource, SpvClient};
 use lampo_common::async_trait;
 use lampo_common::backend::{Backend, BlockData};
 use lampo_common::bitcoin::consensus::encode::serialize_hex;
-use lampo_common::bitcoin::BlockHash;
+use lampo_common::bitcoin::{Block, BlockHash};
 use lampo_common::chainsync::ChainSyncCoordinator;
 use lampo_common::conf::LampoConf;
 use lampo_common::error;
@@ -18,6 +18,51 @@ use lampo_common::json;
 use lampo_common::ldk::chain;
 use lampo_common::serde::Deserialize;
 use lampo_common::types::{LampoChainMonitor, LampoChannel};
+use lampo_common::wallet::WalletManager;
+
+/// Adapts the on-chain wallet to LDK's [`chain::Listen`] so it can ride the
+/// same `synchronize_listeners` pass as the channel manager and chain monitor
+/// -- one RPC stream for the whole node, instead of a second `getblock` scan.
+///
+/// This is the *only* place the LDK chain-sync types meet the wallet: the
+/// coupling is confined to the bitcoind backend crate. The wallet itself
+/// stays free of LDK, driven through the lampo-native `WalletManager` API.
+struct WalletChainListener {
+    wallet: Arc<dyn WalletManager>,
+}
+
+impl chain::Listen for WalletChainListener {
+    fn filtered_block_connected(
+        &self,
+        _header: &lampo_common::bitcoin::block::Header,
+        _txdata: &chain::transaction::TransactionData,
+        _height: u32,
+    ) {
+        // Lampo's bitcoind backend delivers full blocks, so `block_connected`
+        // below is what actually runs. Mirrors ldk-node's wallet listener.
+        debug_assert!(
+            false,
+            "filtered_block_connected is unsupported for the on-chain wallet"
+        );
+    }
+
+    fn block_connected(&self, block: &Block, height: u32) {
+        if let Err(err) = self.wallet.apply_block(block, height) {
+            log::error!(
+                target: "lampo-chain",
+                "on-chain wallet apply_block at height {height} failed: {err}"
+            );
+        }
+    }
+
+    fn blocks_disconnected(&self, _fork_point_block: chain::BlockLocator) {
+        // BDK rolls the wallet chain back via the next `block_connected`'s
+        // `connected_to` (the new parent), so an explicit disconnect is a
+        // no-op. Reorgs do not occur during the initial historical catch-up;
+        // ongoing reorgs are handled by the wallet's Emitter poll.
+        log::debug!(target: "lampo-chain", "on-chain wallet listener: blocks_disconnected");
+    }
+}
 
 /// Welcome in another Facede pattern implementation
 pub struct LampoChainSync {
@@ -27,6 +72,7 @@ pub struct LampoChainSync {
     chain_monitor: OnceLock<Arc<LampoChainMonitor>>,
     handler: OnceLock<Arc<dyn lampo_common::handler::Handler>>,
     coordinator: OnceLock<Arc<ChainSyncCoordinator>>,
+    wallet: OnceLock<Arc<dyn WalletManager>>,
 }
 
 impl LampoChainSync {
@@ -62,6 +108,7 @@ impl LampoChainSync {
             chain_monitor: OnceLock::new(),
             handler: OnceLock::new(),
             coordinator: OnceLock::new(),
+            wallet: OnceLock::new(),
         })
     }
 
@@ -89,6 +136,10 @@ impl LampoChainSync {
             .get()
             .expect("chain monitor not set")
             .clone()
+    }
+
+    fn wallet(&self) -> Option<Arc<dyn WalletManager>> {
+        self.wallet.get().cloned()
     }
 }
 
@@ -228,6 +279,12 @@ impl Backend for LampoChainSync {
             .unwrap_or_else(|_| panic!("chain sync coordinator already set"));
     }
 
+    fn set_wallet_manager(&self, wallet: Arc<dyn WalletManager>) {
+        self.wallet
+            .set(wallet)
+            .unwrap_or_else(|_| panic!("wallet manager already set"));
+    }
+
     async fn listen(self: Arc<Self>) -> lampo_common::error::Result<()> {
         let channel_manager = self.channel_manager();
         let chain_monitor = self.chain_monitor();
@@ -240,7 +297,18 @@ impl Backend for LampoChainSync {
         // N+M+1 to the ChannelManager which still thinks it's at block N,
         // causing a "Blocks must be connected in chain-order" assertion.
         let manager_best = channel_manager.current_best_block();
-        let chain_listeners: Vec<(chain::BlockLocator, &(dyn chain::Listen + Send + Sync))> = vec![
+
+        // When an on-chain wallet is wired in, include it in the same sync pass
+        // so one RPC stream catches up the channel manager, chain monitor, and
+        // wallet together -- deduplicating the overlapping block range instead
+        // of running a second `getblock` scan. Kept in locals so the listener
+        // outlives the `chain_listeners` vec consumed by `synchronize_listeners`.
+        let wallet = self.wallet();
+        let wallet_listener = wallet.as_ref().map(|wallet| WalletChainListener {
+            wallet: wallet.clone(),
+        });
+
+        let mut chain_listeners: Vec<(chain::BlockLocator, &(dyn chain::Listen + Send + Sync))> = vec![
             (
                 manager_best.clone(),
                 &*channel_manager as &(dyn chain::Listen + Send + Sync),
@@ -250,6 +318,24 @@ impl Backend for LampoChainSync {
                 &*chain_monitor as &(dyn chain::Listen + Send + Sync),
             ),
         ];
+        if let (Some(wallet), Some(listener)) = (wallet.as_ref(), wallet_listener.as_ref()) {
+            match wallet.current_best_block() {
+                Ok(best) => {
+                    log::info!(
+                        target: "lampo-chain",
+                        "Including on-chain wallet in chain sync from height {}",
+                        best.height
+                    );
+                    chain_listeners.push((
+                        chain::BlockLocator::new(best.hash, best.height),
+                        listener as &(dyn chain::Listen + Send + Sync),
+                    ));
+                }
+                Err(err) => {
+                    log::error!(target: "lampo-chain", "skipping on-chain wallet in chain sync: {err}")
+                }
+            }
+        }
 
         log::info!(
             target: "lampo-chain",

--- a/lampo-chain/src/lib.rs
+++ b/lampo-chain/src/lib.rs
@@ -1,3 +1,4 @@
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, OnceLock};
 
 use lampo_common::event::onchain::OnChainEvent;
@@ -29,6 +30,29 @@ use lampo_common::wallet::WalletManager;
 /// stays free of LDK, driven through the lampo-native `WalletManager` API.
 struct WalletChainListener {
     wallet: Arc<dyn WalletManager>,
+    /// Set if any `apply_block` failed during a sync pass. `Listen` methods
+    /// can't return errors, so we record the failure here for the caller to
+    /// surface instead of silently advertising a successful unified sync.
+    failed: AtomicBool,
+}
+
+impl WalletChainListener {
+    fn new(wallet: Arc<dyn WalletManager>) -> Self {
+        Self {
+            wallet,
+            failed: AtomicBool::new(false),
+        }
+    }
+
+    /// Clear the failure flag before a (re)try of `synchronize_listeners`.
+    fn reset(&self) {
+        self.failed.store(false, Ordering::Relaxed);
+    }
+
+    /// Whether any block apply failed during the last sync pass.
+    fn had_failure(&self) -> bool {
+        self.failed.load(Ordering::Relaxed)
+    }
 }
 
 impl chain::Listen for WalletChainListener {
@@ -52,6 +76,7 @@ impl chain::Listen for WalletChainListener {
                 target: "lampo-chain",
                 "on-chain wallet apply_block at height {height} failed: {err}"
             );
+            self.failed.store(true, Ordering::Relaxed);
         }
     }
 
@@ -298,51 +323,23 @@ impl Backend for LampoChainSync {
         // causing a "Blocks must be connected in chain-order" assertion.
         let manager_best = channel_manager.current_best_block();
 
-        // When an on-chain wallet is wired in (and not in `legacy` sync mode),
-        // include it in the same sync pass so one RPC stream catches up the
-        // channel manager, chain monitor, and wallet together -- deduplicating
-        // the overlapping block range instead of running a second `getblock`
-        // scan. Kept in locals so the listener outlives the `chain_listeners`
-        // vec consumed by `synchronize_listeners`.
-        let unified = self
+        // Include the on-chain wallet in the same sync pass so one RPC stream
+        // catches up the channel manager, chain monitor, and wallet together --
+        // deduplicating the overlapping block range instead of a second
+        // `getblock` scan. Excluded in `legacy` sync mode, and when
+        // `wallet_sync_parallel` is set (the wallet then runs its own Emitter,
+        // so attaching it here too would double-apply blocks). Kept in a local
+        // so it outlives the `chain_listeners` vec consumed on each attempt.
+        let parallel = self.config.wallet_sync_parallel.unwrap_or(false);
+        let legacy = self
             .config
             .sync_mode
             .as_deref()
-            .map(|mode| !mode.eq_ignore_ascii_case("legacy"))
-            .unwrap_or(true);
+            .map(|mode| mode.eq_ignore_ascii_case("legacy"))
+            .unwrap_or(false);
+        let unified = !legacy && !parallel;
         let wallet = if unified { self.wallet() } else { None };
-        let wallet_listener = wallet.as_ref().map(|wallet| WalletChainListener {
-            wallet: wallet.clone(),
-        });
-
-        let mut chain_listeners: Vec<(chain::BlockLocator, &(dyn chain::Listen + Send + Sync))> = vec![
-            (
-                manager_best.clone(),
-                &*channel_manager as &(dyn chain::Listen + Send + Sync),
-            ),
-            (
-                manager_best.clone(),
-                &*chain_monitor as &(dyn chain::Listen + Send + Sync),
-            ),
-        ];
-        if let (Some(wallet), Some(listener)) = (wallet.as_ref(), wallet_listener.as_ref()) {
-            match wallet.current_best_block() {
-                Ok(best) => {
-                    log::info!(
-                        target: "lampo-chain",
-                        "Including on-chain wallet in chain sync from height {}",
-                        best.height
-                    );
-                    chain_listeners.push((
-                        chain::BlockLocator::new(best.hash, best.height),
-                        listener as &(dyn chain::Listen + Send + Sync),
-                    ));
-                }
-                Err(err) => {
-                    log::error!(target: "lampo-chain", "skipping on-chain wallet in chain sync: {err}")
-                }
-            }
-        }
+        let wallet_listener = wallet.as_ref().map(|w| WalletChainListener::new(w.clone()));
 
         log::info!(
             target: "lampo-chain",
@@ -351,12 +348,72 @@ impl Backend for LampoChainSync {
             manager_best.height
         );
 
-        let (cache, synced_chain_tip) =
-            init::synchronize_listeners(self.as_ref(), self.config.network, chain_listeners)
+        // Retry on transient RPC failures so a hiccup in `synchronize_listeners`
+        // can't leave the coordinator stuck in `PendingInitialSync` (which would
+        // permanently gate the on-chain wallet). Each attempt rebuilds the
+        // listener set from the current best blocks, resuming where it left off.
+        let (cache, synced_chain_tip) = loop {
+            if let Some(listener) = wallet_listener.as_ref() {
+                listener.reset();
+            }
+            let manager_best = channel_manager.current_best_block();
+            let mut chain_listeners: Vec<(
+                chain::BlockLocator,
+                &(dyn chain::Listen + Send + Sync),
+            )> = vec![
+                (
+                    manager_best.clone(),
+                    &*channel_manager as &(dyn chain::Listen + Send + Sync),
+                ),
+                (
+                    manager_best.clone(),
+                    &*chain_monitor as &(dyn chain::Listen + Send + Sync),
+                ),
+            ];
+            if let (Some(wallet), Some(listener)) = (wallet.as_ref(), wallet_listener.as_ref()) {
+                match wallet.current_best_block() {
+                    Ok(best) => {
+                        log::info!(
+                            target: "lampo-chain",
+                            "Including on-chain wallet in chain sync from height {}",
+                            best.height
+                        );
+                        chain_listeners.push((
+                            chain::BlockLocator::new(best.hash, best.height),
+                            listener as &(dyn chain::Listen + Send + Sync),
+                        ));
+                    }
+                    Err(err) => {
+                        log::error!(target: "lampo-chain", "skipping on-chain wallet in chain sync: {err}")
+                    }
+                }
+            }
+
+            match init::synchronize_listeners(self.as_ref(), self.config.network, chain_listeners)
                 .await
-                .map_err(|e| error::anyhow!("Failed to synchronize chain listeners: {:?}", e))?;
+            {
+                Ok(result) => break result,
+                Err(e) => {
+                    log::error!(
+                        target: "lampo-chain",
+                        "Failed to synchronize chain listeners, retrying in 5s: {:?}", e
+                    );
+                    tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+                }
+            }
+        };
 
         log::info!(target: "lampo-chain", "Chain listeners synced to current tip");
+
+        // If the wallet failed to apply some blocks during the pass, surface it.
+        // The node still advances the LDK listeners; the gated wallet Emitter
+        // will recover the wallet from its last good checkpoint.
+        if wallet_listener.as_ref().is_some_and(|l| l.had_failure()) {
+            log::warn!(
+                target: "lampo-chain",
+                "on-chain wallet did not fully apply during unified sync; the wallet scan will recover it from its last good checkpoint"
+            );
+        }
 
         // Publish listener-sync completion so gated components (e.g. the
         // on-chain wallet) can proceed over the now-free RPC. No-op when no

--- a/lampo-chain/src/lib.rs
+++ b/lampo-chain/src/lib.rs
@@ -11,6 +11,7 @@ use lampo_common::async_trait;
 use lampo_common::backend::{Backend, BlockData};
 use lampo_common::bitcoin::consensus::encode::serialize_hex;
 use lampo_common::bitcoin::BlockHash;
+use lampo_common::chainsync::ChainSyncCoordinator;
 use lampo_common::conf::LampoConf;
 use lampo_common::error;
 use lampo_common::json;
@@ -25,6 +26,7 @@ pub struct LampoChainSync {
     channel_manager: OnceLock<Arc<LampoChannel>>,
     chain_monitor: OnceLock<Arc<LampoChainMonitor>>,
     handler: OnceLock<Arc<dyn lampo_common::handler::Handler>>,
+    coordinator: OnceLock<Arc<ChainSyncCoordinator>>,
 }
 
 impl LampoChainSync {
@@ -59,6 +61,7 @@ impl LampoChainSync {
             channel_manager: OnceLock::new(),
             chain_monitor: OnceLock::new(),
             handler: OnceLock::new(),
+            coordinator: OnceLock::new(),
         })
     }
 
@@ -219,6 +222,12 @@ impl Backend for LampoChainSync {
         self.set_chain_monitor(chain_monitor);
     }
 
+    fn set_coordinator(&self, coordinator: Arc<ChainSyncCoordinator>) {
+        self.coordinator
+            .set(coordinator)
+            .unwrap_or_else(|_| panic!("chain sync coordinator already set"));
+    }
+
     async fn listen(self: Arc<Self>) -> lampo_common::error::Result<()> {
         let channel_manager = self.channel_manager();
         let chain_monitor = self.chain_monitor();
@@ -255,6 +264,13 @@ impl Backend for LampoChainSync {
                 .map_err(|e| error::anyhow!("Failed to synchronize chain listeners: {:?}", e))?;
 
         log::info!(target: "lampo-chain", "Chain listeners synced to current tip");
+
+        // Publish listener-sync completion so gated components (e.g. the
+        // on-chain wallet) can proceed over the now-free RPC. No-op when no
+        // coordinator was injected.
+        if let Some(coordinator) = self.coordinator.get() {
+            coordinator.mark_listeners_synced();
+        }
 
         let chain_listener = (chain_monitor, channel_manager);
         let chain_poller = poll::ChainPoller::new(self.as_ref(), self.config.network);

--- a/lampo-chain/src/lib.rs
+++ b/lampo-chain/src/lib.rs
@@ -298,12 +298,19 @@ impl Backend for LampoChainSync {
         // causing a "Blocks must be connected in chain-order" assertion.
         let manager_best = channel_manager.current_best_block();
 
-        // When an on-chain wallet is wired in, include it in the same sync pass
-        // so one RPC stream catches up the channel manager, chain monitor, and
-        // wallet together -- deduplicating the overlapping block range instead
-        // of running a second `getblock` scan. Kept in locals so the listener
-        // outlives the `chain_listeners` vec consumed by `synchronize_listeners`.
-        let wallet = self.wallet();
+        // When an on-chain wallet is wired in (and not in `legacy` sync mode),
+        // include it in the same sync pass so one RPC stream catches up the
+        // channel manager, chain monitor, and wallet together -- deduplicating
+        // the overlapping block range instead of running a second `getblock`
+        // scan. Kept in locals so the listener outlives the `chain_listeners`
+        // vec consumed by `synchronize_listeners`.
+        let unified = self
+            .config
+            .sync_mode
+            .as_deref()
+            .map(|mode| !mode.eq_ignore_ascii_case("legacy"))
+            .unwrap_or(true);
+        let wallet = if unified { self.wallet() } else { None };
         let wallet_listener = wallet.as_ref().map(|wallet| WalletChainListener {
             wallet: wallet.clone(),
         });

--- a/lampo-common/src/backend.rs
+++ b/lampo-common/src/backend.rs
@@ -17,6 +17,7 @@ use crate::chainsync::ChainSyncCoordinator;
 use crate::error;
 use crate::handler::Handler;
 use crate::types::{LampoChainMonitor, LampoChannel};
+use crate::wallet::WalletManager;
 
 #[derive(Serialize, Deserialize, Debug)]
 pub enum TxResult {
@@ -66,6 +67,11 @@ pub trait Backend: Send + Sync {
     /// Inject the backend-agnostic chain-sync coordinator so the backend can
     /// publish listener-sync progress. Default no-op.
     fn set_coordinator(&self, _: Arc<ChainSyncCoordinator>) {}
+
+    /// Inject the on-chain wallet so the backend can drive it through the same
+    /// chain sync as the LDK listeners (one RPC stream). Default no-op. Passed
+    /// as the lampo-native `WalletManager`; the backend never sees BDK types.
+    fn set_wallet_manager(&self, _: Arc<dyn WalletManager>) {}
 
     /// Get the information of a transaction inside the blockchain.
     async fn get_transaction(&self, txid: &Txid) -> error::Result<TxResult>;

--- a/lampo-common/src/backend.rs
+++ b/lampo-common/src/backend.rs
@@ -13,6 +13,7 @@ pub use lightning::routing::utxo::UtxoResult;
 pub use lightning_block_sync::{BlockData, BlockHeaderData, BlockSourceResult};
 use serde::{Deserialize, Serialize};
 
+use crate::chainsync::ChainSyncCoordinator;
 use crate::error;
 use crate::handler::Handler;
 use crate::types::{LampoChainMonitor, LampoChannel};
@@ -61,6 +62,10 @@ pub trait Backend: Send + Sync {
     fn set_channel_manager(&self, _: Arc<LampoChannel>) {}
 
     fn set_chain_monitor(&self, _: Arc<LampoChainMonitor>) {}
+
+    /// Inject the backend-agnostic chain-sync coordinator so the backend can
+    /// publish listener-sync progress. Default no-op.
+    fn set_coordinator(&self, _: Arc<ChainSyncCoordinator>) {}
 
     /// Get the information of a transaction inside the blockchain.
     async fn get_transaction(&self, txid: &Txid) -> error::Result<TxResult>;

--- a/lampo-common/src/chainsync.rs
+++ b/lampo-common/src/chainsync.rs
@@ -33,7 +33,8 @@ const NO_HEIGHT: u64 = u64::MAX;
 /// Cheap to clone behind an `Arc`; all methods take `&self`.
 pub struct ChainSyncCoordinator {
     /// Current lifecycle state. A `watch` channel so callers can `await`
-    /// transitions (`wait_listeners_synced`) as well as read the latest value.
+    /// transitions (`wait_initial_sync_complete`) as well as read the latest
+    /// value.
     state: watch::Sender<SyncState>,
     /// Latest wallet scan height, or `NO_HEIGHT` when none has been reported.
     wallet_scan_height: AtomicU64,
@@ -69,8 +70,19 @@ impl ChainSyncCoordinator {
     }
 
     /// Advance to `Running`: the initial sync is fully complete.
+    ///
+    /// Only advances from `ListenersSynced` (a no-op from `Running`, and
+    /// defensively a no-op from `PendingInitialSync` so the state machine is
+    /// self-consistent regardless of caller).
     pub fn mark_running(&self) {
-        self.state.send_replace(SyncState::Running);
+        self.state.send_if_modified(|state| {
+            if matches!(state, SyncState::ListenersSynced) {
+                *state = SyncState::Running;
+                true
+            } else {
+                false
+            }
+        });
     }
 
     /// Latest reported wallet scan height, if any.
@@ -87,23 +99,6 @@ impl ChainSyncCoordinator {
             .store(u64::from(height), Ordering::Relaxed);
     }
 
-    /// Resolve once the chain listeners have synced (state is `ListenersSynced`
-    /// or `Running`). Returns immediately if already past `PendingInitialSync`.
-    pub async fn wait_listeners_synced(&self) {
-        let mut rx = self.state.subscribe();
-        loop {
-            if !matches!(*rx.borrow_and_update(), SyncState::PendingInitialSync) {
-                return;
-            }
-            // The coordinator owns `self.state`, so the sender never drops while
-            // we hold `&self`; `changed()` therefore cannot error here, but if it
-            // ever did we simply stop waiting rather than spin.
-            if rx.changed().await.is_err() {
-                return;
-            }
-        }
-    }
-
     /// Resolve once the full initial sync has completed (state is `Running`).
     /// Used by the `sync_wallets` RPC to block until the node is caught up.
     pub async fn wait_initial_sync_complete(&self) {
@@ -112,6 +107,9 @@ impl ChainSyncCoordinator {
             if matches!(*rx.borrow_and_update(), SyncState::Running) {
                 return;
             }
+            // The coordinator owns `self.state`, so the sender never drops while
+            // we hold `&self`; `changed()` therefore cannot error here, but if it
+            // ever did we simply stop waiting rather than spin.
             if rx.changed().await.is_err() {
                 return;
             }
@@ -167,12 +165,24 @@ mod tests {
     #[test]
     fn mark_listeners_synced_does_not_regress_running() {
         let coord = ChainSyncCoordinator::new();
+        coord.mark_listeners_synced();
         coord.mark_running();
         // A late listener-sync signal must not pull a Running node backwards.
         coord.mark_listeners_synced();
         assert_eq!(coord.state(), SyncState::Running);
         assert!(coord.initial_sync_complete());
         assert!(!coord.sync_in_progress());
+    }
+
+    #[test]
+    fn mark_running_requires_listeners_synced_first() {
+        let coord = ChainSyncCoordinator::new();
+        // Defensive: never jump straight from Pending to Running.
+        coord.mark_running();
+        assert_eq!(coord.state(), SyncState::PendingInitialSync);
+        coord.mark_listeners_synced();
+        coord.mark_running();
+        assert_eq!(coord.state(), SyncState::Running);
     }
 
     #[test]

--- a/lampo-common/src/chainsync.rs
+++ b/lampo-common/src/chainsync.rs
@@ -104,6 +104,20 @@ impl ChainSyncCoordinator {
         }
     }
 
+    /// Resolve once the full initial sync has completed (state is `Running`).
+    /// Used by the `sync_wallets` RPC to block until the node is caught up.
+    pub async fn wait_initial_sync_complete(&self) {
+        let mut rx = self.state.subscribe();
+        loop {
+            if matches!(*rx.borrow_and_update(), SyncState::Running) {
+                return;
+            }
+            if rx.changed().await.is_err() {
+                return;
+            }
+        }
+    }
+
     /// Whether the LDK chain listeners have completed their initial sync.
     pub fn chain_listeners_synced(&self) -> bool {
         !matches!(self.state(), SyncState::PendingInitialSync)

--- a/lampo-common/src/chainsync.rs
+++ b/lampo-common/src/chainsync.rs
@@ -1,0 +1,171 @@
+//! Backend-agnostic chain-sync coordination.
+//!
+//! `ChainSyncCoordinator` is a small, dependency-free state holder that lets
+//! the chain backend, the on-chain wallet, and the JSON-RPC layer agree on
+//! where the node is in its initial sync — without any of them depending on
+//! each other. It carries **no** LDK or BDK types on purpose: the concrete
+//! `Backend` drives the transitions, the wallet reports progress, and
+//! `getinfo` reads the state. See `docs/designs/unified-chain-sync.md`.
+//!
+//! In this first PR the coordinator is wired in but not yet driven; later PRs
+//! call `mark_listeners_synced` / `mark_running` from the sync path.
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use tokio::sync::watch;
+
+/// Lifecycle of the node's initial chain sync.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum SyncState {
+    /// Initial listener sync has not completed yet.
+    #[default]
+    PendingInitialSync,
+    /// LDK chain listeners are caught up to tip; wallet may still be scanning.
+    ListenersSynced,
+    /// Initial sync fully complete; the node is following the chain tip.
+    Running,
+}
+
+/// Sentinel for "no wallet scan height reported yet" stored in the atomic.
+const NO_HEIGHT: u64 = u64::MAX;
+
+/// Backend-agnostic coordinator for the node's chain-sync state.
+///
+/// Cheap to clone behind an `Arc`; all methods take `&self`.
+pub struct ChainSyncCoordinator {
+    /// Current lifecycle state. A `watch` channel so callers can `await`
+    /// transitions (`wait_listeners_synced`) as well as read the latest value.
+    state: watch::Sender<SyncState>,
+    /// Latest wallet scan height, or `NO_HEIGHT` when none has been reported.
+    wallet_scan_height: AtomicU64,
+}
+
+impl ChainSyncCoordinator {
+    pub fn new() -> Self {
+        let (state, _) = watch::channel(SyncState::PendingInitialSync);
+        Self {
+            state,
+            wallet_scan_height: AtomicU64::new(NO_HEIGHT),
+        }
+    }
+
+    /// Current lifecycle state.
+    pub fn state(&self) -> SyncState {
+        *self.state.borrow()
+    }
+
+    /// Advance to `ListenersSynced` once the LDK listeners reach tip.
+    ///
+    /// Only moves forward from `PendingInitialSync`; never regresses a node
+    /// that is already `Running`.
+    pub fn mark_listeners_synced(&self) {
+        self.state.send_if_modified(|state| {
+            if matches!(state, SyncState::PendingInitialSync) {
+                *state = SyncState::ListenersSynced;
+                true
+            } else {
+                false
+            }
+        });
+    }
+
+    /// Advance to `Running`: the initial sync is fully complete.
+    pub fn mark_running(&self) {
+        self.state.send_replace(SyncState::Running);
+    }
+
+    /// Latest reported wallet scan height, if any.
+    pub fn wallet_scan_height(&self) -> Option<u32> {
+        match self.wallet_scan_height.load(Ordering::Relaxed) {
+            NO_HEIGHT => None,
+            height => Some(height as u32),
+        }
+    }
+
+    /// Report the wallet's current scan height (live progress during catch-up).
+    pub fn set_wallet_scan_height(&self, height: u32) {
+        self.wallet_scan_height
+            .store(u64::from(height), Ordering::Relaxed);
+    }
+
+    /// Resolve once the chain listeners have synced (state is `ListenersSynced`
+    /// or `Running`). Returns immediately if already past `PendingInitialSync`.
+    pub async fn wait_listeners_synced(&self) {
+        let mut rx = self.state.subscribe();
+        loop {
+            if !matches!(*rx.borrow_and_update(), SyncState::PendingInitialSync) {
+                return;
+            }
+            // The coordinator owns `self.state`, so the sender never drops while
+            // we hold `&self`; `changed()` therefore cannot error here, but if it
+            // ever did we simply stop waiting rather than spin.
+            if rx.changed().await.is_err() {
+                return;
+            }
+        }
+    }
+
+    /// Whether the LDK chain listeners have completed their initial sync.
+    pub fn chain_listeners_synced(&self) -> bool {
+        !matches!(self.state(), SyncState::PendingInitialSync)
+    }
+
+    /// Whether the full initial sync (listeners + wallet) has completed.
+    pub fn initial_sync_complete(&self) -> bool {
+        matches!(self.state(), SyncState::Running)
+    }
+
+    /// Whether an initial sync is still in progress (not yet `Running`).
+    pub fn sync_in_progress(&self) -> bool {
+        !matches!(self.state(), SyncState::Running)
+    }
+}
+
+impl Default for ChainSyncCoordinator {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn initial_state_is_pending() {
+        let coord = ChainSyncCoordinator::new();
+        assert_eq!(coord.state(), SyncState::PendingInitialSync);
+        assert!(!coord.chain_listeners_synced());
+        assert!(!coord.initial_sync_complete());
+        assert!(coord.sync_in_progress());
+        assert_eq!(coord.wallet_scan_height(), None);
+    }
+
+    #[test]
+    fn mark_listeners_synced_advances_once() {
+        let coord = ChainSyncCoordinator::new();
+        coord.mark_listeners_synced();
+        assert_eq!(coord.state(), SyncState::ListenersSynced);
+        assert!(coord.chain_listeners_synced());
+        assert!(!coord.initial_sync_complete());
+        assert!(coord.sync_in_progress());
+    }
+
+    #[test]
+    fn mark_listeners_synced_does_not_regress_running() {
+        let coord = ChainSyncCoordinator::new();
+        coord.mark_running();
+        // A late listener-sync signal must not pull a Running node backwards.
+        coord.mark_listeners_synced();
+        assert_eq!(coord.state(), SyncState::Running);
+        assert!(coord.initial_sync_complete());
+        assert!(!coord.sync_in_progress());
+    }
+
+    #[test]
+    fn wallet_scan_height_roundtrip() {
+        let coord = ChainSyncCoordinator::new();
+        assert_eq!(coord.wallet_scan_height(), None);
+        coord.set_wallet_scan_height(307_000);
+        assert_eq!(coord.wallet_scan_height(), Some(307_000));
+    }
+}

--- a/lampo-common/src/conf.rs
+++ b/lampo-common/src/conf.rs
@@ -28,6 +28,10 @@ pub struct LampoConf {
     pub api_port: u64,
     pub reindex: Option<Height>,
     pub dev_sync: Option<bool>,
+    /// Allow the on-chain wallet to scan in parallel with the LDK chain
+    /// listener sync. Defaults to `false`: the wallet waits for listeners to
+    /// catch up first, so the two pipelines don't compete for the same RPC.
+    pub wallet_sync_parallel: Option<bool>,
 }
 
 impl Default for LampoConf {
@@ -60,6 +64,7 @@ impl Default for LampoConf {
             api_port: 7878,
             reindex: None,
             dev_sync: None,
+            wallet_sync_parallel: None,
         }
     }
 }
@@ -249,6 +254,11 @@ impl TryFrom<String> for LampoConf {
             .get_conf("dev-sync")
             .unwrap_or(None)
             .map(|s| s.to_lowercase() == "true" || s == "1");
+        // Parse wallet_sync_parallel field - defaults to None (false)
+        let wallet_sync_parallel = conf
+            .get_conf("wallet-sync-parallel")
+            .unwrap_or(None)
+            .map(|s| s.to_lowercase() == "true" || s == "1");
         Ok(Self {
             inner: Some(conf),
             root_path,
@@ -269,6 +279,7 @@ impl TryFrom<String> for LampoConf {
             api_port,
             reindex,
             dev_sync,
+            wallet_sync_parallel,
         })
     }
 }

--- a/lampo-common/src/conf.rs
+++ b/lampo-common/src/conf.rs
@@ -32,6 +32,14 @@ pub struct LampoConf {
     /// listener sync. Defaults to `false`: the wallet waits for listeners to
     /// catch up first, so the two pipelines don't compete for the same RPC.
     pub wallet_sync_parallel: Option<bool>,
+    /// Chain sync strategy: `"unified"` (default) drives the on-chain wallet
+    /// through the same `synchronize_listeners` pass as the LDK listeners;
+    /// `"legacy"` keeps the wallet on its standalone BDK Emitter scan.
+    pub sync_mode: Option<String>,
+    /// Fast-sync an empty wallet by jumping its checkpoint to the chain tip
+    /// instead of scanning from genesis. Defaults to `true` and only applies
+    /// to a fresh wallet (no UTXOs to miss); set `false` to force a full scan.
+    pub fast_sync: Option<bool>,
 }
 
 impl Default for LampoConf {
@@ -65,6 +73,8 @@ impl Default for LampoConf {
             reindex: None,
             dev_sync: None,
             wallet_sync_parallel: None,
+            sync_mode: None,
+            fast_sync: None,
         }
     }
 }
@@ -259,6 +269,13 @@ impl TryFrom<String> for LampoConf {
             .get_conf("wallet-sync-parallel")
             .unwrap_or(None)
             .map(|s| s.to_lowercase() == "true" || s == "1");
+        // Parse sync_mode field - defaults to None ("unified")
+        let sync_mode = conf.get_conf("sync-mode").unwrap_or(None);
+        // Parse fast_sync field - defaults to None (true)
+        let fast_sync = conf
+            .get_conf("fast-sync")
+            .unwrap_or(None)
+            .map(|s| s.to_lowercase() == "true" || s == "1");
         Ok(Self {
             inner: Some(conf),
             root_path,
@@ -280,6 +297,8 @@ impl TryFrom<String> for LampoConf {
             reindex,
             dev_sync,
             wallet_sync_parallel,
+            sync_mode,
+            fast_sync,
         })
     }
 }

--- a/lampo-common/src/lib.rs
+++ b/lampo-common/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod backend;
+pub mod chainsync;
 pub mod conf;
 pub mod event;
 pub mod handler;

--- a/lampo-common/src/model.rs
+++ b/lampo-common/src/model.rs
@@ -7,6 +7,7 @@ mod network;
 mod new_addr;
 mod on_chain;
 mod open_channel;
+mod sync;
 
 pub use connect::Connect;
 pub use getinfo::GetInfo;
@@ -34,4 +35,5 @@ pub mod response {
     pub use crate::model::new_addr::response::*;
     pub use crate::model::on_chain::response::*;
     pub use crate::model::open_channel::response::*;
+    pub use crate::model::sync::response::*;
 }

--- a/lampo-common/src/model/getinfo.rs
+++ b/lampo-common/src/model/getinfo.rs
@@ -14,12 +14,16 @@ pub struct GetInfo {
     pub block_hash: String,
     pub wallet_height: u64,
     /// Live wallet scan height during initial catch-up, if known.
+    #[serde(default)]
     pub wallet_scan_height: Option<u32>,
     /// Whether the LDK chain listeners have completed their initial sync.
+    #[serde(default)]
     pub chain_listeners_synced: bool,
     /// Whether the full initial sync (listeners + wallet) has completed.
+    #[serde(default)]
     pub initial_sync_complete: bool,
     /// Whether an initial sync is still in progress.
+    #[serde(default)]
     pub sync_in_progress: bool,
 }
 

--- a/lampo-common/src/model/getinfo.rs
+++ b/lampo-common/src/model/getinfo.rs
@@ -13,6 +13,14 @@ pub struct GetInfo {
     pub address: Vec<NetworkInfo>,
     pub block_hash: String,
     pub wallet_height: u64,
+    /// Live wallet scan height during initial catch-up, if known.
+    pub wallet_scan_height: Option<u32>,
+    /// Whether the LDK chain listeners have completed their initial sync.
+    pub chain_listeners_synced: bool,
+    /// Whether the full initial sync (listeners + wallet) has completed.
+    pub initial_sync_complete: bool,
+    /// Whether an initial sync is still in progress.
+    pub sync_in_progress: bool,
 }
 
 #[derive(Debug, Deserialize, Serialize, Apiv2Schema)]

--- a/lampo-common/src/model/sync.rs
+++ b/lampo-common/src/model/sync.rs
@@ -1,0 +1,14 @@
+pub mod response {
+    use paperclip::actix::Apiv2Schema;
+    use serde::{Deserialize, Serialize};
+
+    /// Snapshot of the node's chain-sync progress, returned by `sync_wallets`
+    /// once the initial sync completes.
+    #[derive(Serialize, Deserialize, Debug, Apiv2Schema)]
+    pub struct SyncStatus {
+        pub chain_listeners_synced: bool,
+        pub initial_sync_complete: bool,
+        pub sync_in_progress: bool,
+        pub wallet_scan_height: Option<u32>,
+    }
+}

--- a/lampo-common/src/wallet.rs
+++ b/lampo-common/src/wallet.rs
@@ -4,12 +4,21 @@ use async_trait::async_trait;
 
 use crate::bitcoin::absolute::Height;
 use crate::bitcoin::{Amount, FeeRate};
-use crate::bitcoin::{ScriptBuf, Transaction};
+use crate::bitcoin::{Block, BlockHash, ScriptBuf, Transaction};
 use crate::chainsync::ChainSyncCoordinator;
 use crate::conf::LampoConf;
 use crate::error;
 use crate::keys::LampoKeys;
 use crate::model::response::{NewAddress, Utxo};
+
+/// A lightweight reference to a block (height + hash). Pure `bitcoin` types,
+/// so a chain backend and the wallet can exchange chain positions without the
+/// wallet depending on LDK or the backend depending on BDK.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct BlockRef {
+    pub height: u32,
+    pub hash: BlockHash,
+}
 
 /// Wallet manager trait that define a generic interface
 /// over Wallet implementation!
@@ -50,6 +59,16 @@ pub trait WalletManager: Send + Sync {
     /// Return the last block height of the wallet, but we can abstract
     /// in the future the wallet tips info that we will need.
     async fn wallet_tips(&self) -> error::Result<Height>;
+
+    /// The wallet's current best (checkpoint) block: height + hash. Lets a
+    /// chain backend compute where to start syncing the wallet from in a
+    /// unified sync pass.
+    async fn current_best_block(&self) -> error::Result<BlockRef>;
+
+    /// Apply a connected block, advancing the wallet's view of the chain.
+    /// Takes pure `bitcoin` types so the wallet never depends on LDK
+    /// chain-sync; a backend drives this during unified sync.
+    async fn apply_block(&self, block: &Block, height: u32) -> error::Result<()>;
 
     /// Inject the chain-sync coordinator so the wallet can gate its scan on
     /// the LDK listener sync and report scan progress. Default no-op; the

--- a/lampo-common/src/wallet.rs
+++ b/lampo-common/src/wallet.rs
@@ -5,6 +5,7 @@ use async_trait::async_trait;
 use crate::bitcoin::absolute::Height;
 use crate::bitcoin::{Amount, FeeRate};
 use crate::bitcoin::{ScriptBuf, Transaction};
+use crate::chainsync::ChainSyncCoordinator;
 use crate::conf::LampoConf;
 use crate::error;
 use crate::keys::LampoKeys;
@@ -49,6 +50,12 @@ pub trait WalletManager: Send + Sync {
     /// Return the last block height of the wallet, but we can abstract
     /// in the future the wallet tips info that we will need.
     async fn wallet_tips(&self) -> error::Result<Height>;
+
+    /// Inject the chain-sync coordinator so the wallet can gate its scan on
+    /// the LDK listener sync and report scan progress. Default no-op; the
+    /// gate stays inactive until a coordinator is set. Pure lampo-common type
+    /// (no LDK), keeping the wallet replaceable.
+    fn set_coordinator(&self, _: Arc<ChainSyncCoordinator>) {}
 
     /// Sync the wallet.
     async fn sync(&self) -> error::Result<()>;

--- a/lampo-common/src/wallet.rs
+++ b/lampo-common/src/wallet.rs
@@ -63,12 +63,19 @@ pub trait WalletManager: Send + Sync {
     /// The wallet's current best (checkpoint) block: height + hash. Lets a
     /// chain backend compute where to start syncing the wallet from in a
     /// unified sync pass.
-    async fn current_best_block(&self) -> error::Result<BlockRef>;
+    ///
+    /// Synchronous so an LDK `Listen` adapter can call it without an async
+    /// runtime; the underlying access is a short, non-blocking lookup.
+    fn current_best_block(&self) -> error::Result<BlockRef>;
 
     /// Apply a connected block, advancing the wallet's view of the chain.
     /// Takes pure `bitcoin` types so the wallet never depends on LDK
     /// chain-sync; a backend drives this during unified sync.
-    async fn apply_block(&self, block: &Block, height: u32) -> error::Result<()>;
+    ///
+    /// Synchronous so it can be driven directly from `Listen::block_connected`
+    /// (which is itself sync) on any runtime flavor, keeping `LampoDaemon`
+    /// embeddable. The critical section is a short BDK apply + persist.
+    fn apply_block(&self, block: &Block, height: u32) -> error::Result<()>;
 
     /// Inject the chain-sync coordinator so the wallet can gate its scan on
     /// the LDK listener sync and report scan progress. Default no-op; the

--- a/lampo-httpd/src/commands/inventory.rs
+++ b/lampo-httpd/src/commands/inventory.rs
@@ -11,5 +11,6 @@ use lampod::jsonrpc::onchain::*;
 use crate::{post, AppState, ResultJson};
 
 post!(getinfo, response: response::GetInfo);
+post!(sync_wallets, response: response::SyncStatus);
 post!(networkchannels, request: json::Value, response: response::NetworkChannels);
 post!(funds, request: json::Value, response: response::Utxos);

--- a/lampo-httpd/src/lib.rs
+++ b/lampo-httpd/src/lib.rs
@@ -14,7 +14,7 @@ use lampo_common::json;
 use lampod::LampoDaemon;
 
 use commands::daemon::rest_stop;
-use commands::inventory::{rest_funds, rest_getinfo, rest_networkchannels};
+use commands::inventory::{rest_funds, rest_getinfo, rest_networkchannels, rest_sync_wallets};
 use commands::offchain::{rest_decode, rest_invoice, rest_pay};
 use commands::onchain::rest_new_addr;
 use commands::peer::{rest_channels, rest_close, rest_connect, rest_fundchannel};
@@ -118,6 +118,7 @@ pub async fn run<T: ToSocketAddrs + Display>(
             .wrap_api()
             .service(swagger_api)
             .service(rest_getinfo)
+            .service(rest_sync_wallets)
             .service(rest_channels)
             .service(rest_connect)
             .service(rest_fundchannel)

--- a/lampo-testing/src/lib.rs
+++ b/lampo-testing/src/lib.rs
@@ -166,9 +166,13 @@ impl LampoTesting {
         let lampo_conf = Arc::new(lampo_conf);
         let (wallet, mnemonic) = BDKWalletManager::new(lampo_conf.clone()).await?;
         let wallet = Arc::new(wallet);
-        wallet.clone().listen().await?;
 
         let mut lampo = LampoDaemon::new(lampo_conf.clone(), wallet.clone());
+        // Share the coordinator before starting wallet sync so the wallet gates
+        // its Emitter on listener sync, matching the production startup flow.
+        wallet.set_coordinator(lampo.chain_sync());
+        wallet.clone().listen().await?;
+
         let node = Arc::new(LampoChainSync::new(lampo_conf.clone())?);
         lampo.init(node.clone()).await?;
         log::info!("bitcoin core added inside lampo");

--- a/lampo-testing/src/lib.rs
+++ b/lampo-testing/src/lib.rs
@@ -167,10 +167,9 @@ impl LampoTesting {
         let (wallet, mnemonic) = BDKWalletManager::new(lampo_conf.clone()).await?;
         let wallet = Arc::new(wallet);
 
+        // `LampoDaemon::new` shares the coordinator with the wallet, so the
+        // wallet gates its Emitter on listener sync (production startup flow).
         let mut lampo = LampoDaemon::new(lampo_conf.clone(), wallet.clone());
-        // Share the coordinator before starting wallet sync so the wallet gates
-        // its Emitter on listener sync, matching the production startup flow.
-        wallet.set_coordinator(lampo.chain_sync());
         wallet.clone().listen().await?;
 
         let node = Arc::new(LampoChainSync::new(lampo_conf.clone())?);

--- a/lampo.example.conf
+++ b/lampo.example.conf
@@ -35,3 +35,13 @@ core-pass=lampo
 # sync. Defaults to false: the wallet waits for the listeners to catch up
 # first so the two pipelines don't compete for the same bitcoind RPC.
 # wallet-sync-parallel=false
+
+# Chain sync strategy. "unified" (default) drives the on-chain wallet through
+# the same chain sync pass as the LDK listeners (one RPC stream). "legacy"
+# keeps the wallet on its standalone BDK Emitter scan.
+# sync-mode=unified
+
+# Fast-sync an empty wallet by jumping its checkpoint to the chain tip instead
+# of scanning from genesis. Defaults to true; only applies to a fresh wallet
+# (no UTXOs to miss). Set false to force a full scan from genesis.
+# fast-sync=true

--- a/lampo.example.conf
+++ b/lampo.example.conf
@@ -30,3 +30,8 @@ core-pass=lampo
 # Enable development sync mode (syncs every second instead of every 2 minutes)
 # Only use this for development/testing purposes
 # dev-sync=true
+
+# Allow the on-chain wallet to scan in parallel with the LDK chain listener
+# sync. Defaults to false: the wallet waits for the listeners to catch up
+# first so the two pipelines don't compete for the same bitcoind RPC.
+# wallet-sync-parallel=false

--- a/lampod-cli/src/main.rs
+++ b/lampod-cli/src/main.rs
@@ -176,11 +176,8 @@ async fn run(args: LampoCliArgs) -> error::Result<()> {
     log::debug!(target: "lampod-cli", "wallet created with success");
     let mut lampod = LampoDaemon::new(lampo_conf.clone(), wallet.clone());
 
-    // Share the chain-sync coordinator so the wallet gates its scan on the
-    // LDK listener sync (one RPC pipeline at a time) and reports progress.
-    wallet.set_coordinator(lampod.chain_sync());
-
-    // Do wallet syncing in the background!
+    // Do wallet syncing in the background! (`LampoDaemon::new` already shared
+    // the chain-sync coordinator with the wallet.)
     wallet.listen().await?;
 
     // Init the lampod

--- a/lampod-cli/src/main.rs
+++ b/lampod-cli/src/main.rs
@@ -176,6 +176,10 @@ async fn run(args: LampoCliArgs) -> error::Result<()> {
     log::debug!(target: "lampod-cli", "wallet created with success");
     let mut lampod = LampoDaemon::new(lampo_conf.clone(), wallet.clone());
 
+    // Share the chain-sync coordinator so the wallet gates its scan on the
+    // LDK listener sync (one RPC pipeline at a time) and reports progress.
+    wallet.set_coordinator(lampod.chain_sync());
+
     // Do wallet syncing in the background!
     wallet.listen().await?;
 

--- a/lampod/Cargo.toml
+++ b/lampod/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-tokio = { version = "^1.50.0", features = ["rt-multi-thread", "parking_lot", "macros"] }
+tokio = { version = "^1.50.0", features = ["rt-multi-thread", "parking_lot", "macros", "time"] }
 lampo-common = { path = "../lampo-common" }
 log = "0.4.17"
 time = "0.3.43"

--- a/lampod/src/jsonrpc/inventory.rs
+++ b/lampod/src/jsonrpc/inventory.rs
@@ -72,7 +72,18 @@ pub async fn json_sync_wallets(
 ) -> Result<json::Value, Error> {
     log::info!("calling `sync_wallets` with request `{:?}`", request);
     let chain_sync = ctx.chain_sync();
-    chain_sync.wait_initial_sync_complete().await;
+    // Bound the wait so a stuck node can't pin the HTTP worker indefinitely.
+    // On timeout we return the current (incomplete) status; the caller re-polls.
+    const SYNC_WALLETS_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(600);
+    if tokio::time::timeout(
+        SYNC_WALLETS_TIMEOUT,
+        chain_sync.wait_initial_sync_complete(),
+    )
+    .await
+    .is_err()
+    {
+        log::warn!("`sync_wallets` timed out waiting for initial sync; returning current status");
+    }
     let status = SyncStatus {
         chain_listeners_synced: chain_sync.chain_listeners_synced(),
         initial_sync_complete: chain_sync.initial_sync_complete(),

--- a/lampod/src/jsonrpc/inventory.rs
+++ b/lampod/src/jsonrpc/inventory.rs
@@ -3,7 +3,7 @@ use lampo_common::error;
 use lampo_common::json;
 use lampo_common::jsonrpc::Error;
 use lampo_common::model::request::NetworkInfo;
-use lampo_common::model::response::{NetworkChannel, NetworkChannels};
+use lampo_common::model::response::{NetworkChannel, NetworkChannels, SyncStatus};
 use lampo_common::model::GetInfo;
 
 use crate::{async_run, LampoDaemon};
@@ -62,6 +62,24 @@ pub async fn json_getinfo(ctx: &LampoDaemon, request: &json::Value) -> Result<js
     };
 
     Ok(json::to_value(getinfo)?)
+}
+
+/// Block until the node's initial chain sync (LDK listeners + on-chain wallet)
+/// completes, then return the final sync status. Useful for scripts and CI.
+pub async fn json_sync_wallets(
+    ctx: &LampoDaemon,
+    request: &json::Value,
+) -> Result<json::Value, Error> {
+    log::info!("calling `sync_wallets` with request `{:?}`", request);
+    let chain_sync = ctx.chain_sync();
+    chain_sync.wait_initial_sync_complete().await;
+    let status = SyncStatus {
+        chain_listeners_synced: chain_sync.chain_listeners_synced(),
+        initial_sync_complete: chain_sync.initial_sync_complete(),
+        sync_in_progress: chain_sync.sync_in_progress(),
+        wallet_scan_height: chain_sync.wallet_scan_height(),
+    };
+    Ok(json::to_value(status)?)
 }
 
 // FIXME: check the request

--- a/lampod/src/jsonrpc/inventory.rs
+++ b/lampod/src/jsonrpc/inventory.rs
@@ -38,6 +38,7 @@ pub async fn json_getinfo(ctx: &LampoDaemon, request: &json::Value) -> Result<js
     }
 
     let wallet_tips = ctx.wallet_manager().wallet_tips().await?;
+    let chain_sync = ctx.chain_sync();
 
     let getinfo = GetInfo {
         node_id: ctx
@@ -54,6 +55,10 @@ pub async fn json_getinfo(ctx: &LampoDaemon, request: &json::Value) -> Result<js
         lampo_dir,
         address: address_vec,
         wallet_height: wallet_tips.to_consensus_u32() as u64,
+        wallet_scan_height: chain_sync.wallet_scan_height(),
+        chain_listeners_synced: chain_sync.chain_listeners_synced(),
+        initial_sync_complete: chain_sync.initial_sync_complete(),
+        sync_in_progress: chain_sync.sync_in_progress(),
     };
 
     Ok(json::to_value(getinfo)?)

--- a/lampod/src/lib.rs
+++ b/lampod/src/lib.rs
@@ -25,6 +25,7 @@ use std::time::SystemTime;
 use tokio::task::JoinHandle;
 
 use lampo_common::backend::Backend;
+use lampo_common::chainsync::ChainSyncCoordinator;
 use lampo_common::conf::LampoConf;
 use lampo_common::handler::ExternalHandler;
 use lampo_common::json;
@@ -98,6 +99,7 @@ pub struct LampoDaemon {
     persister: Arc<LampoPersistence>,
     handler: Option<Arc<LampoHandler>>,
     shutdown: Arc<AtomicBool>,
+    chain_sync: Arc<ChainSyncCoordinator>,
 }
 
 impl LampoDaemon {
@@ -115,7 +117,14 @@ impl LampoDaemon {
             offchain_manager: None,
             handler: None,
             shutdown: Arc::new(AtomicBool::new(false)),
+            chain_sync: Arc::new(ChainSyncCoordinator::new()),
         }
+    }
+
+    /// Backend-agnostic chain-sync coordinator shared across the daemon's
+    /// components. Drives the sync-progress fields exposed by `getinfo`.
+    pub fn chain_sync(&self) -> Arc<ChainSyncCoordinator> {
+        self.chain_sync.clone()
     }
 
     /// Signal the daemon to shut down gracefully. This causes the LDK

--- a/lampod/src/lib.rs
+++ b/lampod/src/lib.rs
@@ -249,6 +249,7 @@ impl LampoDaemon {
         client.set_handler(self.handler());
         client.set_channel_manager(self.channel_manager().manager());
         client.set_chain_monitor(self.channel_manager().chain_monitor());
+        client.set_coordinator(self.chain_sync());
         self.channel_manager().set_handler(self.handler());
         Ok(())
     }

--- a/lampod/src/lib.rs
+++ b/lampod/src/lib.rs
@@ -105,6 +105,11 @@ pub struct LampoDaemon {
 impl LampoDaemon {
     pub fn new(config: Arc<LampoConf>, wallet_manager: Arc<dyn WalletManager>) -> Self {
         let root_path = config.path();
+        let chain_sync = Arc::new(ChainSyncCoordinator::new());
+        // Wire the wallet to the coordinator here so every daemon (CLI, tests,
+        // embedders) gets consistent sync-progress reporting with no per-caller
+        // setup. The backend is wired separately in `init`.
+        wallet_manager.set_coordinator(chain_sync.clone());
         LampoDaemon {
             conf: config,
             logger: Arc::new(LampoLogger {}),
@@ -117,7 +122,7 @@ impl LampoDaemon {
             offchain_manager: None,
             handler: None,
             shutdown: Arc::new(AtomicBool::new(false)),
-            chain_sync: Arc::new(ChainSyncCoordinator::new()),
+            chain_sync,
         }
     }
 

--- a/lampod/src/lib.rs
+++ b/lampod/src/lib.rs
@@ -255,6 +255,11 @@ impl LampoDaemon {
         client.set_channel_manager(self.channel_manager().manager());
         client.set_chain_monitor(self.channel_manager().chain_monitor());
         client.set_coordinator(self.chain_sync());
+        // The on-chain manager is the only component that calls
+        // `mark_listeners_synced` once the unified listener sync completes;
+        // without this the coordinator stays `PendingInitialSync` and the
+        // gated wallet cron waits forever for `chain_listeners_synced`.
+        self.onchain_manager().set_coordinator(self.chain_sync());
         client.set_wallet_manager(self.wallet_manager());
         self.channel_manager().set_handler(self.handler());
         Ok(())

--- a/lampod/src/lib.rs
+++ b/lampod/src/lib.rs
@@ -250,6 +250,7 @@ impl LampoDaemon {
         client.set_channel_manager(self.channel_manager().manager());
         client.set_chain_monitor(self.channel_manager().chain_monitor());
         client.set_coordinator(self.chain_sync());
+        client.set_wallet_manager(self.wallet_manager());
         self.channel_manager().set_handler(self.handler());
         Ok(())
     }

--- a/lampod/src/ln/inventory_manager.rs
+++ b/lampod/src/ln/inventory_manager.rs
@@ -65,6 +65,12 @@ impl LampoInventoryManager {
             address: address_vec,
             block_hash: block_hash.to_string(),
             wallet_height: wallet_tips.to_consensus_u32() as u64,
+            // Sync-progress fields are not tracked on this deprecated path;
+            // report the same defaults as a freshly created coordinator.
+            wallet_scan_height: None,
+            chain_listeners_synced: false,
+            initial_sync_complete: false,
+            sync_in_progress: true,
         };
         Ok(getinfo)
     }

--- a/tools/check-wallet-decoupling.sh
+++ b/tools/check-wallet-decoupling.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+#
+# Guard the unified-chain-sync invariant: the on-chain wallet crate
+# (`lampo-bdk-wallet`) must NOT depend directly on any LDK (`lightning*`) crate.
+#
+# The LDK <-> wallet coupling lives in `lampo-chain` via the
+# `WalletChainListener` adapter, so the wallet stays independently replaceable.
+# See docs/designs/unified-chain-sync.md.
+#
+# Note: a *transitive* `lightning` dep is expected (through `lampo-common`); we
+# only forbid a *direct* dependency, hence `--depth 1`.
+set -euo pipefail
+
+direct=$(cargo tree -p lampo-bdk-wallet --edges normal --depth 1 --prefix none 2>/dev/null \
+    | grep -iE 'lightning' || true)
+
+if [ -n "$direct" ]; then
+    echo "::error::lampo-bdk-wallet directly depends on an LDK crate:" >&2
+    echo "$direct" >&2
+    echo "Keep the on-chain wallet free of LDK chain-sync; put the coupling in" >&2
+    echo "lampo-chain instead (see docs/designs/unified-chain-sync.md)." >&2
+    exit 1
+fi
+
+echo "OK: lampo-bdk-wallet has no direct LDK (lightning*) dependency."

--- a/tools/check-wallet-decoupling.sh
+++ b/tools/check-wallet-decoupling.sh
@@ -12,7 +12,7 @@
 set -euo pipefail
 
 direct=$(cargo tree -p lampo-bdk-wallet --edges normal --depth 1 --prefix none 2>/dev/null \
-    | grep -iE 'lightning' || true)
+    | grep -E '^lightning' || true)
 
 if [ -n "$direct" ]; then
     echo "::error::lampo-bdk-wallet directly depends on an LDK crate:" >&2


### PR DESCRIPTION
## Summary

Fixes the unreachable `mark_listeners_synced` call in the unified chain-sync path (#545 / #546).

- **What was broken:** the on-chain wallet cron is gated behind `chain_listeners_synced`, which is only advanced by `mark_listeners_synced()`. That call lives in `LampoChainManager::listen()` (guarded by `if let Some(coordinator) = self.coordinator.get()`), but the coordinator was injected into the wallet (`LampoDaemon::new`) and the backend `client` (`LampoDaemon::init`) — **never into the `LampoChainManager`** itself. `set_coordinator` on the on-chain manager had zero callers, so `self.coordinator` was always `None`.
- **Effect:** the coordinator stayed `PendingInitialSync` forever; the wallet cron logged `Waiting for chain listeners to sync` every 2 minutes and made zero progress, even though the listeners were running. Verified live on signet: a restored wallet (height 21021 vs tip 312037) showed `chain_listeners_synced: false` / `wallet_scan_height: null` indefinitely after 4+ minutes.
- **Root cause:** missing coordinator wiring on the on-chain manager.
- **Fix:** also call `set_coordinator` on the on-chain manager in `LampoDaemon::init`, so `mark_listeners_synced()` can fire once `synchronize_listeners` completes.

`set_coordinator` is a `Backend` trait method, so no visibility change is needed — it was simply never invoked on the on-chain manager.

## Test plan

- [x] `cargo check --workspace --all-targets` clean (only pre-existing warnings)
- [x] `cargo test -p lampo-common chainsync` — all 5 coordinator unit tests pass
- [x] Deployed to the signet host and confirmed the node boots with the coordinator now wired to the on-chain manager

## Known follow-up (not addressed here — needs a design decision)

While verifying this fix live, a second, deeper issue surfaced on top of the wiring bug. After the wiring fix the coordinator is reachable, but on this host `synchronize_listeners` (which drives `mark_listeners_synced`) **hangs** rather than completing:

- the on-chain `BlockSource` uses `lightning_block_sync::rpc::RpcClient` (a separate, unlogged client from the wallet's `bitcoincore_rpc`), so its calls don't appear in the RPC histogram;
- the lampo process holds an `ESTABLISHED` but **idle** connection to the backend at `0.4% CPU` — `synchronize_listeners` is blocked awaiting an RPC response that never returns (the SSH-tunneled backend shows `CLOSE-WAIT`/`FIN-WAIT-2` sockets);
- because the wallet cron is **hard-gated** behind `chain_listeners_synced` with no timeout/escape path, a hung listener sync permanently deadlocks the wallet (zero `getblock` progress), whereas `main` scans the wallet in parallel and progresses.

This is precisely the P2 concern the review raised ("…needs an escape path when the backend sync has failed"). The wiring fix in this PR is necessary regardless (without it `mark_listeners_synced` is unreachable even on a healthy backend), but fully resolving the deadlock will additionally require either a bounded timeout / escape hatch in the wallet gate, or a read timeout on the `RpcClient`. I've left that as a separate change for the maintainer to decide on, with the live evidence captured here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
