### PR TITLE
sync: unified chain sync with a decoupled coordinator

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -88,3 +88,8 @@ jobs:
             exit 1
           fi
           echo "OK: each lightning* crate resolves to a single version."
+
+      # Guards the unified-chain-sync invariant (#545): the on-chain wallet
+      # crate must stay free of LDK so it remains independently replaceable.
+      - name: Ensure the on-chain wallet stays free of LDK
+        run: ./tools/check-wallet-decoupling.sh

--- a/lampo-bdk-wallet/src/lib.rs
+++ b/lampo-bdk-wallet/src/lib.rs
@@ -1,6 +1,11 @@
 //! Wallet Manager implementation with BDK
 use std::str::FromStr;
-use std::sync::Arc;
+// The on-chain wallet + its sqlite handle are guarded by a std (blocking)
+// mutex, not a tokio one: their critical sections are short and fully
+// synchronous (BDK apply + rusqlite persist), and a sync lock lets the LDK
+// `Listen` adapter drive `apply_block` without an async runtime. `guard`
+// stays a tokio mutex because it is held across `.await`.
+use std::sync::{Arc, Mutex as StdMutex, OnceLock};
 
 use bdk_bitcoind_rpc::bitcoincore_rpc::{Auth, Client, RpcApi};
 use bdk_bitcoind_rpc::Emitter;
@@ -22,17 +27,18 @@ use lampo_common::bitcoin::bip32::Xpriv;
 use lampo_common::bitcoin::blockdata::locktime::absolute::LockTime;
 use lampo_common::bitcoin::PrivateKey;
 use lampo_common::bitcoin::{Amount, Block, FeeRate, ScriptBuf, Transaction};
+use lampo_common::chainsync::ChainSyncCoordinator;
 use lampo_common::conf::{LampoConf, Network};
 use lampo_common::keys::LampoKeys;
 use lampo_common::model::response::NewAddress;
 use lampo_common::model::response::Utxo;
 use lampo_common::secp256k1::SecretKey;
-use lampo_common::wallet::WalletManager;
+use lampo_common::wallet::{BlockRef, WalletManager};
 use lampo_common::{async_trait, error};
 
 pub struct BDKWalletManager {
-    pub wallet: Mutex<PersistedWallet<Connection>>,
-    pub wallet_db: Mutex<Connection>,
+    pub wallet: StdMutex<PersistedWallet<Connection>>,
+    pub wallet_db: StdMutex<Connection>,
     pub rpc: Arc<Client>,
     pub keymanager: Arc<LampoKeys>,
     pub network: Network,
@@ -40,6 +46,10 @@ pub struct BDKWalletManager {
     pub conf: Arc<LampoConf>,
 
     guard: Mutex<bool>,
+    /// Chain-sync coordinator, when wired in. Gates the Emitter scan on LDK
+    /// listener sync and carries scan progress. `None` (e.g. in tests) leaves
+    /// the wallet syncing immediately, exactly as before.
+    coordinator: OnceLock<Arc<ChainSyncCoordinator>>,
 }
 
 impl BDKWalletManager {
@@ -166,6 +176,36 @@ impl BDKWalletManager {
         let client = Client::new(url, Auth::UserPass(user.clone(), pass.clone()))?;
         Ok(client)
     }
+
+    /// Apply a connected block to the wallet, given the BDK `connected_to`
+    /// point. Synchronous: holds the wallet/db locks only for the short BDK
+    /// apply + persist, so callers (including the async `sync` loop and the
+    /// LDK `Listen` adapter) never hold a `MutexGuard` across an `.await`.
+    fn apply_block_inner(
+        &self,
+        block: &Block,
+        height: u32,
+        connected_to: BlockId,
+    ) -> error::Result<()> {
+        let mut wallet = self.wallet.lock().unwrap();
+        let mut wallet_db = self.wallet_db.lock().unwrap();
+        wallet.apply_block_connected_to(block, height, connected_to)?;
+        wallet.persist(&mut wallet_db)?;
+        if let Some(coordinator) = self.coordinator.get() {
+            coordinator.set_wallet_scan_height(height);
+        }
+        Ok(())
+    }
+
+    /// Apply unconfirmed (mempool) transactions to the wallet. Synchronous for
+    /// the same reason as [`Self::apply_block_inner`].
+    fn apply_mempool(&self, txs: Vec<(Arc<Transaction>, u64)>) -> error::Result<()> {
+        let mut wallet = self.wallet.lock().unwrap();
+        let mut wallet_db = self.wallet_db.lock().unwrap();
+        wallet.apply_unconfirmed_txs(txs);
+        wallet.persist(&mut wallet_db)?;
+        Ok(())
+    }
 }
 
 #[async_trait]
@@ -180,14 +220,15 @@ impl WalletManager for BDKWalletManager {
         let client = Self::build_client(conf.clone())?;
         Ok((
             Self {
-                wallet: Mutex::new(wallet),
-                wallet_db: Mutex::new(db),
+                wallet: StdMutex::new(wallet),
+                wallet_db: StdMutex::new(db),
                 keymanager: Arc::new(keymanager),
                 network: conf.network,
                 rpc: Arc::new(client),
                 guard: Mutex::new(false),
                 reindex_from: conf.reindex,
                 conf: conf.clone(),
+                coordinator: OnceLock::new(),
             },
             mnemonic_words,
         ))
@@ -198,14 +239,15 @@ impl WalletManager for BDKWalletManager {
             BDKWalletManager::build_wallet(conf.clone(), mnemonic_words).await?;
         let client = BDKWalletManager::build_client(conf.clone())?;
         Ok(Self {
-            wallet: Mutex::new(wallet),
-            wallet_db: Mutex::new(db),
+            wallet: StdMutex::new(wallet),
+            wallet_db: StdMutex::new(db),
             keymanager: Arc::new(keymanager),
             network: conf.network,
             rpc: Arc::new(client),
             guard: Mutex::new(false),
             reindex_from: conf.reindex,
             conf: conf.clone(),
+            coordinator: OnceLock::new(),
         })
     }
 
@@ -214,8 +256,8 @@ impl WalletManager for BDKWalletManager {
     }
 
     async fn get_onchain_address(&self) -> error::Result<NewAddress> {
-        let mut wallet = self.wallet.lock().await;
-        let mut wallet_db = self.wallet_db.lock().await;
+        let mut wallet = self.wallet.lock().unwrap();
+        let mut wallet_db = self.wallet_db.lock().unwrap();
         let address = wallet.reveal_next_address(KeychainKind::External);
         wallet.persist(&mut wallet_db)?;
         Ok(NewAddress {
@@ -225,7 +267,7 @@ impl WalletManager for BDKWalletManager {
 
     // Return in satoshis
     async fn get_onchain_balance(&self) -> error::Result<u64> {
-        let balance = self.wallet.lock().await.balance();
+        let balance = self.wallet.lock().unwrap().balance();
         log::warn!(target: "lampo-wallet", "balance: {balance:?}");
         Ok(balance.confirmed.to_sat())
     }
@@ -237,7 +279,7 @@ impl WalletManager for BDKWalletManager {
         fee_rate: FeeRate,
         best_block: Height,
     ) -> error::Result<Transaction> {
-        let mut wallet = self.wallet.lock().await;
+        let mut wallet = self.wallet.lock().unwrap();
 
         // We set nLockTime to the current height to discourage fee sniping.
         let locktime =
@@ -257,7 +299,7 @@ impl WalletManager for BDKWalletManager {
 
     async fn list_transactions(&self) -> error::Result<Vec<Utxo>> {
         log::info!("lampo-wallet: list transactions");
-        let wallet = self.wallet.lock().await;
+        let wallet = self.wallet.lock().unwrap();
         log::info!("lampo-wallet: wallet lock taken");
         let txs = wallet
             .list_unspent()
@@ -270,6 +312,15 @@ impl WalletManager for BDKWalletManager {
             })
             .collect::<Vec<_>>();
         Ok(txs)
+    }
+
+    fn set_coordinator(&self, coordinator: Arc<ChainSyncCoordinator>) {
+        if self.coordinator.set(coordinator).is_err() {
+            log::debug!(
+                target: "lampo-wallet",
+                "chain sync coordinator already set; keeping existing"
+            );
+        }
     }
 
     async fn sync(&self) -> error::Result<()> {
@@ -291,10 +342,14 @@ impl WalletManager for BDKWalletManager {
         });*/
 
         let rpc_client = self.rpc.clone();
-        let wallet = self.wallet.lock().await;
-        let wallet_tip = wallet.latest_checkpoint();
-        let start_height = wallet_tip.height();
-        drop(wallet);
+        // Scope the (std) wallet guard so it is provably released before the
+        // async work below; the checkpoint we return is owned.
+        let (wallet_tip, start_height) = {
+            let wallet = self.wallet.lock().unwrap();
+            let checkpoint = wallet.latest_checkpoint();
+            let height = checkpoint.height();
+            (checkpoint, height)
+        };
 
         let emitter_handle = tokio::spawn(async move {
             let mut emitter = Emitter::new(
@@ -312,9 +367,8 @@ impl WalletManager for BDKWalletManager {
         });
 
         while let Some(emission) = receiver.recv().await {
-            let mut wallet = self.wallet.lock().await;
-            let mut wallet_db = self.wallet_db.lock().await;
-
+            // All wallet locking happens inside the synchronous helpers so no
+            // `MutexGuard` is held across the `.await` above.
             match emission {
                 Emission::SigTerm => {
                     println!("Sigterm received, exiting...");
@@ -325,8 +379,7 @@ impl WalletManager for BDKWalletManager {
                     let hash = block_emission.block_hash();
                     let connected_to = block_emission.connected_to();
                     let start_apply_block = Instant::now();
-                    wallet.apply_block_connected_to(&block_emission.block, height, connected_to)?;
-                    wallet.persist(&mut wallet_db)?;
+                    self.apply_block_inner(&block_emission.block, height, connected_to)?;
                     let elapsed = start_apply_block.elapsed().as_secs_f32();
                     log::info!(target: "lampo-wallet",
                         "Applied block {} at height {} in {}s",
@@ -336,8 +389,7 @@ impl WalletManager for BDKWalletManager {
                 Emission::Mempool(mempool_emission) => {
                     log::warn!(target: "lampo-wallet", "Mempool emission: {mempool_emission:?}");
                     let start_apply_mempool = Instant::now();
-                    wallet.apply_unconfirmed_txs(mempool_emission);
-                    wallet.persist(&mut wallet_db)?;
+                    self.apply_mempool(mempool_emission)?;
                     log::info!(target: "lampo-wallet",
                         "Applied unconfirmed transactions in {}s",
                         start_apply_mempool.elapsed().as_secs_f32()
@@ -359,14 +411,42 @@ impl WalletManager for BDKWalletManager {
             }
             Ok(Ok(())) => {}
         }
+
+        // The wallet has caught up to the chain tip. If the LDK listeners are
+        // also synced, the node's initial sync is complete.
+        if let Some(coordinator) = self.coordinator.get() {
+            if coordinator.chain_listeners_synced() {
+                coordinator.mark_running();
+            }
+        }
         Ok(())
     }
 
     async fn wallet_tips(&self) -> error::Result<Height> {
-        let wallet = self.wallet.lock().await;
+        let wallet = self.wallet.lock().unwrap();
         let tip = wallet.latest_checkpoint().height();
         let tip = Height::from_consensus(tip)?;
         Ok(tip)
+    }
+
+    fn current_best_block(&self) -> error::Result<BlockRef> {
+        let wallet = self.wallet.lock().unwrap();
+        let checkpoint = wallet.latest_checkpoint();
+        Ok(BlockRef {
+            height: checkpoint.height(),
+            hash: checkpoint.hash(),
+        })
+    }
+
+    fn apply_block(&self, block: &Block, height: u32) -> error::Result<()> {
+        // Connect to the parent block. During sequential catch-up this is the
+        // previous block, which BDK matches against its checkpoint chain; on a
+        // reorg the differing `prev_blockhash` rolls the wallet chain back.
+        let connected_to = BlockId {
+            height: height.saturating_sub(1),
+            hash: block.header.prev_blockhash,
+        };
+        self.apply_block_inner(block, height, connected_to)
     }
 
     async fn listen(self: Arc<Self>) -> error::Result<()> {
@@ -374,42 +454,67 @@ impl WalletManager for BDKWalletManager {
         sched.shutdown_on_ctrl_c();
 
         async fn innet_sync(wallet: Arc<BDKWalletManager>) -> error::Result<()> {
+            // Gate: hold the Emitter scan until the LDK chain listeners have
+            // synced, so the two pipelines don't compete for the same RPC.
+            // Active only when a coordinator is wired in and
+            // `wallet_sync_parallel` is unset; otherwise sync runs as before.
+            // `wallet_scan_allowed` opens the gate after a grace window even
+            // when the listener sync is stuck, so a degraded backend cannot
+            // block the wallet forever.
+            let parallel = wallet.conf.wallet_sync_parallel.unwrap_or(false);
+            if !parallel {
+                if let Some(coordinator) = wallet.coordinator.get() {
+                    if !coordinator.wallet_scan_allowed() {
+                        log::info!(target: "lampo-wallet", "Waiting for chain listeners to sync before scanning the wallet");
+                        return Ok(());
+                    }
+                }
+            }
             let _is_sync = wallet.guard.lock().await;
             log::debug!(target: "lampo-wallet", "Tick tock, time to check if we need to sync the wallet");
             wallet.sync().await?;
             Ok(())
         }
 
-        // we need to modify the bdk wallet state in this position.
-        let rpc_client = self.rpc.clone();
-        let mut wallet = self.wallet.lock().await;
-        let wallet_tip = wallet.latest_checkpoint();
-        let start_height = wallet_tip.height();
+        // Set up the initial wallet checkpoint (reindex / fast-forward). Scoped
+        // so the synchronous wallet guard is released before the async
+        // scheduler work below. Previously this guard was shadowed by
+        // `let wallet = self.clone()` and held across the scheduler `.await`s.
+        {
+            let rpc_client = self.rpc.clone();
+            let mut wallet = self.wallet.lock().unwrap();
+            let wallet_tip = wallet.latest_checkpoint();
+            let start_height = wallet_tip.height();
 
-        let reindex_from = self.reindex_from.or_else(|| {
-            if start_height == 0 {
-                rpc_client.get_blockchain_info().ok().map(|info| {
-                    Height::from_consensus(info.blocks as u32)
-                        .expect("Failed to convert blockchain height to consensus height")
-                })
-            } else {
-                None
-            }
-        });
+            // Fast-sync (default on) jumps an empty wallet's checkpoint to the
+            // chain tip rather than scanning from genesis. Only ever applies to
+            // a fresh wallet (height 0), which has no UTXOs to miss.
+            let fast_sync = self.conf.fast_sync.unwrap_or(true);
+            let reindex_from = self.reindex_from.or_else(|| {
+                if start_height == 0 && fast_sync {
+                    rpc_client.get_blockchain_info().ok().map(|info| {
+                        Height::from_consensus(info.blocks as u32)
+                            .expect("Failed to convert blockchain height to consensus height")
+                    })
+                } else {
+                    None
+                }
+            });
 
-        // Instruct the wallet to reindex from the specified height, ensuring it starts scanning the blockchain from this point onward.
-        if let Some(height) = reindex_from {
-            let height = height.to_consensus_u32();
-            if height > wallet_tip.height() {
-                // Insert a checkpoint into the wallet to avoid scanning the entire chain.
-                let hash = rpc_client.get_block_hash(height as u64)?;
-                let block = BlockId { height, hash };
-                let new_tip = wallet_tip.insert(block);
-                let update = bdk_wallet::Update {
-                    chain: Some(new_tip),
-                    ..Default::default()
-                };
-                wallet.apply_update(update)?;
+            // Instruct the wallet to reindex from the specified height, ensuring it starts scanning the blockchain from this point onward.
+            if let Some(height) = reindex_from {
+                let height = height.to_consensus_u32();
+                if height > wallet_tip.height() {
+                    // Insert a checkpoint into the wallet to avoid scanning the entire chain.
+                    let hash = rpc_client.get_block_hash(height as u64)?;
+                    let block = BlockId { height, hash };
+                    let new_tip = wallet_tip.insert(block);
+                    let update = bdk_wallet::Update {
+                        chain: Some(new_tip),
+                        ..Default::default()
+                    };
+                    wallet.apply_update(update)?;
+                }
             }
         }
 

--- a/lampo-chain/src/lib.rs
+++ b/lampo-chain/src/lib.rs
@@ -1,3 +1,4 @@
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, OnceLock};
 
 use lampo_common::event::onchain::OnChainEvent;
@@ -10,13 +11,83 @@ use lightning_block_sync::{BlockSource, SpvClient};
 use lampo_common::async_trait;
 use lampo_common::backend::{Backend, BlockData};
 use lampo_common::bitcoin::consensus::encode::serialize_hex;
-use lampo_common::bitcoin::BlockHash;
+use lampo_common::bitcoin::{Block, BlockHash};
+use lampo_common::chainsync::ChainSyncCoordinator;
 use lampo_common::conf::LampoConf;
 use lampo_common::error;
 use lampo_common::json;
 use lampo_common::ldk::chain;
 use lampo_common::serde::Deserialize;
 use lampo_common::types::{LampoChainMonitor, LampoChannel};
+use lampo_common::wallet::WalletManager;
+
+/// Adapts the on-chain wallet to LDK's [`chain::Listen`] so it can ride the
+/// same `synchronize_listeners` pass as the channel manager and chain monitor
+/// -- one RPC stream for the whole node, instead of a second `getblock` scan.
+///
+/// This is the *only* place the LDK chain-sync types meet the wallet: the
+/// coupling is confined to the bitcoind backend crate. The wallet itself
+/// stays free of LDK, driven through the lampo-native `WalletManager` API.
+struct WalletChainListener {
+    wallet: Arc<dyn WalletManager>,
+    /// Set if any `apply_block` failed during a sync pass. `Listen` methods
+    /// can't return errors, so we record the failure here for the caller to
+    /// surface instead of silently advertising a successful unified sync.
+    failed: AtomicBool,
+}
+
+impl WalletChainListener {
+    fn new(wallet: Arc<dyn WalletManager>) -> Self {
+        Self {
+            wallet,
+            failed: AtomicBool::new(false),
+        }
+    }
+
+    /// Clear the failure flag before a (re)try of `synchronize_listeners`.
+    fn reset(&self) {
+        self.failed.store(false, Ordering::Relaxed);
+    }
+
+    /// Whether any block apply failed during the last sync pass.
+    fn had_failure(&self) -> bool {
+        self.failed.load(Ordering::Relaxed)
+    }
+}
+
+impl chain::Listen for WalletChainListener {
+    fn filtered_block_connected(
+        &self,
+        _header: &lampo_common::bitcoin::block::Header,
+        _txdata: &chain::transaction::TransactionData,
+        _height: u32,
+    ) {
+        // Lampo's bitcoind backend delivers full blocks, so `block_connected`
+        // below is what actually runs. Mirrors ldk-node's wallet listener.
+        debug_assert!(
+            false,
+            "filtered_block_connected is unsupported for the on-chain wallet"
+        );
+    }
+
+    fn block_connected(&self, block: &Block, height: u32) {
+        if let Err(err) = self.wallet.apply_block(block, height) {
+            log::error!(
+                target: "lampo-chain",
+                "on-chain wallet apply_block at height {height} failed: {err}"
+            );
+            self.failed.store(true, Ordering::Relaxed);
+        }
+    }
+
+    fn blocks_disconnected(&self, _fork_point_block: chain::BlockLocator) {
+        // BDK rolls the wallet chain back via the next `block_connected`'s
+        // `connected_to` (the new parent), so an explicit disconnect is a
+        // no-op. Reorgs do not occur during the initial historical catch-up;
+        // ongoing reorgs are handled by the wallet's Emitter poll.
+        log::debug!(target: "lampo-chain", "on-chain wallet listener: blocks_disconnected");
+    }
+}
 
 /// Welcome in another Facede pattern implementation
 pub struct LampoChainSync {
@@ -25,6 +96,8 @@ pub struct LampoChainSync {
     channel_manager: OnceLock<Arc<LampoChannel>>,
     chain_monitor: OnceLock<Arc<LampoChainMonitor>>,
     handler: OnceLock<Arc<dyn lampo_common::handler::Handler>>,
+    coordinator: OnceLock<Arc<ChainSyncCoordinator>>,
+    wallet: OnceLock<Arc<dyn WalletManager>>,
 }
 
 impl LampoChainSync {
@@ -59,6 +132,8 @@ impl LampoChainSync {
             channel_manager: OnceLock::new(),
             chain_monitor: OnceLock::new(),
             handler: OnceLock::new(),
+            coordinator: OnceLock::new(),
+            wallet: OnceLock::new(),
         })
     }
 
@@ -86,6 +161,10 @@ impl LampoChainSync {
             .get()
             .expect("chain monitor not set")
             .clone()
+    }
+
+    fn wallet(&self) -> Option<Arc<dyn WalletManager>> {
+        self.wallet.get().cloned()
     }
 }
 
@@ -225,6 +304,24 @@ impl Backend for LampoChainSync {
         self.set_chain_monitor(chain_monitor);
     }
 
+    fn set_coordinator(&self, coordinator: Arc<ChainSyncCoordinator>) {
+        if self.coordinator.set(coordinator).is_err() {
+            log::debug!(
+                target: "lampo-chain",
+                "chain sync coordinator already set; keeping existing"
+            );
+        }
+    }
+
+    fn set_wallet_manager(&self, wallet: Arc<dyn WalletManager>) {
+        if self.wallet.set(wallet).is_err() {
+            log::debug!(
+                target: "lampo-chain",
+                "wallet manager already set; keeping existing"
+            );
+        }
+    }
+
     async fn listen(self: Arc<Self>) -> lampo_common::error::Result<()> {
         let channel_manager = self.channel_manager();
         let chain_monitor = self.chain_monitor();
@@ -237,16 +334,29 @@ impl Backend for LampoChainSync {
         // N+M+1 to the ChannelManager which still thinks it's at block N,
         // causing a "Blocks must be connected in chain-order" assertion.
         let manager_best = channel_manager.current_best_block();
-        let chain_listeners: Vec<(chain::BlockLocator, &(dyn chain::Listen + Send + Sync))> = vec![
-            (
-                manager_best.clone(),
-                &*channel_manager as &(dyn chain::Listen + Send + Sync),
-            ),
-            (
-                manager_best.clone(),
-                &*chain_monitor as &(dyn chain::Listen + Send + Sync),
-            ),
-        ];
+
+        // Include the on-chain wallet in the same sync pass so one RPC stream
+        // catches up the channel manager, chain monitor, and wallet together --
+        // deduplicating the overlapping block range instead of a second
+        // `getblock` scan. Excluded in `legacy` sync mode, and when
+        // `wallet_sync_parallel` is set (the wallet then runs its own Emitter,
+        // so attaching it here too would double-apply blocks). Kept in a local
+        // so it outlives the `chain_listeners` vec consumed on each attempt.
+        let parallel = self.config.wallet_sync_parallel.unwrap_or(false);
+        let legacy = match self.config.sync_mode.as_deref() {
+            Some(mode) if mode.eq_ignore_ascii_case("legacy") => true,
+            Some("unified") | None => false,
+            Some(mode) => {
+                log::warn!(
+                    target: "lampo-chain",
+                    "unrecognized sync_mode `{mode}`; falling back to unified"
+                );
+                false
+            }
+        };
+        let unified = !legacy && !parallel;
+        let wallet = if unified { self.wallet() } else { None };
+        let wallet_listener = wallet.as_ref().map(|w| WalletChainListener::new(w.clone()));
 
         log::info!(
             target: "lampo-chain",
@@ -255,12 +365,98 @@ impl Backend for LampoChainSync {
             manager_best.height
         );
 
-        let (cache, synced_chain_tip) =
-            init::synchronize_listeners(self.as_ref(), self.config.network, chain_listeners)
-                .await
-                .map_err(|e| error::anyhow!("Failed to synchronize chain listeners: {:?}", e))?;
+        // Retry on transient RPC failures so a hiccup in `synchronize_listeners`
+        // can't leave the coordinator stuck in `PendingInitialSync` (which would
+        // permanently gate the on-chain wallet). Each attempt rebuilds the
+        // listener set from the current best blocks, resuming where it left off.
+        let mut retry_delay = std::time::Duration::from_secs(5);
+        let (cache, synced_chain_tip) = loop {
+            if let Some(listener) = wallet_listener.as_ref() {
+                listener.reset();
+            }
+            let manager_best = channel_manager.current_best_block();
+            let mut chain_listeners: Vec<(
+                chain::BlockLocator,
+                &(dyn chain::Listen + Send + Sync),
+            )> = vec![
+                (
+                    manager_best.clone(),
+                    &*channel_manager as &(dyn chain::Listen + Send + Sync),
+                ),
+                (
+                    manager_best.clone(),
+                    &*chain_monitor as &(dyn chain::Listen + Send + Sync),
+                ),
+            ];
+            if let (Some(wallet), Some(listener)) = (wallet.as_ref(), wallet_listener.as_ref()) {
+                match wallet.current_best_block() {
+                    Ok(best) => {
+                        log::info!(
+                            target: "lampo-chain",
+                            "Including on-chain wallet in chain sync from height {}",
+                            best.height
+                        );
+                        chain_listeners.push((
+                            chain::BlockLocator::new(best.hash, best.height),
+                            listener as &(dyn chain::Listen + Send + Sync),
+                        ));
+                    }
+                    Err(err) => {
+                        log::error!(target: "lampo-chain", "skipping on-chain wallet in chain sync: {err}")
+                    }
+                }
+            }
+
+            // Bound each pass: a hung backend (the lightning-block-sync
+            // `RpcClient` has no read timeout) must not stall the listener
+            // sync -- and thus the gated wallet -- forever. On timeout we
+            // retry immediately; each attempt resumes from the listeners'
+            // current best blocks, so a slow-but-progressing sync keeps its
+            // progress across passes.
+            const SYNC_PASS_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(120);
+            match tokio::time::timeout(
+                SYNC_PASS_TIMEOUT,
+                init::synchronize_listeners(self.as_ref(), self.config.network, chain_listeners),
+            )
+            .await
+            {
+                Ok(Ok(result)) => break result,
+                Ok(Err(e)) => {
+                    log::error!(
+                        target: "lampo-chain",
+                        "Failed to synchronize chain listeners, retrying in {:?}: {:?}", retry_delay, e
+                    );
+                    tokio::time::sleep(retry_delay).await;
+                    retry_delay = (retry_delay * 2).min(std::time::Duration::from_secs(60));
+                }
+                Err(_) => {
+                    log::error!(
+                        target: "lampo-chain",
+                        "Timed out synchronizing chain listeners after {:?}, retrying",
+                        SYNC_PASS_TIMEOUT
+                    );
+                }
+            }
+        };
 
         log::info!(target: "lampo-chain", "Chain listeners synced to current tip");
+
+        // If the wallet failed to apply some blocks during the pass, surface it.
+        // The node still advances the LDK listeners; the gated wallet Emitter
+        // will recover the wallet from its last good checkpoint.
+        if wallet_listener.as_ref().is_some_and(|l| l.had_failure()) {
+            log::warn!(
+                target: "lampo-chain",
+                "on-chain wallet did not fully apply during unified sync; the wallet scan will recover it from its last good checkpoint"
+            );
+        }
+
+        // Publish listener-sync completion so gated components (e.g. the
+        // on-chain wallet) can proceed over the now-free RPC. No-op when no
+        // coordinator was injected.
+        if let Some(coordinator) = self.coordinator.get() {
+            coordinator.mark_listeners_synced();
+        }
 
         let chain_listener = (chain_monitor, channel_manager);
         let chain_poller = poll::ChainPoller::new(self.as_ref(), self.config.network);
@@ -273,5 +469,146 @@ impl Backend for LampoChainSync {
             // FIXME: make this configurable
             tokio::time::sleep(std::time::Duration::from_secs(1)).await;
         }
+    }
+}
+#[cfg(test)]
+mod tests {
+    use std::sync::{Arc, Mutex};
+
+    use lampo_common::async_trait;
+    use lampo_common::bitcoin::absolute::Height;
+    use lampo_common::bitcoin::block::Header as BlockHeader;
+    use lampo_common::bitcoin::block::{TxMerkleNode, Version};
+    use lampo_common::bitcoin::hashes::Hash;
+    use lampo_common::bitcoin::pow::CompactTarget;
+    use lampo_common::bitcoin::{Amount, Block, BlockHash, FeeRate, ScriptBuf, Transaction};
+    use lampo_common::conf::LampoConf;
+    use lampo_common::error;
+    use lampo_common::keys::LampoKeys;
+    use lampo_common::ldk::chain::Listen;
+    use lampo_common::model::response::{NewAddress, Utxo};
+    use lampo_common::wallet::{BlockRef, WalletManager};
+
+    use super::WalletChainListener;
+
+    struct MockWallet {
+        heights: Mutex<Vec<u32>>,
+        fail_height: Option<u32>,
+    }
+
+    impl MockWallet {
+        fn new(fail_height: Option<u32>) -> Self {
+            Self {
+                heights: Mutex::new(Vec::new()),
+                fail_height,
+            }
+        }
+    }
+
+    #[async_trait]
+    impl WalletManager for MockWallet {
+        async fn new(_: Arc<LampoConf>) -> error::Result<(Self, String)> {
+            unimplemented!()
+        }
+
+        async fn restore(_: Arc<LampoConf>, _: &str) -> error::Result<Self> {
+            unimplemented!()
+        }
+
+        fn ldk_keys(&self) -> Arc<LampoKeys> {
+            unimplemented!()
+        }
+
+        async fn get_onchain_address(&self) -> error::Result<NewAddress> {
+            unimplemented!()
+        }
+
+        async fn get_onchain_balance(&self) -> error::Result<u64> {
+            Ok(0)
+        }
+
+        async fn create_transaction(
+            &self,
+            _script: ScriptBuf,
+            _amount: Amount,
+            _fee_rate: FeeRate,
+            _best_block: Height,
+        ) -> error::Result<Transaction> {
+            unimplemented!()
+        }
+
+        async fn list_transactions(&self) -> error::Result<Vec<Utxo>> {
+            Ok(Vec::new())
+        }
+
+        async fn wallet_tips(&self) -> error::Result<Height> {
+            unimplemented!()
+        }
+
+        fn current_best_block(&self) -> error::Result<BlockRef> {
+            Ok(BlockRef {
+                height: 0,
+                hash: BlockHash::all_zeros(),
+            })
+        }
+
+        fn apply_block(&self, _block: &Block, height: u32) -> error::Result<()> {
+            self.heights.lock().unwrap().push(height);
+            if self.fail_height == Some(height) {
+                Err(error::anyhow!(
+                    "mock apply_block failure at height {}",
+                    height
+                ))
+            } else {
+                Ok(())
+            }
+        }
+
+        async fn sync(&self) -> error::Result<()> {
+            Ok(())
+        }
+
+        async fn listen(self: Arc<Self>) -> error::Result<()> {
+            Ok(())
+        }
+    }
+
+    fn dummy_block() -> Block {
+        Block {
+            header: BlockHeader {
+                version: Version::default(),
+                prev_blockhash: BlockHash::all_zeros(),
+                merkle_root: TxMerkleNode::all_zeros(),
+                time: 0,
+                bits: CompactTarget::from_consensus(0),
+                nonce: 0,
+            },
+            txdata: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn block_connected_delegates_to_apply_block_in_order() {
+        let wallet = Arc::new(MockWallet::new(None));
+        let listener = WalletChainListener::new(wallet.clone());
+
+        let block = dummy_block();
+        listener.block_connected(&block, 100);
+        listener.block_connected(&block, 101);
+
+        assert_eq!(wallet.heights.lock().unwrap().as_slice(), &[100, 101]);
+        assert!(!listener.had_failure());
+    }
+
+    #[test]
+    fn block_connected_failure_sets_failed_flag() {
+        let wallet = Arc::new(MockWallet::new(Some(42)));
+        let listener = WalletChainListener::new(wallet.clone());
+
+        let block = dummy_block();
+        listener.block_connected(&block, 42);
+
+        assert!(listener.had_failure());
+        assert_eq!(wallet.heights.lock().unwrap().as_slice(), &[42]);
     }
 }

--- a/lampo-common/src/backend.rs
+++ b/lampo-common/src/backend.rs
@@ -13,9 +13,11 @@ pub use lightning::routing::utxo::UtxoResult;
 pub use lightning_block_sync::{BlockData, BlockHeaderData, BlockSourceResult};
 use serde::{Deserialize, Serialize};
 
+use crate::chainsync::ChainSyncCoordinator;
 use crate::error;
 use crate::handler::Handler;
 use crate::types::{LampoChainMonitor, LampoChannel};
+use crate::wallet::WalletManager;
 
 #[derive(Serialize, Deserialize, Debug)]
 pub enum TxResult {
@@ -61,6 +63,15 @@ pub trait Backend: Send + Sync {
     fn set_channel_manager(&self, _: Arc<LampoChannel>) {}
 
     fn set_chain_monitor(&self, _: Arc<LampoChainMonitor>) {}
+
+    /// Inject the backend-agnostic chain-sync coordinator so the backend can
+    /// publish listener-sync progress. Default no-op.
+    fn set_coordinator(&self, _: Arc<ChainSyncCoordinator>) {}
+
+    /// Inject the on-chain wallet so the backend can drive it through the same
+    /// chain sync as the LDK listeners (one RPC stream). Default no-op. Passed
+    /// as the lampo-native `WalletManager`; the backend never sees BDK types.
+    fn set_wallet_manager(&self, _: Arc<dyn WalletManager>) {}
 
     /// Get the information of a transaction inside the blockchain.
     async fn get_transaction(&self, txid: &Txid) -> error::Result<TxResult>;

--- a/lampo-common/src/chainsync.rs
+++ b/lampo-common/src/chainsync.rs
@@ -1,0 +1,243 @@
+//! Backend-agnostic chain-sync coordination.
+//!
+//! `ChainSyncCoordinator` is a small, dependency-free state holder that lets
+//! the chain backend, the on-chain wallet, and the JSON-RPC layer agree on
+//! where the node is in its initial sync — without any of them depending on
+//! each other. It carries **no** LDK or BDK types on purpose: the concrete
+//! `Backend` drives the transitions, the wallet reports progress, and
+//! `getinfo` reads the state. See `docs/designs/unified-chain-sync.md`.
+//!
+//! The coordinator is driven now: `mark_listeners_synced` is called from
+//! `lampo-chain` after `synchronize_listeners`, and `mark_running` is called
+//! from the wallet `sync()` once the on-chain scan is up to tip.
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::time::{Duration, Instant};
+
+use tokio::sync::watch;
+
+/// Lifecycle of the node's initial chain sync.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum SyncState {
+    /// Initial listener sync has not completed yet.
+    #[default]
+    PendingInitialSync,
+    /// LDK chain listeners are caught up to tip; wallet may still be scanning.
+    ListenersSynced,
+    /// Initial sync fully complete; the node is following the chain tip.
+    Running,
+}
+
+/// Sentinel for "no wallet scan height reported yet" stored in the atomic.
+const NO_HEIGHT: u64 = u64::MAX;
+
+/// How long the on-chain wallet waits for the LDK listener sync before it
+/// scans independently, so a hung or very slow backend cannot permanently gate
+/// the wallet (mirrors `main`'s parallel scan). See `wallet_scan_allowed`.
+const LISTENER_SYNC_GRACE: Duration = Duration::from_secs(300);
+
+/// Backend-agnostic coordinator for the node's chain-sync state.
+///
+/// Cheap to clone behind an `Arc`; all methods take `&self`.
+pub struct ChainSyncCoordinator {
+    /// Current lifecycle state. A `watch` channel so callers can `await`
+    /// transitions (`wait_initial_sync_complete`) as well as read the latest
+    /// value.
+    state: watch::Sender<SyncState>,
+    /// Latest wallet scan height, or `NO_HEIGHT` when none has been reported.
+    wallet_scan_height: AtomicU64,
+    /// When the listener sync began; used by the wallet-gate escape path.
+    listener_sync_started: Instant,
+    /// Guards the one-time escape-path log message.
+    escape_logged: AtomicBool,
+}
+
+impl ChainSyncCoordinator {
+    pub fn new() -> Self {
+        let (state, _) = watch::channel(SyncState::PendingInitialSync);
+        Self {
+            state,
+            wallet_scan_height: AtomicU64::new(NO_HEIGHT),
+            listener_sync_started: Instant::now(),
+            escape_logged: AtomicBool::new(false),
+        }
+    }
+
+    /// Current lifecycle state.
+    pub fn state(&self) -> SyncState {
+        *self.state.borrow()
+    }
+
+    /// Advance to `ListenersSynced` once the LDK listeners reach tip.
+    ///
+    /// Only moves forward from `PendingInitialSync`; never regresses a node
+    /// that is already `Running`.
+    pub fn mark_listeners_synced(&self) {
+        self.state.send_if_modified(|state| {
+            if matches!(state, SyncState::PendingInitialSync) {
+                *state = SyncState::ListenersSynced;
+                true
+            } else {
+                false
+            }
+        });
+    }
+
+    /// Advance to `Running`: the initial sync is fully complete.
+    ///
+    /// Only advances from `ListenersSynced` (a no-op from `Running`, and
+    /// defensively a no-op from `PendingInitialSync` so the state machine is
+    /// self-consistent regardless of caller).
+    pub fn mark_running(&self) {
+        self.state.send_if_modified(|state| {
+            if matches!(state, SyncState::ListenersSynced) {
+                *state = SyncState::Running;
+                true
+            } else {
+                false
+            }
+        });
+    }
+
+    /// Latest reported wallet scan height, if any.
+    pub fn wallet_scan_height(&self) -> Option<u32> {
+        match self.wallet_scan_height.load(Ordering::Relaxed) {
+            NO_HEIGHT => None,
+            height => Some(height as u32),
+        }
+    }
+
+    /// Report the wallet's current scan height (live progress during catch-up).
+    pub fn set_wallet_scan_height(&self, height: u32) {
+        self.wallet_scan_height
+            .store(u64::from(height), Ordering::Relaxed);
+    }
+
+    /// Resolve once the full initial sync has completed (state is `Running`).
+    /// Wait until listeners + wallet have both finished their initial sync.
+    pub async fn wait_initial_sync_complete(&self) {
+        let mut rx = self.state.subscribe();
+        loop {
+            if matches!(*rx.borrow_and_update(), SyncState::Running) {
+                return;
+            }
+            // The coordinator owns `self.state`, so the sender never drops while
+            // we hold `&self`; `changed()` therefore cannot error here, but if it
+            // ever did we simply stop waiting rather than spin.
+            if rx.changed().await.is_err() {
+                return;
+            }
+        }
+    }
+
+    /// Whether the LDK chain listeners have completed their initial sync.
+    pub fn chain_listeners_synced(&self) -> bool {
+        !matches!(self.state(), SyncState::PendingInitialSync)
+    }
+
+    /// Whether the on-chain wallet may scan right now.
+    ///
+    /// `true` once the listeners have synced. As an escape path, also `true`
+    /// after `LISTENER_SYNC_GRACE` has elapsed without the listeners finishing,
+    /// so a hung or very slow backend cannot permanently block the wallet (it
+    /// then scans in parallel, as on `main`). Logged once when the escape fires.
+    pub fn wallet_scan_allowed(&self) -> bool {
+        if self.chain_listeners_synced() {
+            return true;
+        }
+        let elapsed = self.listener_sync_started.elapsed();
+        if elapsed >= LISTENER_SYNC_GRACE {
+            if !self.escape_logged.swap(true, Ordering::Relaxed) {
+                log::warn!(
+                    target: "lampo-chain-sync",
+                    "listener sync not complete after {:?}; allowing the on-chain wallet to scan independently so it is not blocked",
+                    elapsed
+                );
+            }
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Whether the full initial sync (listeners + wallet) has completed.
+    pub fn initial_sync_complete(&self) -> bool {
+        matches!(self.state(), SyncState::Running)
+    }
+
+    /// Whether an initial sync is still in progress (not yet `Running`).
+    pub fn sync_in_progress(&self) -> bool {
+        !matches!(self.state(), SyncState::Running)
+    }
+}
+
+impl Default for ChainSyncCoordinator {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn initial_state_is_pending() {
+        let coord = ChainSyncCoordinator::new();
+        assert_eq!(coord.state(), SyncState::PendingInitialSync);
+        assert!(!coord.chain_listeners_synced());
+        assert!(!coord.initial_sync_complete());
+        assert!(coord.sync_in_progress());
+        assert_eq!(coord.wallet_scan_height(), None);
+    }
+
+    #[test]
+    fn mark_listeners_synced_advances_once() {
+        let coord = ChainSyncCoordinator::new();
+        coord.mark_listeners_synced();
+        assert_eq!(coord.state(), SyncState::ListenersSynced);
+        assert!(coord.chain_listeners_synced());
+        assert!(!coord.initial_sync_complete());
+        assert!(coord.sync_in_progress());
+    }
+
+    #[test]
+    fn mark_listeners_synced_does_not_regress_running() {
+        let coord = ChainSyncCoordinator::new();
+        coord.mark_listeners_synced();
+        coord.mark_running();
+        // A late listener-sync signal must not pull a Running node backwards.
+        coord.mark_listeners_synced();
+        assert_eq!(coord.state(), SyncState::Running);
+        assert!(coord.initial_sync_complete());
+        assert!(!coord.sync_in_progress());
+    }
+
+    #[test]
+    fn mark_running_requires_listeners_synced_first() {
+        let coord = ChainSyncCoordinator::new();
+        // Defensive: never jump straight from Pending to Running.
+        coord.mark_running();
+        assert_eq!(coord.state(), SyncState::PendingInitialSync);
+        coord.mark_listeners_synced();
+        coord.mark_running();
+        assert_eq!(coord.state(), SyncState::Running);
+    }
+
+    #[test]
+    fn wallet_scan_allowed_reflects_sync_state() {
+        let coord = ChainSyncCoordinator::new();
+        // Before the listeners sync the wallet must wait (grace not elapsed).
+        assert!(!coord.wallet_scan_allowed());
+        coord.mark_listeners_synced();
+        // Once listeners are synced the wallet is always allowed to scan.
+        assert!(coord.wallet_scan_allowed());
+    }
+
+    #[test]
+    fn wallet_scan_height_roundtrip() {
+        let coord = ChainSyncCoordinator::new();
+        assert_eq!(coord.wallet_scan_height(), None);
+        coord.set_wallet_scan_height(307_000);
+        assert_eq!(coord.wallet_scan_height(), Some(307_000));
+    }
+}

--- a/lampo-common/src/conf.rs
+++ b/lampo-common/src/conf.rs
@@ -28,6 +28,18 @@ pub struct LampoConf {
     pub api_port: u64,
     pub reindex: Option<Height>,
     pub dev_sync: Option<bool>,
+    /// Allow the on-chain wallet to scan in parallel with the LDK chain
+    /// listener sync. Defaults to `false`: the wallet waits for listeners to
+    /// catch up first, so the two pipelines don't compete for the same RPC.
+    pub wallet_sync_parallel: Option<bool>,
+    /// Chain sync strategy: `"unified"` (default) drives the on-chain wallet
+    /// through the same `synchronize_listeners` pass as the LDK listeners;
+    /// `"legacy"` keeps the wallet on its standalone BDK Emitter scan.
+    pub sync_mode: Option<String>,
+    /// Fast-sync an empty wallet by jumping its checkpoint to the chain tip
+    /// instead of scanning from genesis. Defaults to `true` and only applies
+    /// to a fresh wallet (no UTXOs to miss); set `false` to force a full scan.
+    pub fast_sync: Option<bool>,
 }
 
 impl Default for LampoConf {
@@ -60,6 +72,9 @@ impl Default for LampoConf {
             api_port: 7878,
             reindex: None,
             dev_sync: None,
+            wallet_sync_parallel: None,
+            sync_mode: None,
+            fast_sync: None,
         }
     }
 }
@@ -249,6 +264,18 @@ impl TryFrom<String> for LampoConf {
             .get_conf("dev-sync")
             .unwrap_or(None)
             .map(|s| s.to_lowercase() == "true" || s == "1");
+        // Parse wallet_sync_parallel field - defaults to None (false)
+        let wallet_sync_parallel = conf
+            .get_conf("wallet-sync-parallel")
+            .unwrap_or(None)
+            .map(|s| s.to_lowercase() == "true" || s == "1");
+        // Parse sync_mode field - defaults to None ("unified")
+        let sync_mode = conf.get_conf("sync-mode").unwrap_or(None);
+        // Parse fast_sync field - defaults to None (true)
+        let fast_sync = conf
+            .get_conf("fast-sync")
+            .unwrap_or(None)
+            .map(|s| s.to_lowercase() == "true" || s == "1");
         Ok(Self {
             inner: Some(conf),
             root_path,
@@ -269,6 +296,9 @@ impl TryFrom<String> for LampoConf {
             api_port,
             reindex,
             dev_sync,
+            wallet_sync_parallel,
+            sync_mode,
+            fast_sync,
         })
     }
 }

--- a/lampo-common/src/lib.rs
+++ b/lampo-common/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod backend;
+pub mod chainsync;
 pub mod conf;
 pub mod event;
 pub mod handler;

--- a/lampo-common/src/wallet.rs
+++ b/lampo-common/src/wallet.rs
@@ -5,6 +5,7 @@ use async_trait::async_trait;
 use crate::bitcoin::absolute::Height;
 use crate::bitcoin::{Amount, FeeRate};
 use crate::bitcoin::{ScriptBuf, Transaction};
+use crate::chainsync::ChainSyncCoordinator;
 use crate::conf::LampoConf;
 use crate::error;
 use crate::keys::LampoKeys;
@@ -49,6 +50,12 @@ pub trait WalletManager: Send + Sync {
     /// Return the last block height of the wallet, but we can abstract
     /// in the future the wallet tips info that we will need.
     async fn wallet_tips(&self) -> error::Result<Height>;
+
+    /// Inject the chain-sync coordinator so the wallet can gate its scan on
+    /// the LDK listener sync and report scan progress. Default no-op; the
+    /// gate stays inactive until a coordinator is set. Pure lampo-common type
+    /// (no LDK), keeping the wallet replaceable.
+    fn set_coordinator(&self, _: Arc<ChainSyncCoordinator>) {}
 
     /// Sync the wallet.
     async fn sync(&self) -> error::Result<()>;

--- a/lampo-common/src/wallet.rs
+++ b/lampo-common/src/wallet.rs
@@ -4,12 +4,21 @@ use async_trait::async_trait;
 
 use crate::bitcoin::absolute::Height;
 use crate::bitcoin::{Amount, FeeRate};
-use crate::bitcoin::{ScriptBuf, Transaction};
+use crate::bitcoin::{Block, BlockHash, ScriptBuf, Transaction};
 use crate::chainsync::ChainSyncCoordinator;
 use crate::conf::LampoConf;
 use crate::error;
 use crate::keys::LampoKeys;
 use crate::model::response::{NewAddress, Utxo};
+
+/// A lightweight reference to a block (height + hash). Pure `bitcoin` types,
+/// so a chain backend and the wallet can exchange chain positions without the
+/// wallet depending on LDK or the backend depending on BDK.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct BlockRef {
+    pub height: u32,
+    pub hash: BlockHash,
+}
 
 /// Wallet manager trait that define a generic interface
 /// over Wallet implementation!
@@ -50,6 +59,23 @@ pub trait WalletManager: Send + Sync {
     /// Return the last block height of the wallet, but we can abstract
     /// in the future the wallet tips info that we will need.
     async fn wallet_tips(&self) -> error::Result<Height>;
+
+    /// The wallet's current best (checkpoint) block: height + hash. Lets a
+    /// chain backend compute where to start syncing the wallet from in a
+    /// unified sync pass.
+    ///
+    /// Synchronous so an LDK `Listen` adapter can call it without an async
+    /// runtime; the underlying access is a short, non-blocking lookup.
+    fn current_best_block(&self) -> error::Result<BlockRef>;
+
+    /// Apply a connected block, advancing the wallet's view of the chain.
+    /// Takes pure `bitcoin` types so the wallet never depends on LDK
+    /// chain-sync; a backend drives this during unified sync.
+    ///
+    /// Synchronous so it can be driven directly from `Listen::block_connected`
+    /// (which is itself sync) on any runtime flavor, keeping `LampoDaemon`
+    /// embeddable. The critical section is a short BDK apply + persist.
+    fn apply_block(&self, block: &Block, height: u32) -> error::Result<()>;
 
     /// Inject the chain-sync coordinator so the wallet can gate its scan on
     /// the LDK listener sync and report scan progress. Default no-op; the

--- a/lampo-testing/src/lib.rs
+++ b/lampo-testing/src/lib.rs
@@ -166,9 +166,12 @@ impl LampoTesting {
         let lampo_conf = Arc::new(lampo_conf);
         let (wallet, mnemonic) = BDKWalletManager::new(lampo_conf.clone()).await?;
         let wallet = Arc::new(wallet);
+
+        // `LampoDaemon::new` shares the coordinator with the wallet, so the
+        // wallet gates its Emitter on listener sync (production startup flow).
+        let mut lampo = LampoDaemon::new(lampo_conf.clone(), wallet.clone());
         wallet.clone().listen().await?;
 
-        let mut lampo = LampoDaemon::new(lampo_conf.clone(), wallet.clone());
         let node = Arc::new(LampoChainSync::new(lampo_conf.clone())?);
         lampo.init(node.clone()).await?;
         log::info!("bitcoin core added inside lampo");

--- a/lampod-cli/src/main.rs
+++ b/lampod-cli/src/main.rs
@@ -176,7 +176,8 @@ async fn run(args: LampoCliArgs) -> error::Result<()> {
     log::debug!(target: "lampod-cli", "wallet created with success");
     let mut lampod = LampoDaemon::new(lampo_conf.clone(), wallet.clone());
 
-    // Do wallet syncing in the background!
+    // Do wallet syncing in the background! (`LampoDaemon::new` already shared
+    // the chain-sync coordinator with the wallet.)
     wallet.listen().await?;
 
     // Init the lampod

--- a/lampod/Cargo.toml
+++ b/lampod/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-tokio = { version = "^1.50.0", features = ["rt-multi-thread", "parking_lot", "macros"] }
+tokio = { version = "^1.50.0", features = ["rt-multi-thread", "parking_lot", "macros", "time"] }
 lampo-common = { path = "../lampo-common" }
 log = "0.4.17"
 time = "0.3.43"

--- a/lampod/src/chain/blockchain.rs
+++ b/lampod/src/chain/blockchain.rs
@@ -165,4 +165,24 @@ impl Backend for LampoChainManager {
     fn set_handler(&self, arc: Arc<dyn lampo_common::handler::Handler>) {
         self.backend.set_handler(arc);
     }
+
+    // Forward every injection hook to the wrapped backend. The `Backend`
+    // trait defaults them to no-ops, so a facade that does not forward
+    // silently swallows the injection and the coordinator/wallet never
+    // reaches the real backend.
+    fn set_channel_manager(&self, channel_manager: Arc<lampo_common::types::LampoChannel>) {
+        self.backend.set_channel_manager(channel_manager);
+    }
+
+    fn set_chain_monitor(&self, chain_monitor: Arc<lampo_common::types::LampoChainMonitor>) {
+        self.backend.set_chain_monitor(chain_monitor);
+    }
+
+    fn set_coordinator(&self, coordinator: Arc<lampo_common::chainsync::ChainSyncCoordinator>) {
+        self.backend.set_coordinator(coordinator);
+    }
+
+    fn set_wallet_manager(&self, wallet: Arc<dyn WalletManager>) {
+        self.backend.set_wallet_manager(wallet);
+    }
 }

--- a/lampod/src/lib.rs
+++ b/lampod/src/lib.rs
@@ -25,6 +25,7 @@ use std::time::SystemTime;
 use tokio::task::JoinHandle;
 
 use lampo_common::backend::Backend;
+use lampo_common::chainsync::ChainSyncCoordinator;
 use lampo_common::conf::LampoConf;
 use lampo_common::handler::ExternalHandler;
 use lampo_common::json;
@@ -98,11 +99,17 @@ pub struct LampoDaemon {
     persister: Arc<LampoPersistence>,
     handler: Option<Arc<LampoHandler>>,
     shutdown: Arc<AtomicBool>,
+    chain_sync: Arc<ChainSyncCoordinator>,
 }
 
 impl LampoDaemon {
     pub fn new(config: Arc<LampoConf>, wallet_manager: Arc<dyn WalletManager>) -> Self {
         let root_path = config.path();
+        let chain_sync = Arc::new(ChainSyncCoordinator::new());
+        // Wire the wallet to the coordinator here so every daemon (CLI, tests,
+        // embedders) gets consistent sync-progress reporting with no per-caller
+        // setup. The backend is wired separately in `init`.
+        wallet_manager.set_coordinator(chain_sync.clone());
         LampoDaemon {
             conf: config,
             logger: Arc::new(LampoLogger {}),
@@ -115,7 +122,14 @@ impl LampoDaemon {
             offchain_manager: None,
             handler: None,
             shutdown: Arc::new(AtomicBool::new(false)),
+            chain_sync,
         }
+    }
+
+    /// Backend-agnostic chain-sync coordinator shared across the daemon's
+    /// components.
+    pub fn chain_sync(&self) -> Arc<ChainSyncCoordinator> {
+        self.chain_sync.clone()
     }
 
     /// Signal the daemon to shut down gracefully. This causes the LDK
@@ -244,6 +258,8 @@ impl LampoDaemon {
         client.set_handler(self.handler());
         client.set_channel_manager(self.channel_manager().manager());
         client.set_chain_monitor(self.channel_manager().chain_monitor());
+        client.set_coordinator(self.chain_sync());
+        client.set_wallet_manager(self.wallet_manager());
         self.channel_manager().set_handler(self.handler());
         Ok(())
     }

--- a/tools/check-wallet-decoupling.sh
+++ b/tools/check-wallet-decoupling.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+#
+# Guard the unified-chain-sync invariant: the on-chain wallet crate
+# (`lampo-bdk-wallet`) must NOT depend directly on any LDK (`lightning*`) crate.
+#
+# The LDK <-> wallet coupling lives in `lampo-chain` via the
+# `WalletChainListener` adapter, so the wallet stays independently replaceable.
+# See docs/designs/unified-chain-sync.md.
+#
+# Note: a *transitive* `lightning` dep is expected (through `lampo-common`); we
+# only forbid a *direct* dependency, hence `--depth 1`.
+set -euo pipefail
+
+# We only check --edges normal because dev-dependencies on lightning would be
+# weird but still slip through; the real API-coupling surface is the normal
+# dependency graph, which is what this guard protects.
+#
+# Run `cargo tree` on its own first so a failure (bad package name, broken
+# workspace) aborts the guard instead of being masked as a clean pass by the
+# `grep || true` below.
+tree=$(cargo tree -p lampo-bdk-wallet --edges normal --depth 1 --prefix none)
+direct=$(printf '%s\n' "$tree" | grep -E '^lightning' || true)
+
+if [ -n "$direct" ]; then
+    echo "::error::lampo-bdk-wallet directly depends on an LDK crate:" >&2
+    echo "$direct" >&2
+    echo "Keep the on-chain wallet free of LDK chain-sync; put the coupling in" >&2
+    echo "lampo-chain instead (see docs/designs/unified-chain-sync.md)." >&2
+    exit 1
+fi
+
+echo "OK: lampo-bdk-wallet has no direct LDK (lightning*) dependency."


### PR DESCRIPTION
This PR replaces #546, #548 and #549 with a single series on top of the current main, so the unified chain sync work (#545) is reviewable in one place.

The review surface is the sync machine only: coordinator, wallet adapter, and the wallet-decoupling CI guard. Operator API (`getinfo` sync fields, `sync_wallets` RPC) and the design-doc rewrite stay out until the path is locked.

## What this does

- Adds a backend-agnostic `ChainSyncCoordinator` in `lampo-common`: pure state (atomics + a tokio `watch` channel), no LDK and no BDK types. The backend drives it; the wallet reports progress.
- Drives the on-chain wallet through the same `synchronize_listeners` pass as the channel manager and chain monitor, so one RPC stream catches up the whole node instead of two overlapping `getblock` scans. The LDK to wallet coupling lives only in `lampo-chain` via a small `Listen` adapter, and CI now guards that `lampo-bdk-wallet` stays free of LDK.
- Adds `sync-mode`, `fast-sync` and `wallet-sync-parallel` config knobs (absent-by-default).

## Commits

1. `config: add chain-sync tuning options`
2. `sync: add ChainSyncCoordinator`
3. `wallet: integrate with the chain-sync coordinator`
4. `chain: drive wallet through synchronize_listeners`
5. `ci: guard wallet stays free of LDK`

## What it fixes from the previous PRs

Running #546 live on my signet node (SSH tunnel, so a slow and sometimes hung backend) showed two real problems, and this series folds the fixes directly into the commits that introduced the code instead of stacking more PRs on top:

1. `lightning-block-sync`'s `RpcClient` has no read timeout, so a hung RPC stalls `synchronize_listeners` forever and the gated wallet makes zero progress. Now every pass is bounded by a 120s timeout and retried, and each attempt resumes from the listeners' current best blocks, so a slow but progressing sync keeps its progress (this was #549).
2. The wallet gate has an escape path now: after a 300s grace window the wallet scans independently, exactly like on main, so a degraded backend can never block the wallet forever (also #549).

The #548 fix is not here because it turned out to be a no-op: the call went through the `Backend` trait's default empty `set_coordinator`, so it never reached the real backend. The default-no-op injection hooks are the real foot-gun, and now `LampoChainManager` forwards all of them to the wrapped backend, so this class of bug cannot happen again.

Link: https://github.com/vincenzopalazzo/lampo.rs/issues/545

Signed-off-by: Vincenzo Palazzo <vincenzopalazzodev@gmail.com>
