### PR TITLE
Close on-chain fund-loss holes for production use

### DIFF
--- a/docs/brainstorms/2026-08-09-lampo-production-fund-safety.md
+++ b/docs/brainstorms/2026-08-09-lampo-production-fund-safety.md
@@ -1,0 +1,151 @@
+# Lampo Production Fund-Safety
+
+Date: 2026-08-09
+Status: Brainstorm (clarified problem statement)
+
+## Clarified Problem Statement
+
+**Goal:** Make Lampo safe to run on mainnet with small funds by closing the
+onchain fund-loss holes (sweeping, fees, broadcast, bumping), adding a
+VSS-mirrored channel-state backup, unifying chain sync per the existing design
+doc, and hardening startup/acceptance paths — reusing LDK's battle-tested
+components (like ldk-node does) while keeping Lampo's own architecture.
+
+**Constraints:**
+- Reuse LDK off-the-shelf components: `lightning::util::sweep::OutputSweeper`,
+  `BumpTransactionEventHandler`, `vss-client` — no Lampo-native rewrites.
+- Filesystem stays the primary store (fast, fsync'd); VSS is a mirror/backup,
+  not the primary KVStore. Recovery from VSS is an explicit tool/flow.
+- Keep Lampo's design solid: small, self-contained PRs per CLAUDE.md; no
+  dependency additions without maintainer sign-off (vss-client is the main new one).
+- bitcoind RPC remains the only chain backend for now.
+- LDK is pinned at 0.3 (git rev `84605cf`); all work targets that API.
+
+**Non-goals:**
+- Esplora/electrum/compact-filter backends.
+- VSS as primary store (ldk-node's "VSS mode") — mirror only.
+- Adopting ldk-node itself as a dependency; we mirror its patterns, not its crate.
+- Watchtowers, splicing, LSP flows.
+- Mnemonic encryption (worth doing, tracked separately — not fund-loss via LN).
+
+**Success criteria:**
+- Integration test: force-close a channel on regtest → `SpendableOutputs` is
+  swept back into the BDK wallet automatically (sweeper survives restart mid-sweep).
+- `FeeEstimator` serves per-`ConfirmationTarget` rates from `estimatesmartfee`
+  (cached, with sane floors/fallbacks), no hardcoded 256 sat/kW anywhere.
+- Anchor channels negotiable; `Event::BumpTransaction` handled end-to-end
+  (CPFP a commitment tx on regtest under a fee spike).
+- Broadcast failures are logged as errors, retried, and surfaced — no
+  fire-and-forget `tokio::spawn` discarding results.
+- Every KVStore write is mirrored to a running vss-server; a "restore from VSS
+  onto empty datadir" drill recovers the node with monitors intact.
+- Chain sync: single coordinator, each ChannelMonitor synced from its own best
+  block (not the manager's); the signet 11-hour stall scenario is gone.
+- Hardening: pid lock acquired before any state is read; inbound channels gated
+  by a config policy (off by default on mainnet); corrupt graph/scorer reads
+  warn loudly; `PaymentClaimable` no longer `unwrap()`s the preimage.
+
+## Baseline findings (2026-08-09 audit)
+
+Ranked fund-loss risks found in the code today:
+
+1. `Event::SpendableOutputs` unhandled → force-close outputs never swept
+   (`lampod/src/actions/handler.rs:457`; `None` sweeper at `lampod/src/lib.rs:290`).
+2. `FeeEstimator` hardcoded to 256 sat/kW for every target
+   (`lampod/src/chain/blockchain.rs:78-84`).
+3. No `BumpTransactionEventHandler` / anchor support — no CPFP/RBF escape.
+4. Broadcast errors discarded (`blockchain.rs:87-101`, `lampo-chain/src/lib.rs:126-139`).
+5. ChainMonitor synced from ChannelManager's best block, not per-monitor
+   (`lampo-chain/src/lib.rs:233-243`) — missed replay window after crash.
+6. Persistence is `FilesystemStore` only; module doc itself says not
+   production-ready (`lampod/src/persistence/mod.rs`).
+7. Auto-accept of all inbound channels (`handler.rs:119-136`); pid lock taken
+   after state load (`lampod-cli/src/main.rs:186`); silent fallback on corrupt
+   graph/scorer; `preimage.unwrap()` panic path (`handler.rs:347`).
+
+What's already sound: monitor persistence is synchronous and fsync'd
+(FilesystemStore tmp→sync→rename→sync), and `docs/designs/unified-chain-sync.md`
+already designs the sync fix.
+
+## Approaches Considered
+
+### Approach A: Safety-first phased ladder (onchain → VSS → sync unification)
+- Sketch: Land the direct fund-loss fixes as a sequence of small PRs on the
+  current architecture, gate mainnet on phases 1–2, and do the chain-sync
+  redesign last. Phase 1 (mainnet gate): real fee estimator + broadcast retry +
+  hardening batch. Phase 2 (mainnet gate): `OutputSweeper` wiring + anchors/
+  `BumpTransactionEventHandler`. Phase 3: VSS mirror KVStore. Phase 4: unified
+  chain sync per the design doc.
+- Affected files: `lampod/src/chain/blockchain.rs` (FeeEstimator, broadcaster),
+  `lampo-chain/src/lib.rs` (fee cache, broadcast result), `lampod/src/lib.rs`
+  (sweeper wiring, change-destination source backed by BDK wallet),
+  `lampod/src/actions/handler.rs` (events, accept policy, preimage),
+  `lampod/src/persistence/mod.rs` (KVStore trait + mirror), `lampod-cli/src/main.rs`
+  (pid lock), `lampo-common/src/conf.rs` (anchors, accept policy).
+- Tradeoffs: fastest path to "mainnet with small funds"; each PR is small and
+  testable. But the sweeper/fees land on top of the known-flaky dual sync
+  pipeline, and some fee-estimator plumbing may be touched again in phase 4.
+- Effort: L overall (Phase 1: S–M, Phase 2: M, Phase 3: M, Phase 4: L).
+
+### Approach B: Architecture-first (unified sync coordinator as the foundation)
+- Sketch: Implement `docs/designs/unified-chain-sync.md` first — single
+  `ChainSyncCoordinator`, `impl Listen for BDKWalletManager`, per-listener best
+  blocks — then build fee estimation, sweeper, and bump handling on the new
+  coordinator, then VSS mirror.
+- Affected files: new `lampo-chain` coordinator module, `lampo-bdk-wallet/src/lib.rs`
+  (Listen impl, drop Emitter cron), then the same files as Approach A.
+- Tradeoffs: cleanest end state, no rework, fixes the per-monitor replay risk
+  and the signet stall early. But it front-loads the largest and riskiest
+  refactor while the node still can't sweep force-closes or set fees — mainnet
+  is weeks further out.
+- Effort: L (coordinator alone is the design doc's 7-PR plan).
+
+### Approach C: Storage-first (VSS mirror before onchain work)
+- Sketch: Abstract `LampoPersistence` behind LDK's `KVStore` trait, add a
+  `MirroredStore` (filesystem primary + vss-client secondary with a durability
+  policy and replay journal), plus a restore tool; onchain fixes follow.
+- Affected files: `lampod/src/persistence/` (new module + mirror store),
+  `lampo-common/src/conf.rs`, new `lampo-vss` crate, recovery subcommand in
+  `lampod-cli`.
+- Tradeoffs: protects against disk loss early and is well-isolated. But today's
+  dominant risks are onchain (unswept closes, 1 sat/vB commitments) — a perfect
+  backup of a node that can't sweep or fee-bump still loses funds. Wrong order
+  for "mainnet soon".
+- Effort: M for the mirror, but delays the highest-value fixes.
+
+## Recommendation
+
+Approach A. The user wants mainnet with small funds soon; the unswept-outputs
+and hardcoded-fee holes are the ones that actually lose money there, and each
+phase-1/2 PR is small and independently shippable. The chain-sync redesign
+(already well-documented) lands last with everything else already tested on
+signet. Sequence the fee-estimator work so its interface (per-target cache in
+`lampo-chain`) survives the later coordinator refactor unchanged.
+
+Suggested phase order (each item ≈ one PR):
+1. Real `FeeEstimator` (estimatesmartfee cache, per-target mapping, floors).
+2. Broadcast error handling + retry.
+3. Hardening batch: early pid lock, accept-policy config, preimage unwrap fix,
+   loud corrupt-state warnings.
+4. Wire `OutputSweeper` (BDK-backed `ChangeDestinationSource`, sweeper in
+   `process_events_async`) + regtest force-close sweep test.
+5. Anchors: `UserConfig` negotiation + `BumpTransactionEventHandler` + reserve
+   management for anchor spends.
+6. Pluggable KVStore + VSS mirror + restore drill.
+7. Unified chain sync (per existing design doc).
+
+Mainnet-with-small-funds gate: after item 5. VSS (6) and sync unification (7)
+continue while mainnet runs with limited exposure.
+
+## Open questions
+
+- Anchor reserve policy: how many sats to keep unencumbered in the BDK wallet
+  for CPFP? (ldk-node uses a per-channel reserve heuristic.)
+- Should the VSS mirror block monitor persist on remote ack (stronger, slower)
+  or journal-and-replay (weaker, faster)? Leaning journal-and-replay since
+  filesystem is primary.
+- vss-server deployment/auth model (self-hosted? LNURL-auth? mTLS?) — needed
+  before item 6, not before.
+- Does the LDK 0.3 git pin expose `OutputSweeper`/`vss-client` compatible
+  versions, or does vss-client need a matching git pin?
+- Inbound accept policy default for mainnet: closed-by-default vs. allowlist.

--- a/docs/designs/production-onchain-safety.md
+++ b/docs/designs/production-onchain-safety.md
@@ -1,0 +1,140 @@
+# Production On-Chain Safety
+
+Status: Implemented
+Date: 2026-08-09
+Related: [unified-chain-sync.md](unified-chain-sync.md),
+[2026-08-09-lampo-production-fund-safety.md](../brainstorms/2026-08-09-lampo-production-fund-safety.md)
+
+## Motivation
+
+Lampo could not be run on mainnet without risking funds. An audit of the
+tree (see the brainstorm document above) found seven concrete fund-loss
+vectors, all in the on-chain path:
+
+1. **Channel monitors were never registered on restart.** Monitors were
+   read from disk and passed to `ChannelManagerReadArgs`, but no
+   `watch_channel` call existed anywhere in the tree. After any restart the
+   `ChainMonitor` was empty: counterparty force-closes, revoked
+   commitments, and on-chain HTLCs went undetected for every existing
+   channel. This was the single worst finding and was not in the original
+   audit ranking — it was found while implementing it.
+2. **`Event::SpendableOutputs` was dropped.** No `OutputSweeper` was wired
+   (`process_events_async` received `sweeper: None`), so funds from any
+   closed channel were permanently unswept.
+3. **The `FeeEstimator` returned a hardcoded 256 sat/kW** (~1 sat/vB) for
+   every `ConfirmationTarget`. Commitment/HTLC/close transactions were all
+   built at min-relay fee; under congestion a force-close would not
+   confirm before the CLTV deadline. On top of that, the funding path
+   interpreted the backend's sat/kvB value as sat/vB, overpaying funding
+   fees ~1000x.
+4. **No `BumpTransactionEventHandler`** even though anchor channels are
+   negotiated by default under LDK 0.3, whose commitments are *designed*
+   to need CPFP to confirm.
+5. **Broadcast failures were silently swallowed** (fire-and-forget
+   `tokio::spawn` discarding the result).
+6. **Chain listeners were synced from the ChannelManager's best block**,
+   not each listener's own, so a monitor persisted behind the manager
+   missed the blocks in between.
+7. **Startup races and panics**: the pid lock was taken *after* channel
+   state was loaded; the peer manager started concurrently with the
+   initial chain sync; `PaymentClaimable` unwrapped an optional preimage.
+
+## What was implemented
+
+One PR, one commit per concern, in dependency order:
+
+| Commit | Concern |
+|---|---|
+| `chain: Estimate fees per target instead of hardcoding` | Per-target fee cache refreshed from `estimatesmartfee`/`getmempoolinfo`; unified all feerates on sat-per-1000-weight; headroom on `MaximumFeeEstimate` |
+| `chain: Surface and retry failed transaction broadcasts` | `Backend::brodcast_tx` returns `Result`; multi-transaction packages relayed atomically via `submitpackage`; "already known" treated as success; bounded retry; `BroadcastFailed` event unblocks waiting RPC callers |
+| `node: Register channel monitors on restart` | Per-monitor catch-up sync + `watch_channel`; `sync_chain` runs to completion before peers/events start |
+| `node: Sweep spendable outputs of closed channels` | `OutputSweeper` wired end to end (persisted state, BDK change addresses, chain listener, background-processor timer); `SpendableOutputs` replayed on failure |
+| `node: Handle BumpTransaction events for anchors` | `BumpTransactionEventHandler` + `WalletSource` primitives on the BDK wallet; anchors made explicit in config; inbound anchor channels require a confirmed on-chain reserve |
+| `node: Harden startup and event handling paths` | Early pid lock, `accept-inbound-channels` option, no preimage unwrap, loud corrupt-state warnings, RPC surface gated until the initial sync completes |
+
+### Key design decisions
+
+- **Reuse LDK components, keep Lampo's architecture.** The sweeper is
+  `lightning::util::sweep::OutputSweeper`, fee bumping is
+  `BumpTransactionEventHandler`, coin selection is LDK's `Wallet` wrapper.
+  Lampo contributes only thin adapters: `LampoChangeDestination` and
+  `LampoWalletSource` in `lampo-common::wallet`, bridging the
+  `WalletManager` trait to LDK's traits. This mirrors ldk-node's choices
+  while keeping the `Backend`/facade structure intact.
+- **Only `SpendableOutputs` failures are replayed.** Dropping that event
+  on a transient persistence failure is fund loss, and replay is the
+  LDK-intended mechanism for it. Other events are *not* replayed: LDK
+  keeps a failed event at the head of the queue, so replaying an event
+  that fails permanently (a funding flow whose peer disconnected, a
+  wallet without funds) would block every later event — including
+  `PaymentClaimable` — forever.
+- **Packages are broadcast atomically.** When LDK hands the broadcaster
+  more than one transaction they form a child-pays-for-parent package
+  (anchor CPFP + commitment); they are submitted through bitcoind's
+  `submitpackage` so the low-feerate commitment cannot be rejected for
+  paying below the mempool minimum. "Already known" responses count as
+  success, so LDK's rebroadcast timer does not spam error logs.
+- **Inbound anchor channels require a reserve.** An anchor channel with
+  an empty on-chain wallet cannot CPFP its own force-close; inbound
+  anchor channel requests are rejected unless the confirmed wallet
+  balance covers a 25k-sat reserve (matching ldk-node's default).
+- **Static outputs are not excluded from sweeping.** They pay to scripts
+  derived from the LDK keys manager, which the separate BDK wallet does
+  not track. Only the sweeper can claim them. (ldk-node excludes them
+  because its on-chain wallet shares descriptors with LDK; Lampo's does
+  not.)
+- **Startup is now strictly ordered**: pid lock → load state →
+  `sync_chain` (per-listener catch-up + `watch_channel`) → SPV loop →
+  peer manager → background processor → RPC surface. A node that cannot
+  complete the initial sync exits instead of going live blind, and the
+  httpd does not accept commands while monitors are still unregistered
+  (a monitor update issued in that window would be silently dropped).
+
+## Justification for extending the unified-chain-sync design
+
+The existing [unified-chain-sync design](unified-chain-sync.md) plans a
+`ChainSyncCoordinator` that folds the BDK wallet and all LDK listeners
+into a single `synchronize_listeners` pipeline across ~7 PRs. This work
+does **not** implement that coordinator. It does, however, implement two
+items from that design's comparison table ahead of schedule, inside the
+current architecture:
+
+- per-listener block locators in the initial sync (each channel monitor
+  catches up from its own best block), and
+- the monitor-registration step (`watch_channel`) the design assumed but
+  the code lacked.
+
+The justification for doing these now, out of order:
+
+1. **Correctness cannot wait for architecture.** The missing
+   `watch_channel` is a total loss of channel enforcement after restart.
+   Landing it inside the coordinator refactor would couple the most
+   critical fix in the tree to the largest and riskiest refactor planned.
+2. **The work is forward-compatible.** The coordinator design already
+   requires per-listener locators and monitor registration; the
+   `ChainListeners` struct and `sync_chain`/`listen` split introduced here
+   are exactly the seams the coordinator will slot into. Nothing here
+   needs to be undone — the coordinator PRs shrink.
+3. **The dual-pipeline problem is unchanged.** The BDK wallet still runs
+   its own `Emitter` scan; the signet stall documented in the design doc
+   is still open and still owned by the coordinator work. This PR neither
+   fixes nor worsens it.
+
+## Follow-ups (deliberately out of scope)
+
+In the order recommended by the brainstorm document:
+
+1. **VSS mirror for channel state** — pluggable `KVStore` with
+   filesystem primary and `vss-client` mirror, plus a restore drill.
+2. **Unified chain sync** — the coordinator from the existing design doc.
+3. **Anchor reserve maintenance** — inbound anchor channels are now
+   gated on a 25k-sat confirmed balance at accept time, but nothing
+   stops the wallet from spending that balance later. A real reserve
+   (excluded from coin selection, sized per anchor channel) is still
+   needed.
+4. **Payment persistence** — `PaymentClaimed`/`PaymentSent` are still
+   logged only.
+5. **Mnemonic encryption** — `wallet.dat` is still plaintext.
+6. **Regtest coverage** — an integration test that force-closes a
+   channel, restarts the node, and asserts the sweep lands in the BDK
+   wallet would lock in the two biggest fixes here.

--- a/docs/designs/unified-chain-sync.md
+++ b/docs/designs/unified-chain-sync.md
@@ -7,6 +7,15 @@
 | Date | 2026-06-03 |
 | Related issues | [#540](https://github.com/vincenzopalazzo/lampo.rs/issues/540) (fast sync), [#444](https://github.com/vincenzopalazzo/lampo.rs/issues/444) (`reindex` semantics) |
 
+> **Status update (2026-08-09):** two items from this design's comparison
+> table landed early as part of
+> [production-onchain-safety.md](production-onchain-safety.md): the
+> initial sync now uses per-listener block locators (each channel monitor
+> catches up from its own best block) and restored monitors are registered
+> with the chain monitor via `watch_channel`. The `ChainSyncCoordinator`,
+> the wallet `Listen` integration, and the single-pipeline sync remain to
+> be implemented as designed here.
+
 ## Summary
 
 Lampo currently runs **two independent, competing chain-sync pipelines** over the same Bitcoin Core RPC backend: LDK `synchronize_listeners` (channel manager + chain monitor) and a separate BDK `Emitter` full-block scan (on-chain wallet). Production on Ocean Signet (~307k blocks) shows multi-day catch-up, RPC saturation, and LDK listener sync that never logs completion while the BDK path dominates `getblock` traffic.

--- a/lampo-bdk-wallet/src/lib.rs
+++ b/lampo-bdk-wallet/src/lib.rs
@@ -21,7 +21,9 @@ use lampo_common::bitcoin::absolute::Height;
 use lampo_common::bitcoin::bip32::Xpriv;
 use lampo_common::bitcoin::blockdata::locktime::absolute::LockTime;
 use lampo_common::bitcoin::PrivateKey;
-use lampo_common::bitcoin::{Amount, Block, FeeRate, ScriptBuf, Transaction};
+use lampo_common::bitcoin::{
+    Amount, Block, FeeRate, OutPoint, Psbt, ScriptBuf, Transaction, TxOut, Txid,
+};
 use lampo_common::conf::{LampoConf, Network};
 use lampo_common::keys::LampoKeys;
 use lampo_common::model::response::NewAddress;
@@ -367,6 +369,42 @@ impl WalletManager for BDKWalletManager {
         let tip = wallet.latest_checkpoint().height();
         let tip = Height::from_consensus(tip)?;
         Ok(tip)
+    }
+
+    async fn list_confirmed_utxos(&self) -> error::Result<Vec<(OutPoint, TxOut)>> {
+        let wallet = self.wallet.lock().await;
+        let utxos = wallet
+            .list_unspent()
+            .filter(|utxo| !utxo.is_spent && utxo.chain_position.is_confirmed())
+            .map(|utxo| (utxo.outpoint, utxo.txout))
+            .collect();
+        Ok(utxos)
+    }
+
+    async fn get_wallet_transaction(&self, txid: Txid) -> error::Result<Option<Transaction>> {
+        let wallet = self.wallet.lock().await;
+        Ok(wallet.get_tx(txid).map(|tx| tx.tx_node.tx.as_ref().clone()))
+    }
+
+    async fn get_change_script(&self) -> error::Result<ScriptBuf> {
+        let mut wallet = self.wallet.lock().await;
+        let mut wallet_db = self.wallet_db.lock().await;
+        let address = wallet.reveal_next_address(KeychainKind::Internal);
+        wallet.persist(&mut wallet_db)?;
+        Ok(address.address.script_pubkey())
+    }
+
+    async fn sign_psbt(&self, mut psbt: Psbt) -> error::Result<Transaction> {
+        let wallet = self.wallet.lock().await;
+        let opts = SignOptions {
+            // The PSBT may spend inputs the wallet does not own (e.g. the
+            // anchor output in a CPFP transaction): sign what belongs to
+            // the wallet and leave the rest for LDK to fill in.
+            trust_witness_utxo: true,
+            ..Default::default()
+        };
+        let _finalized = wallet.sign(&mut psbt, opts)?;
+        Ok(psbt.extract_tx()?)
     }
 
     async fn listen(self: Arc<Self>) -> error::Result<()> {

--- a/lampo-bdk-wallet/src/lib.rs
+++ b/lampo-bdk-wallet/src/lib.rs
@@ -403,7 +403,10 @@ impl WalletManager for BDKWalletManager {
             trust_witness_utxo: true,
             ..Default::default()
         };
-        let _finalized = wallet.sign(&mut psbt, opts)?;
+        let finalized = wallet.sign(&mut psbt, opts)?;
+        if !finalized {
+            error::bail!("wallet could not finalize every PSBT input");
+        }
         Ok(psbt.extract_tx()?)
     }
 

--- a/lampo-chain/src/lib.rs
+++ b/lampo-chain/src/lib.rs
@@ -18,9 +18,9 @@ use lampo_common::error;
 use lampo_common::json;
 use lampo_common::ldk::chain;
 use lampo_common::ldk::chain::chaininterface::FEERATE_FLOOR_SATS_PER_KW;
-use lampo_common::ldk::chain::{BlockLocator, ChannelMonitorUpdateStatus, Watch};
+use lampo_common::ldk::chain::{BlockLocator, ChannelMonitorUpdateStatus, Listen, Watch};
 use lampo_common::serde::Deserialize;
-use lampo_common::types::{LampoChainMonitor, LampoChannel, LampoMonitorListener};
+use lampo_common::types::{LampoChainMonitor, LampoChannel, LampoMonitorListener, LampoSweeper};
 
 /// Welcome in another Facede pattern implementation
 pub struct LampoChainSync {
@@ -36,6 +36,42 @@ pub struct LampoChainSync {
     /// Header cache and validated chain tip produced by the initial sync,
     /// consumed by [`Backend::listen`] to seed the SPV client.
     sync_state: Mutex<Option<(HeaderCache, ValidatedBlockHeader)>>,
+    /// The output sweeper, registered as an ongoing chain listener with the
+    /// best block its persisted state was last synced to.
+    sweeper: OnceLock<(BlockLocator, Arc<LampoSweeper>)>,
+}
+
+/// The set of ongoing chain listeners fed by the SPV client after the
+/// initial synchronization.
+struct ChainListeners {
+    chain_monitor: Arc<LampoChainMonitor>,
+    channel_manager: Arc<LampoChannel>,
+    sweeper: Option<Arc<LampoSweeper>>,
+}
+
+impl chain::Listen for ChainListeners {
+    fn filtered_block_connected(
+        &self,
+        header: &lampo_common::bitcoin::block::Header,
+        txdata: &chain::transaction::TransactionData,
+        height: u32,
+    ) {
+        self.chain_monitor
+            .filtered_block_connected(header, txdata, height);
+        self.channel_manager
+            .filtered_block_connected(header, txdata, height);
+        if let Some(ref sweeper) = self.sweeper {
+            sweeper.filtered_block_connected(header, txdata, height);
+        }
+    }
+
+    fn blocks_disconnected(&self, fork_point: BlockLocator) {
+        self.chain_monitor.blocks_disconnected(fork_point.clone());
+        self.channel_manager.blocks_disconnected(fork_point.clone());
+        if let Some(ref sweeper) = self.sweeper {
+            sweeper.blocks_disconnected(fork_point);
+        }
+    }
 }
 
 impl LampoChainSync {
@@ -72,6 +108,7 @@ impl LampoChainSync {
             handler: OnceLock::new(),
             stale_monitors: Mutex::new(Vec::new()),
             sync_state: Mutex::new(None),
+            sweeper: OnceLock::new(),
         })
     }
 
@@ -328,6 +365,12 @@ impl Backend for LampoChainSync {
         *self.stale_monitors.lock().unwrap() = monitors;
     }
 
+    fn set_sweeper(&self, best_block: BlockLocator, sweeper: Arc<LampoSweeper>) {
+        self.sweeper
+            .set((best_block, sweeper))
+            .unwrap_or_else(|_| panic!("sweeper already set"));
+    }
+
     async fn sync_chain(&self) -> lampo_common::error::Result<()> {
         let channel_manager = self.channel_manager();
         let chain_monitor = self.chain_monitor();
@@ -364,6 +407,12 @@ impl Backend for LampoChainSync {
             chain_listeners.push((
                 locator.clone(),
                 listener as &(dyn chain::Listen + Send + Sync),
+            ));
+        }
+        if let Some((sweeper_best, sweeper)) = self.sweeper.get() {
+            chain_listeners.push((
+                sweeper_best.clone(),
+                &**sweeper as &(dyn chain::Listen + Send + Sync),
             ));
         }
 
@@ -417,7 +466,11 @@ impl Backend for LampoChainSync {
             .take()
             .expect("sync_chain populated the state above");
 
-        let chain_listener = (self.chain_monitor(), self.channel_manager());
+        let chain_listener = ChainListeners {
+            chain_monitor: self.chain_monitor(),
+            channel_manager: self.channel_manager(),
+            sweeper: self.sweeper.get().map(|(_, sweeper)| sweeper.clone()),
+        };
         let chain_poller = poll::ChainPoller::new(self.as_ref(), self.config.network);
         let mut spv_client = SpvClient::new(synced_chain_tip, chain_poller, cache, &chain_listener);
         log::info!(target: "lampo-chain", "Start Backend ...");

--- a/lampo-chain/src/lib.rs
+++ b/lampo-chain/src/lib.rs
@@ -88,6 +88,29 @@ impl LampoChainSync {
             .expect("chain monitor not set")
             .clone()
     }
+
+    fn emit_broadcast_success(&self, tx: &lampo_common::bitcoin::Transaction) {
+        if let Some(handler) = self.handler.get() {
+            handler.emit(Event::OnChain(OnChainEvent::SendRawTransaction(tx.clone())));
+        }
+    }
+
+    fn emit_broadcast_failure(&self, tx: &lampo_common::bitcoin::Transaction) {
+        if let Some(handler) = self.handler.get() {
+            handler.emit(Event::OnChain(OnChainEvent::BroadcastFailed(
+                tx.compute_txid(),
+            )));
+        }
+    }
+}
+
+/// Whether a bitcoind broadcast error means the transaction (or package)
+/// is already in the mempool or the chain, i.e. the broadcast goal is met.
+fn is_already_broadcast_error(err: &str) -> bool {
+    err.contains("already in block chain")
+        || err.contains("txn-already-in-mempool")
+        || err.contains("txn-already-known")
+        || err.contains("already known")
 }
 
 impl BlockSource for LampoChainSync {
@@ -124,19 +147,85 @@ impl Backend for LampoChainSync {
         self.rpc_client.get_best_block().await
     }
 
-    async fn brodcast_tx(&self, tx: &lampo_common::bitcoin::Transaction) {
+    async fn brodcast_tx(
+        &self,
+        tx: &lampo_common::bitcoin::Transaction,
+    ) -> lampo_common::error::Result<()> {
         let resp = self
             .rpc_client
             .call_method::<json::Value>("sendrawtransaction", &[serialize_hex(tx).into()])
             .await;
-        log::info!("Broadcasting tx result: {:?}", resp);
-        if resp.is_ok() {
-            let Some(handler) = self.handler.get() else {
-                return;
-            };
-            handler.emit(Event::OnChain(OnChainEvent::SendRawTransaction(tx.clone())));
+        log::debug!(target: "lampo-chain", "broadcasting tx `{}` result: {:?}", tx.compute_txid(), resp);
+        match resp {
+            Ok(_) => {
+                self.emit_broadcast_success(tx);
+                Ok(())
+            }
+            // LDK's rebroadcast timer resends transactions that may already
+            // be in the mempool or confirmed; bitcoind rejects those with
+            // "already known"-style errors that mean the broadcast goal is
+            // achieved, not failed.
+            Err(err) if is_already_broadcast_error(&format!("{err:?}")) => {
+                self.emit_broadcast_success(tx);
+                Ok(())
+            }
+            Err(err) => {
+                self.emit_broadcast_failure(tx);
+                Err(error::anyhow!(
+                    "failed to broadcast tx `{}`: {:?}",
+                    tx.compute_txid(),
+                    err
+                ))
+            }
         }
-        // FIXME: emit the brodcast event for lampo in case of errors, just to unlock the client
+    }
+
+    async fn brodcast_txs(
+        &self,
+        txs: &[lampo_common::bitcoin::Transaction],
+    ) -> lampo_common::error::Result<()> {
+        let [_, _, ..] = txs else {
+            // Zero or one transaction: no package semantics needed.
+            if let Some(tx) = txs.first() {
+                return self.brodcast_tx(tx).await;
+            }
+            return Ok(());
+        };
+        // More than one transaction is a package (a child and its
+        // parents, e.g. an anchor CPFP paying for a low-feerate
+        // commitment): it must be submitted atomically or the parent can
+        // be rejected for paying below the mempool minimum feerate.
+        let hexes = txs
+            .iter()
+            .map(|tx| json::Value::from(serialize_hex(tx)))
+            .collect::<Vec<_>>();
+        let resp = self
+            .rpc_client
+            .call_method::<json::Value>("submitpackage", &[json::Value::from(hexes)])
+            .await;
+        log::debug!(target: "lampo-chain", "submitpackage result: {:?}", resp);
+        let err = match resp {
+            Ok(resp) => {
+                if resp.get("package_msg").and_then(|msg| msg.as_str()) == Some("success") {
+                    for tx in txs {
+                        self.emit_broadcast_success(tx);
+                    }
+                    return Ok(());
+                }
+                error::anyhow!("submitpackage rejected the package: {resp}")
+            }
+            Err(err) if is_already_broadcast_error(&format!("{err:?}")) => {
+                for tx in txs {
+                    self.emit_broadcast_success(tx);
+                }
+                return Ok(());
+            }
+            Err(err) => error::anyhow!("submitpackage failed: {err:?}"),
+        };
+        for tx in txs {
+            self.emit_broadcast_failure(tx);
+        }
+        Err(err)
     }
 
     async fn fee_rate_estimation(&self, blocks: u64) -> lampo_common::error::Result<u32> {

--- a/lampo-chain/src/lib.rs
+++ b/lampo-chain/src/lib.rs
@@ -15,6 +15,7 @@ use lampo_common::conf::LampoConf;
 use lampo_common::error;
 use lampo_common::json;
 use lampo_common::ldk::chain;
+use lampo_common::ldk::chain::chaininterface::FEERATE_FLOOR_SATS_PER_KW;
 use lampo_common::serde::Deserialize;
 use lampo_common::types::{LampoChainMonitor, LampoChannel};
 
@@ -146,7 +147,7 @@ impl Backend for LampoChainSync {
         }
 
         if self.config.network == lampo_common::bitcoin::Network::Regtest {
-            return Ok(256);
+            return Ok(FEERATE_FLOOR_SATS_PER_KW);
         }
 
         let resp = self
@@ -160,8 +161,10 @@ impl Backend for LampoChainSync {
         let Some(feerate) = resp.feerate else {
             return Err(error::anyhow!("No fee rate estimation available").into());
         };
-        // estimate fee rate in BTC/kvB
-        Ok((feerate * (100_000_000 as f64)) as u32)
+        // `estimatesmartfee` returns BTC/kvB; convert to sat/kvB and then to
+        // sats per 1000 weight units (a vbyte is 4 weight units).
+        let sat_per_kvb = feerate * 100_000_000f64;
+        Ok(((sat_per_kvb / 4.0) as u32).max(FEERATE_FLOOR_SATS_PER_KW))
     }
 
     async fn get_transaction(
@@ -187,7 +190,6 @@ impl Backend for LampoChainSync {
         unimplemented!()
     }
 
-    // TODO: specify what kind of format the result should be!
     async fn minimum_mempool_fee(&self) -> lampo_common::error::Result<u32> {
         #[derive(Debug, Deserialize)]
         struct MempoolInfo {
@@ -199,10 +201,12 @@ impl Backend for LampoChainSync {
             .call_method::<json::Value>("getmempoolinfo", &[])
             .await?;
         let mempool_info: MempoolInfo = json::from_value(mempool_info)?;
-        if mempool_info.loaded {
+        if !mempool_info.loaded {
             log::warn!("mempool is still loading, so the fee may be not accurate!");
         }
-        Ok((mempool_info.mempoolminfee * (100_000_000 as f64)) as u32)
+        // `mempoolminfee` is in BTC/kvB; convert to sats per 1000 weight units.
+        let sat_per_kvb = mempool_info.mempoolminfee * 100_000_000f64;
+        Ok(((sat_per_kvb / 4.0) as u32).max(FEERATE_FLOOR_SATS_PER_KW))
     }
 
     fn set_handler(&self, handler: Arc<dyn lampo_common::handler::Handler>) {

--- a/lampo-chain/src/lib.rs
+++ b/lampo-chain/src/lib.rs
@@ -1,9 +1,11 @@
-use std::sync::{Arc, OnceLock};
+use std::sync::{Arc, Mutex, OnceLock};
 
 use lampo_common::event::onchain::OnChainEvent;
 use lampo_common::event::Event;
 use lightning_block_sync::init;
+use lightning_block_sync::poll::ValidatedBlockHeader;
 use lightning_block_sync::rpc::RpcClient;
+use lightning_block_sync::HeaderCache;
 use lightning_block_sync::{poll, BlockHeaderData, BlockSourceResult};
 use lightning_block_sync::{BlockSource, SpvClient};
 
@@ -16,8 +18,9 @@ use lampo_common::error;
 use lampo_common::json;
 use lampo_common::ldk::chain;
 use lampo_common::ldk::chain::chaininterface::FEERATE_FLOOR_SATS_PER_KW;
+use lampo_common::ldk::chain::{BlockLocator, ChannelMonitorUpdateStatus, Watch};
 use lampo_common::serde::Deserialize;
-use lampo_common::types::{LampoChainMonitor, LampoChannel};
+use lampo_common::types::{LampoChainMonitor, LampoChannel, LampoMonitorListener};
 
 /// Welcome in another Facede pattern implementation
 pub struct LampoChainSync {
@@ -26,6 +29,13 @@ pub struct LampoChainSync {
     channel_manager: OnceLock<Arc<LampoChannel>>,
     chain_monitor: OnceLock<Arc<LampoChainMonitor>>,
     handler: OnceLock<Arc<dyn lampo_common::handler::Handler>>,
+    /// Channel monitors read from disk on restart. Each is synced to the
+    /// chain tip from its own best block during [`Backend::sync_chain`] and
+    /// then registered with the chain monitor via `watch_channel`.
+    stale_monitors: Mutex<Vec<(BlockLocator, LampoMonitorListener)>>,
+    /// Header cache and validated chain tip produced by the initial sync,
+    /// consumed by [`Backend::listen`] to seed the SPV client.
+    sync_state: Mutex<Option<(HeaderCache, ValidatedBlockHeader)>>,
 }
 
 impl LampoChainSync {
@@ -60,6 +70,8 @@ impl LampoChainSync {
             channel_manager: OnceLock::new(),
             chain_monitor: OnceLock::new(),
             handler: OnceLock::new(),
+            stale_monitors: Mutex::new(Vec::new()),
+            sync_state: Mutex::new(None),
         })
     }
 
@@ -312,28 +324,48 @@ impl Backend for LampoChainSync {
         self.set_chain_monitor(chain_monitor);
     }
 
-    async fn listen(self: Arc<Self>) -> lampo_common::error::Result<()> {
+    fn set_stale_monitors(&self, monitors: Vec<(BlockLocator, LampoMonitorListener)>) {
+        *self.stale_monitors.lock().unwrap() = monitors;
+    }
+
+    async fn sync_chain(&self) -> lampo_common::error::Result<()> {
         let channel_manager = self.channel_manager();
         let chain_monitor = self.chain_monitor();
 
-        // Synchronize the channel manager and chain monitor from their
-        // persisted best block up to the current chain tip. This is critical
-        // on restart: the ChannelManager may have been persisted at block N,
-        // but the chain may now be at block N+M. Without this sync, the
-        // SpvClient would start at the current tip and try to connect block
-        // N+M+1 to the ChannelManager which still thinks it's at block N,
-        // causing a "Blocks must be connected in chain-order" assertion.
+        // Synchronize the channel manager, the chain monitor, and every
+        // channel monitor read from disk, each from its own persisted best
+        // block up to the current chain tip. This is critical on restart:
+        // the ChannelManager may have been persisted at block N while a
+        // ChannelMonitor was persisted at block N-M; each listener gets
+        // exactly the blocks it is missing, so no on-chain HTLC claim or
+        // counterparty revocation in that window can be skipped.
+        let stale_monitors = std::mem::take(&mut *self.stale_monitors.lock().unwrap());
         let manager_best = channel_manager.current_best_block();
-        let chain_listeners: Vec<(chain::BlockLocator, &(dyn chain::Listen + Send + Sync))> = vec![
+        let mut chain_listeners: Vec<(chain::BlockLocator, &(dyn chain::Listen + Send + Sync))> = vec![
             (
                 manager_best.clone(),
                 &*channel_manager as &(dyn chain::Listen + Send + Sync),
             ),
+            // On restart the chain monitor holds no monitors yet (they are
+            // registered below, after they synced individually), so the
+            // manager's best block is a valid starting point for it.
             (
                 manager_best.clone(),
                 &*chain_monitor as &(dyn chain::Listen + Send + Sync),
             ),
         ];
+        for (locator, listener) in &stale_monitors {
+            log::info!(
+                target: "lampo-chain",
+                "Syncing channel monitor `{}` from height {} to current tip",
+                listener.0.channel_id(),
+                locator.height,
+            );
+            chain_listeners.push((
+                locator.clone(),
+                listener as &(dyn chain::Listen + Send + Sync),
+            ));
+        }
 
         log::info!(
             target: "lampo-chain",
@@ -343,13 +375,49 @@ impl Backend for LampoChainSync {
         );
 
         let (cache, synced_chain_tip) =
-            init::synchronize_listeners(self.as_ref(), self.config.network, chain_listeners)
+            init::synchronize_listeners(self, self.config.network, chain_listeners)
                 .await
                 .map_err(|e| error::anyhow!("Failed to synchronize chain listeners: {:?}", e))?;
 
         log::info!(target: "lampo-chain", "Chain listeners synced to current tip");
 
-        let chain_listener = (chain_monitor, channel_manager);
+        // Now that every monitor is at the chain tip, hand it to the chain
+        // monitor so it keeps watching the channel from here on. Failing to
+        // register a monitor means force-closes and HTLC claims for that
+        // channel would go undetected: abort startup instead.
+        for (_, (monitor, ..)) in stale_monitors {
+            let channel_id = monitor.channel_id();
+            match chain_monitor.watch_channel(channel_id, monitor) {
+                Ok(ChannelMonitorUpdateStatus::Completed)
+                | Ok(ChannelMonitorUpdateStatus::InProgress) => {
+                    log::info!(target: "lampo-chain", "Watching channel `{channel_id}`");
+                }
+                Ok(ChannelMonitorUpdateStatus::UnrecoverableError) | Err(()) => {
+                    error::bail!(
+                        "failed to register channel monitor `{channel_id}` with the chain monitor"
+                    );
+                }
+            }
+        }
+
+        *self.sync_state.lock().unwrap() = Some((cache, synced_chain_tip));
+        Ok(())
+    }
+
+    async fn listen(self: Arc<Self>) -> lampo_common::error::Result<()> {
+        // If the caller did not run `sync_chain` yet, do it now: the SPV
+        // client below must start from a synced tip.
+        if self.sync_state.lock().unwrap().is_none() {
+            self.sync_chain().await?;
+        }
+        let (cache, synced_chain_tip) = self
+            .sync_state
+            .lock()
+            .unwrap()
+            .take()
+            .expect("sync_chain populated the state above");
+
+        let chain_listener = (self.chain_monitor(), self.channel_manager());
         let chain_poller = poll::ChainPoller::new(self.as_ref(), self.config.network);
         let mut spv_client = SpvClient::new(synced_chain_tip, chain_poller, cache, &chain_listener);
         log::info!(target: "lampo-chain", "Start Backend ...");

--- a/lampo-common/src/backend.rs
+++ b/lampo-common/src/backend.rs
@@ -15,7 +15,9 @@ use serde::{Deserialize, Serialize};
 
 use crate::error;
 use crate::handler::Handler;
-use crate::types::{LampoChainMonitor, LampoChannel};
+use crate::types::{LampoChainMonitor, LampoChannel, LampoMonitorListener};
+
+pub use lightning::chain::BlockLocator;
 
 #[derive(Serialize, Deserialize, Debug)]
 pub enum TxResult {
@@ -86,6 +88,20 @@ pub trait Backend: Send + Sync {
     fn set_channel_manager(&self, _: Arc<LampoChannel>) {}
 
     fn set_chain_monitor(&self, _: Arc<LampoChainMonitor>) {}
+
+    /// Hand over the channel monitors read from disk on restart, each
+    /// paired with the best block it was persisted at. The backend must
+    /// sync every monitor up to the chain tip individually and register
+    /// it with the chain monitor before connecting new blocks.
+    fn set_stale_monitors(&self, _: Vec<(BlockLocator, LampoMonitorListener)>) {}
+
+    /// Perform the initial chain synchronization: bring the channel
+    /// manager, the chain monitor, and any stale channel monitors up to
+    /// the current chain tip. Must complete before the node starts
+    /// processing peers or events.
+    async fn sync_chain(&self) -> error::Result<()> {
+        Ok(())
+    }
 
     /// Get the information of a transaction inside the blockchain.
     async fn get_transaction(&self, txid: &Txid) -> error::Result<TxResult>;

--- a/lampo-common/src/backend.rs
+++ b/lampo-common/src/backend.rs
@@ -43,11 +43,14 @@ pub trait Backend: Send + Sync {
     /// concrete backends implement `BlockSource` separately for chain sync.
     async fn get_best_block(&self) -> BlockSourceResult<(BlockHash, Option<u32>)>;
 
-    /// Fetch feerate give a number of blocks
+    /// Estimate the feerate to confirm within the given number of blocks,
+    /// in sats per 1000 weight units (the unit LDK's `FeeEstimator` uses).
     ///
     /// FIXME: use `FeeRate` instead of `u32`
     async fn fee_rate_estimation(&self, blocks: u64) -> error::Result<u32>;
 
+    /// The minimum feerate accepted into the backend's mempool, in sats
+    /// per 1000 weight units.
     async fn minimum_mempool_fee(&self) -> error::Result<u32>;
 
     async fn brodcast_tx(&self, tx: &Transaction);

--- a/lampo-common/src/backend.rs
+++ b/lampo-common/src/backend.rs
@@ -15,7 +15,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::error;
 use crate::handler::Handler;
-use crate::types::{LampoChainMonitor, LampoChannel, LampoMonitorListener};
+use crate::types::{LampoChainMonitor, LampoChannel, LampoMonitorListener, LampoSweeper};
 
 pub use lightning::chain::BlockLocator;
 
@@ -94,6 +94,10 @@ pub trait Backend: Send + Sync {
     /// sync every monitor up to the chain tip individually and register
     /// it with the chain monitor before connecting new blocks.
     fn set_stale_monitors(&self, _: Vec<(BlockLocator, LampoMonitorListener)>) {}
+
+    /// Register the output sweeper as a chain listener, together with the
+    /// best block its persisted state was last synced to.
+    fn set_sweeper(&self, _: BlockLocator, _: Arc<LampoSweeper>) {}
 
     /// Perform the initial chain synchronization: bring the channel
     /// manager, the chain monitor, and any stale channel monitors up to

--- a/lampo-common/src/backend.rs
+++ b/lampo-common/src/backend.rs
@@ -53,7 +53,29 @@ pub trait Backend: Send + Sync {
     /// per 1000 weight units.
     async fn minimum_mempool_fee(&self) -> error::Result<u32>;
 
-    async fn brodcast_tx(&self, tx: &Transaction);
+    /// Broadcast the transaction to the network.
+    ///
+    /// Returns an error when the backend rejected or failed to relay the
+    /// transaction, so callers can retry or surface the failure. Silently
+    /// dropping a failed broadcast of a commitment or HTLC transaction can
+    /// cost funds.
+    async fn brodcast_tx(&self, tx: &Transaction) -> error::Result<()>;
+
+    /// Broadcast a set of transactions that form a single package (a
+    /// child paying for its parents), preserving order.
+    ///
+    /// LDK hands anchor CPFP transactions to the broadcaster together
+    /// with their low-feerate commitment parent: submitting them one by
+    /// one can leave the parent stuck below the mempool minimum feerate
+    /// and the child rejected for missing inputs. Backends should use a
+    /// package-aware RPC (`submitpackage`) when more than one transaction
+    /// is given.
+    async fn brodcast_txs(&self, txs: &[Transaction]) -> error::Result<()> {
+        for tx in txs {
+            self.brodcast_tx(tx).await?;
+        }
+        Ok(())
+    }
 
     async fn get_utxo(&self, block: &BlockHash, idx: u64) -> UtxoResult;
 

--- a/lampo-common/src/conf.rs
+++ b/lampo-common/src/conf.rs
@@ -6,6 +6,20 @@ use clightningrpc_conf::{CLNConf, SyncCLNConf};
 pub use bitcoin::Network;
 pub use lightning::util::config::UserConfig;
 
+/// The LDK configuration lampo runs with.
+///
+/// Anchor channels are negotiated on purpose: commitment transactions are
+/// built at a low feerate and bumped via CPFP when they need to confirm
+/// (`Event::BumpTransaction`), so a congested mempool cannot strand a
+/// force-close. This matches the LDK default, but is set explicitly here
+/// because lampo's fee-bumping wiring depends on it.
+fn default_ldk_conf() -> UserConfig {
+    let mut conf = UserConfig::default();
+    conf.channel_handshake_config
+        .negotiate_anchors_zero_fee_htlc_tx = true;
+    conf
+}
+
 #[derive(Clone, Debug)]
 pub struct LampoConf {
     pub inner: Option<CLNConf>,
@@ -46,7 +60,7 @@ impl Default for LampoConf {
             inner: None,
             // default network is testnet
             network: Network::Testnet,
-            ldk_conf: UserConfig::default(),
+            ldk_conf: default_ldk_conf(),
             // default port is 19735 for testnet
             port: 19735,
             root_path: lampo_home,
@@ -267,7 +281,7 @@ impl TryFrom<String> for LampoConf {
             inner: Some(conf),
             root_path,
             network,
-            ldk_conf: UserConfig::default(),
+            ldk_conf: default_ldk_conf(),
             port: u64::from_str(&port)?,
             node,
             core_url,

--- a/lampo-common/src/conf.rs
+++ b/lampo-common/src/conf.rs
@@ -28,6 +28,10 @@ pub struct LampoConf {
     pub api_port: u64,
     pub reindex: Option<Height>,
     pub dev_sync: Option<bool>,
+    /// Whether inbound channel requests are accepted (`accept-inbound-channels`,
+    /// default `true`). Operators that do not want arbitrary peers opening
+    /// channels to them can turn this off.
+    pub accept_inbound_channels: bool,
 }
 
 impl Default for LampoConf {
@@ -60,6 +64,7 @@ impl Default for LampoConf {
             api_port: 7878,
             reindex: None,
             dev_sync: None,
+            accept_inbound_channels: true,
         }
     }
 }
@@ -249,6 +254,15 @@ impl TryFrom<String> for LampoConf {
             .get_conf("dev-sync")
             .unwrap_or(None)
             .map(|s| s.to_lowercase() == "true" || s == "1");
+
+        let accept_inbound_channels = conf
+            .get_conf("accept-inbound-channels")
+            .unwrap_or(None)
+            .map(|s| {
+                let s = s.to_trimmed().to_lowercase();
+                s == "true" || s == "1"
+            })
+            .unwrap_or(true);
         Ok(Self {
             inner: Some(conf),
             root_path,
@@ -269,6 +283,7 @@ impl TryFrom<String> for LampoConf {
             api_port,
             reindex,
             dev_sync,
+            accept_inbound_channels,
         })
     }
 }

--- a/lampo-common/src/event/onchain.rs
+++ b/lampo-common/src/event/onchain.rs
@@ -11,6 +11,8 @@ pub enum OnChainEvent {
     NewBestBlock((Header, Height)),
     FeeEstimation(u32),
     SendRawTransaction(Transaction),
+    /// The backend definitively failed to broadcast the transaction.
+    BroadcastFailed(Txid),
     ConfirmedTransaction((Transaction, u32, Header, Height)),
     DiscardedTransaction(Txid),
     UnconfirmedTransaction(Txid),
@@ -30,6 +32,7 @@ impl Debug for OnChainEvent {
             }
             Self::NewBlock(block) => write!(f, "NewBlock({})", block.block_hash()),
             Self::SendRawTransaction(tx) => write!(f, "SendRawTransaction({})", tx.txid()),
+            Self::BroadcastFailed(txid) => write!(f, "BroadcastFailed({txid})"),
             Self::UnconfirmedTransaction(tx) => write!(f, "UnconfirmedTransaction({})", tx),
             _ => write!(f, "Debug fmt not unsupported"),
         }

--- a/lampo-common/src/types.rs
+++ b/lampo-common/src/types.rs
@@ -6,6 +6,7 @@ use lightning::onion_message::messenger::DefaultMessageRouter;
 
 use crate::bitcoin::secp256k1::PublicKey;
 use crate::ldk::chain::chainmonitor::ChainMonitor;
+use crate::ldk::chain::channelmonitor::ChannelMonitor;
 use crate::ldk::chain::Filter;
 use crate::ldk::ln::channelmanager::ChannelManager;
 use crate::ldk::persister::fs_store::v1::FilesystemStore;
@@ -43,6 +44,20 @@ pub type LampoArcChannelManager<M, L> = ChannelManager<
 >;
 
 pub type LampoChannel = LampoArcChannelManager<LampoChainMonitor, LampoLogger>;
+
+/// A [`ChannelMonitor`] read from disk on restart, paired with the chain
+/// context it needs to replay blocks on its own (LDK implements
+/// [`chain::Listen`] for this tuple). Each monitor must be synced from its
+/// own best block up to the chain tip and then registered with the
+/// [`LampoChainMonitor`] via `watch_channel` before the node goes live.
+///
+/// [`chain::Listen`]: crate::ldk::chain::Listen
+pub type LampoMonitorListener = (
+    ChannelMonitor<InMemorySigner>,
+    Arc<dyn BroadcasterInterface + Send + Sync>,
+    Arc<dyn FeeEstimator + Send + Sync>,
+    Arc<LampoLogger>,
+);
 
 pub type LampoGraph = NetworkGraph<Arc<LampoLogger>>;
 pub type LampoScorer = ProbabilisticScorer<Arc<LampoGraph>, Arc<LampoLogger>>;

--- a/lampo-common/src/types.rs
+++ b/lampo-common/src/types.rs
@@ -14,9 +14,11 @@ use crate::ldk::routing::gossip::NetworkGraph;
 use crate::ldk::routing::router::DefaultRouter;
 use crate::ldk::routing::scoring::{ProbabilisticScorer, ProbabilisticScoringFeeParameters};
 use crate::ldk::sign::InMemorySigner;
+use crate::ldk::util::sweep::OutputSweeper;
 
 use crate::keys::LampoKeysManager;
 use crate::utils::logger::LampoLogger;
+use crate::wallet::LampoChangeDestination;
 
 pub type NodeId = PublicKey;
 pub type ChannelId = crate::ldk::ln::types::ChannelId;
@@ -44,6 +46,19 @@ pub type LampoArcChannelManager<M, L> = ChannelManager<
 >;
 
 pub type LampoChannel = LampoArcChannelManager<LampoChainMonitor, LampoLogger>;
+
+/// Tracks and sweeps spendable outputs of closed channels back into the
+/// on-chain wallet. Fed by `Event::SpendableOutputs`, driven by the
+/// background processor, and notified of blocks by the chain backend.
+pub type LampoSweeper = OutputSweeper<
+    Arc<dyn BroadcasterInterface + Send + Sync>,
+    Arc<LampoChangeDestination>,
+    Arc<dyn FeeEstimator + Send + Sync>,
+    Arc<dyn Filter + Send + Sync>,
+    Arc<FilesystemStore>,
+    Arc<LampoLogger>,
+    Arc<LampoKeysManager>,
+>;
 
 /// A [`ChannelMonitor`] read from disk on restart, paired with the chain
 /// context it needs to replay blocks on its own (LDK implements

--- a/lampo-common/src/wallet.rs
+++ b/lampo-common/src/wallet.rs
@@ -1,13 +1,15 @@
+use std::str::FromStr;
 use std::sync::Arc;
 
 use async_trait::async_trait;
 
 use crate::bitcoin::absolute::Height;
+use crate::bitcoin::{Address, Network, ScriptBuf, Transaction};
 use crate::bitcoin::{Amount, FeeRate};
-use crate::bitcoin::{ScriptBuf, Transaction};
 use crate::conf::LampoConf;
 use crate::error;
 use crate::keys::LampoKeys;
+use crate::ldk::sign::ChangeDestinationSource;
 use crate::model::response::{NewAddress, Utxo};
 
 /// Wallet manager trait that define a generic interface
@@ -56,4 +58,36 @@ pub trait WalletManager: Send + Sync {
     /// Run a task for wallet sync operation, this usually need to
     /// be run in a `tokio::spawn(wallet.listen())`.
     async fn listen(self: Arc<Self>) -> error::Result<()>;
+}
+
+/// [`ChangeDestinationSource`] backed by the node's on-chain wallet: swept
+/// channel outputs land on a fresh wallet address.
+pub struct LampoChangeDestination {
+    wallet: Arc<dyn WalletManager>,
+    network: Network,
+}
+
+impl LampoChangeDestination {
+    pub fn new(wallet: Arc<dyn WalletManager>, network: Network) -> Self {
+        Self { wallet, network }
+    }
+}
+
+impl ChangeDestinationSource for LampoChangeDestination {
+    fn get_change_destination_script<'a>(
+        &'a self,
+    ) -> impl std::future::Future<Output = Result<ScriptBuf, ()>> + Send + 'a {
+        async move {
+            let address = self.wallet.get_onchain_address().await.map_err(|err| {
+                log::error!(target: "lampo-wallet", "failed to derive a sweep destination address: {err}");
+            })?;
+            let address = Address::from_str(&address.address).map_err(|err| {
+                log::error!(target: "lampo-wallet", "invalid sweep destination address: {err}");
+            })?;
+            let address = address.require_network(self.network).map_err(|err| {
+                log::error!(target: "lampo-wallet", "sweep destination address on wrong network: {err}");
+            })?;
+            Ok(address.script_pubkey())
+        }
+    }
 }

--- a/lampo-common/src/wallet.rs
+++ b/lampo-common/src/wallet.rs
@@ -4,12 +4,13 @@ use std::sync::Arc;
 use async_trait::async_trait;
 
 use crate::bitcoin::absolute::Height;
-use crate::bitcoin::{Address, Network, ScriptBuf, Transaction};
+use crate::bitcoin::{Address, Network, OutPoint, Psbt, ScriptBuf, Transaction, TxOut, Txid};
 use crate::bitcoin::{Amount, FeeRate};
 use crate::conf::LampoConf;
 use crate::error;
 use crate::keys::LampoKeys;
 use crate::ldk::sign::ChangeDestinationSource;
+use crate::ldk::util::wallet_utils::{Utxo as LdkUtxo, WalletSource};
 use crate::model::response::{NewAddress, Utxo};
 
 /// Wallet manager trait that define a generic interface
@@ -58,6 +59,20 @@ pub trait WalletManager: Send + Sync {
     /// Run a task for wallet sync operation, this usually need to
     /// be run in a `tokio::spawn(wallet.listen())`.
     async fn listen(self: Arc<Self>) -> error::Result<()>;
+
+    /// Return all wallet UTXOs with at least one confirmation, available
+    /// to fund fee bumps (anchor CPFP, HTLC transactions).
+    async fn list_confirmed_utxos(&self) -> error::Result<Vec<(OutPoint, TxOut)>>;
+
+    /// Return the full wallet transaction with the given txid, if known.
+    async fn get_wallet_transaction(&self, txid: Txid) -> error::Result<Option<Transaction>>;
+
+    /// Return a fresh change script from the wallet.
+    async fn get_change_script(&self) -> error::Result<ScriptBuf>;
+
+    /// Sign every wallet-owned input of the PSBT and return the resulting
+    /// transaction. Inputs the wallet does not own are left untouched.
+    async fn sign_psbt(&self, psbt: Psbt) -> error::Result<Transaction>;
 }
 
 /// [`ChangeDestinationSource`] backed by the node's on-chain wallet: swept
@@ -70,6 +85,88 @@ pub struct LampoChangeDestination {
 impl LampoChangeDestination {
     pub fn new(wallet: Arc<dyn WalletManager>, network: Network) -> Self {
         Self { wallet, network }
+    }
+}
+
+/// [`WalletSource`] backed by the node's on-chain wallet, used by LDK's
+/// coin selection when funding anchor CPFP and HTLC fee bumps.
+pub struct LampoWalletSource {
+    wallet: Arc<dyn WalletManager>,
+}
+
+impl LampoWalletSource {
+    pub fn new(wallet: Arc<dyn WalletManager>) -> Self {
+        Self { wallet }
+    }
+}
+
+impl WalletSource for LampoWalletSource {
+    fn list_confirmed_utxos<'a>(
+        &'a self,
+    ) -> impl std::future::Future<Output = Result<Vec<LdkUtxo>, ()>> + Send + 'a {
+        async move {
+            let utxos = self.wallet.list_confirmed_utxos().await.map_err(|err| {
+                log::error!(target: "lampo-wallet", "failed to list confirmed utxos: {err}");
+            })?;
+            // The wallet is BIP84, so every spendable output is P2WPKH;
+            // skip anything else instead of misreporting its weight.
+            let utxos = utxos
+                .into_iter()
+                .filter_map(|(outpoint, output)| {
+                    if output.script_pubkey.is_p2wpkh() {
+                        use crate::bitcoin::hashes::Hash;
+                        let pubkey_hash = crate::bitcoin::WPubkeyHash::from_slice(
+                            &output.script_pubkey.as_bytes()[2..22],
+                        )
+                        .ok()?;
+                        Some(LdkUtxo::new_v0_p2wpkh(outpoint, output.value, &pubkey_hash))
+                    } else {
+                        log::warn!(
+                            target: "lampo-wallet",
+                            "skipping non-p2wpkh utxo `{outpoint}` for fee bumping"
+                        );
+                        None
+                    }
+                })
+                .collect();
+            Ok(utxos)
+        }
+    }
+
+    fn get_prevtx<'a>(
+        &'a self,
+        outpoint: OutPoint,
+    ) -> impl std::future::Future<Output = Result<Transaction, ()>> + Send + 'a {
+        async move {
+            self.wallet
+                .get_wallet_transaction(outpoint.txid)
+                .await
+                .map_err(|err| {
+                    log::error!(target: "lampo-wallet", "failed to load prev tx `{}`: {err}", outpoint.txid);
+                })?
+                .ok_or(())
+        }
+    }
+
+    fn get_change_script<'a>(
+        &'a self,
+    ) -> impl std::future::Future<Output = Result<ScriptBuf, ()>> + Send + 'a {
+        async move {
+            self.wallet.get_change_script().await.map_err(|err| {
+                log::error!(target: "lampo-wallet", "failed to derive a change script: {err}");
+            })
+        }
+    }
+
+    fn sign_psbt<'a>(
+        &'a self,
+        psbt: Psbt,
+    ) -> impl std::future::Future<Output = Result<Transaction, ()>> + Send + 'a {
+        async move {
+            self.wallet.sign_psbt(psbt).await.map_err(|err| {
+                log::error!(target: "lampo-wallet", "failed to sign fee-bump psbt: {err}");
+            })
+        }
     }
 }
 

--- a/lampo-httpd/src/commands/peer.rs
+++ b/lampo-httpd/src/commands/peer.rs
@@ -12,6 +12,6 @@ use lampod::jsonrpc::peer_control::*;
 use crate::{post, AppState, ResultJson};
 
 post!(connect, request: request::Connect, response: request::Connect);
-post!(close, response: response::CloseChannel);
+post!(close, request: request::CloseChannel, response: response::CloseChannel);
 post!(channels, request: json::Value, response: json::Value);
 post!(fundchannel, request: request::OpenChannel, response: json::Value);

--- a/lampod-cli/src/main.rs
+++ b/lampod-cli/src/main.rs
@@ -116,6 +116,16 @@ async fn run(args: LampoCliArgs) -> error::Result<()> {
 
     let lampo_conf = Arc::new(lampo_conf);
 
+    // Take the instance lock before touching any state on disk: two
+    // concurrent lampod instances loading the same channel monitors is a
+    // direct path to broadcasting a revoked state.
+    log::debug!(target: "lampod-cli", "Lampo directory `{}`", lampo_conf.path());
+    let mut _pid = filelock_rs::pid::Pid::new(lampo_conf.path(), "lampod".to_owned())
+        .map_err(|err| {
+            log::error!("{err}");
+            error::anyhow!("impossible take a lock on the `lampod.pid` file, maybe there is another instance running?")
+        })?;
+
     // Prepare the backend
     let client = lampo_conf.node.clone();
     log::debug!(target: "lampod-cli", "lampo running with `{client}` backend");
@@ -182,22 +192,7 @@ async fn run(args: LampoCliArgs) -> error::Result<()> {
     // Init the lampod
     lampod.init(client).await?;
 
-    log::debug!(target: "lampod-cli", "Lampo directory `{}`", lampo_conf.path());
-    let mut _pid = filelock_rs::pid::Pid::new(lampo_conf.path(), "lampod".to_owned())
-        .map_err(|err| {
-            log::error!("{err}");
-            error::anyhow!("impossible take a lock on the `lampod.pid` file, maybe there is another instance running?")
-        })?;
-
     let lampod = Arc::new(lampod);
-
-    run_httpd(lampod.clone()).await?;
-
-    let handler = Arc::new(HttpdHandler::new(format!(
-        "{}:{}",
-        lampo_conf.api_host, lampo_conf.api_port
-    ))?);
-    lampod.add_external_handler(handler).await?;
 
     // Signal the daemon to shut down gracefully on Ctrl+C.
     // This causes the LDK event processor to persist all state
@@ -209,7 +204,30 @@ async fn run(args: LampoCliArgs) -> error::Result<()> {
     })?;
 
     log::info!(target: "lampod-cli", "------------ Starting Server ------------");
-    lampod.listen().await??;
+    let mut daemon = lampod.clone().listen();
+
+    // Expose the RPC surface only once the initial chain sync completed
+    // and every channel monitor is registered: a close command issued
+    // before that point would produce monitor updates the chain monitor
+    // silently drops.
+    tokio::select! {
+        _ = lampod.wait_ready() => {}
+        result = &mut daemon => {
+            result??;
+            log::info!(target: "lampod-cli", "Shutdown complete.");
+            return Ok(());
+        }
+    }
+
+    run_httpd(lampod.clone()).await?;
+
+    let handler = Arc::new(HttpdHandler::new(format!(
+        "{}:{}",
+        lampo_conf.api_host, lampo_conf.api_port
+    ))?);
+    lampod.add_external_handler(handler).await?;
+
+    daemon.await??;
     log::info!(target: "lampod-cli", "Shutdown complete.");
     Ok(())
 }

--- a/lampod/src/actions/handler.rs
+++ b/lampod/src/actions/handler.rs
@@ -383,6 +383,30 @@ impl Handler for LampoHandler {
                 // FIXME: make peristent these information
                 Ok(())
             }
+            ldk::events::Event::SpendableOutputs {
+                outputs,
+                channel_id,
+                counterparty_node_id,
+            } => {
+                log::info!(
+                    target: "lampod",
+                    "tracking {} spendable output(s) from channel `{:?}` for sweeping",
+                    outputs.len(),
+                    channel_id,
+                );
+                // `exclude_static_outputs` must stay `false`: static outputs
+                // pay to scripts derived from the LDK keys manager, which the
+                // BDK on-chain wallet does not track. Only the sweeper can
+                // claim them.
+                self.channel_manager
+                    .sweeper()
+                    .track_spendable_outputs(outputs, channel_id, counterparty_node_id, false, None)
+                    .await
+                    .map_err(|_| {
+                        error::anyhow!("failed to persist spendable outputs in the sweeper")
+                    })?;
+                Ok(())
+            }
             ldk::events::Event::PaymentSent {
                 payment_id,
                 payment_preimage,

--- a/lampod/src/actions/handler.rs
+++ b/lampod/src/actions/handler.rs
@@ -16,19 +16,39 @@ use lampo_common::handler::ExternalHandler;
 use lampo_common::handler::Handler as EventHandler;
 use lampo_common::json;
 use lampo_common::jsonrpc::Request;
+use lampo_common::keys::LampoKeysManager;
 use lampo_common::ldk;
+use lampo_common::ldk::chain::chaininterface::BroadcasterInterface;
+use lampo_common::ldk::events::bump_transaction::BumpTransactionEventHandler;
 use lampo_common::ldk::sign::NodeSigner;
+use lampo_common::ldk::util::wallet_utils::Wallet as LdkWallet;
 use lampo_common::model::response::PaymentHop;
 use lampo_common::model::response::PaymentState;
+use lampo_common::wallet::LampoWalletSource;
 
 use crate::chain::{LampoChainManager, WalletManager};
 use crate::command::Command;
 use crate::ln::payer_proof::{self, PayerProofRecord};
 use crate::ln::{LampoChannelManager, LampoInventoryManager, LampoPeerManager};
 use crate::persistence::LampoPersistence;
+use crate::utils::logger::LampoLogger;
 use crate::LampoDaemon;
 
 use super::Handler;
+
+/// Minimum confirmed on-chain balance required to accept an inbound anchor
+/// channel: the reserve that would fund a CPFP of its commitment on
+/// force-close. Matches ldk-node's per-channel anchor reserve default.
+const ANCHOR_RESERVE_SAT: u64 = 25_000;
+
+/// Handles `Event::BumpTransaction`: builds and broadcasts anchor CPFP and
+/// HTLC fee-bump transactions, funding them from the on-chain wallet.
+type LampoBumpEventHandler = BumpTransactionEventHandler<
+    Arc<dyn BroadcasterInterface + Send + Sync>,
+    Arc<LdkWallet<Arc<LampoWalletSource>, Arc<LampoLogger>>>,
+    Arc<LampoKeysManager>,
+    Arc<LampoLogger>,
+>;
 
 pub struct LampoHandler {
     channel_manager: Arc<LampoChannelManager>,
@@ -38,6 +58,7 @@ pub struct LampoHandler {
     chain_manager: Arc<LampoChainManager>,
     persister: Arc<LampoPersistence>,
     external_handlers: RwLock<Vec<Arc<dyn ExternalHandler>>>,
+    bump_event_handler: LampoBumpEventHandler,
     #[allow(dead_code)]
     emitter: Emitter<Event>,
     subscriber: Subscriber<Event>,
@@ -47,6 +68,14 @@ impl LampoHandler {
     pub(crate) fn new(lampod: &LampoDaemon) -> Self {
         let emitter = Emitter::default();
         let subscriber = emitter.subscriber();
+        let logger = lampod.logger();
+        let wallet_source = Arc::new(LampoWalletSource::new(lampod.wallet_manager()));
+        let bump_event_handler = BumpTransactionEventHandler::new(
+            lampod.onchain_manager() as Arc<dyn BroadcasterInterface + Send + Sync>,
+            Arc::new(LdkWallet::new(wallet_source, logger.clone())),
+            lampod.wallet_manager().ldk_keys().keys_manager.clone(),
+            logger,
+        );
         Self {
             channel_manager: lampod.channel_manager(),
             peer_manager: lampod.peer_manager(),
@@ -55,6 +84,7 @@ impl LampoHandler {
             chain_manager: lampod.onchain_manager(),
             persister: lampod.persister(),
             external_handlers: RwLock::new(Vec::new()),
+            bump_event_handler,
             emitter,
             subscriber,
         }
@@ -124,16 +154,35 @@ impl Handler for LampoHandler {
             ldk::events::Event::OpenChannelRequest {
                 temporary_channel_id,
                 counterparty_node_id,
+                channel_type,
                 ..
             } => {
                 // LDK 0.3 removed `manually_accept_inbound_channels`; inbound
                 // channels are now always surfaced here and must be accepted
                 // explicitly.
-                if !self.channel_manager.conf.accept_inbound_channels {
+                let reject_reason = if !self.channel_manager.conf.accept_inbound_channels {
+                    Some("inbound channels are disabled on this node".to_owned())
+                } else if channel_type.supports_anchors_zero_fee_htlc_tx() {
+                    // An anchor channel needs confirmed on-chain funds to
+                    // CPFP its commitment on force-close; accepting one
+                    // with an empty wallet means a stuck commitment and
+                    // lost HTLCs when the counterparty goes silent.
+                    let balance = self.wallet_manager.get_onchain_balance().await.unwrap_or(0);
+                    if balance < ANCHOR_RESERVE_SAT {
+                        Some(format!(
+                            "insufficient on-chain reserve for an anchor channel \
+                             ({balance} sat confirmed, {ANCHOR_RESERVE_SAT} sat required)"
+                        ))
+                    } else {
+                        None
+                    }
+                } else {
+                    None
+                };
+                if let Some(reason) = reject_reason {
                     log::warn!(
                         target: "lampod",
-                        "rejecting inbound channel request from `{counterparty_node_id}`: \
-                         `accept-inbound-channels` is disabled"
+                        "rejecting inbound channel request from `{counterparty_node_id}`: {reason}"
                     );
                     if let Err(err) = self
                         .channel_manager
@@ -141,7 +190,7 @@ impl Handler for LampoHandler {
                         .force_close_broadcasting_latest_txn(
                             &temporary_channel_id,
                             &counterparty_node_id,
-                            "inbound channels are disabled on this node".to_owned(),
+                            reason,
                         )
                     {
                         log::error!(target: "lampod", "failed to reject inbound channel: {err:?}");
@@ -413,6 +462,11 @@ impl Handler for LampoHandler {
                 };
                 log::warn!("please note the payments are not make persistent for the moment");
                 // FIXME: make peristent these information
+                Ok(())
+            }
+            ldk::events::Event::BumpTransaction(bump_event) => {
+                log::info!(target: "lampod", "bump transaction event: {:?}", bump_event);
+                self.bump_event_handler.handle_event(&bump_event).await;
                 Ok(())
             }
             ldk::events::Event::SpendableOutputs {

--- a/lampod/src/actions/handler.rs
+++ b/lampod/src/actions/handler.rs
@@ -128,7 +128,26 @@ impl Handler for LampoHandler {
             } => {
                 // LDK 0.3 removed `manually_accept_inbound_channels`; inbound
                 // channels are now always surfaced here and must be accepted
-                // explicitly. Auto-accept to preserve the previous behaviour.
+                // explicitly.
+                if !self.channel_manager.conf.accept_inbound_channels {
+                    log::warn!(
+                        target: "lampod",
+                        "rejecting inbound channel request from `{counterparty_node_id}`: \
+                         `accept-inbound-channels` is disabled"
+                    );
+                    if let Err(err) = self
+                        .channel_manager
+                        .manager()
+                        .force_close_broadcasting_latest_txn(
+                            &temporary_channel_id,
+                            &counterparty_node_id,
+                            "inbound channels are disabled on this node".to_owned(),
+                        )
+                    {
+                        log::error!(target: "lampod", "failed to reject inbound channel: {err:?}");
+                    }
+                    return Ok(());
+                }
                 log::info!(
                     target: "lampod",
                     "accepting inbound channel request from `{counterparty_node_id}`"
@@ -347,9 +366,22 @@ impl Handler for LampoHandler {
                     } => payment_preimage,
                     ldk::events::PaymentPurpose::SpontaneousPayment(preimage) => Some(preimage),
                 };
-                self.channel_manager
-                    .manager()
-                    .claim_funds(preimage.unwrap());
+                // LDK hands out `None` when the preimage is not known to the
+                // node (e.g. externally generated invoices). Lampo cannot
+                // claim such HTLCs: fail them backwards instead of panicking
+                // the event processor and leaving the HTLC hanging until its
+                // timeout forces the channel on-chain.
+                let Some(preimage) = preimage else {
+                    log::error!(
+                        target: "lampod",
+                        "payment `{payment_hash}` claimable but no preimage is known, failing it backwards"
+                    );
+                    self.channel_manager
+                        .manager()
+                        .fail_htlc_backwards(&payment_hash);
+                    return Ok(());
+                };
+                self.channel_manager.manager().claim_funds(preimage);
                 Ok(())
             }
             ldk::events::Event::PaymentClaimed {

--- a/lampod/src/actions/handler.rs
+++ b/lampod/src/actions/handler.rs
@@ -258,7 +258,7 @@ impl Handler for LampoHandler {
                 }));
 
                 log::info!("propagate funding transaction for open a channel with `{counterparty_node_id}`");
-                // FIXME: estimate the fee rate with a callback
+                // The backend returns sats per 1000 weight units.
                 let fee = self
                     .chain_manager
                     .backend
@@ -272,7 +272,7 @@ impl Handler for LampoHandler {
                         }));
                         err
                     })?;
-                log::info!("fee estimated {:?} sats", fee);
+                log::info!("fee estimated `{fee}` sat/kwu");
 
                 let best_block = self.channel_manager.manager().current_best_block().height;
                 let transaction = self
@@ -280,7 +280,7 @@ impl Handler for LampoHandler {
                     .create_transaction(
                         output_script,
                         Amount::from_sat(channel_value_satoshis),
-                        FeeRate::from_sat_per_vb_unchecked(fee as u64),
+                        FeeRate::from_sat_per_kwu(fee as u64),
                         // FIXME: remove unwrap
                         Height::from_consensus(best_block).unwrap(),
                     )

--- a/lampod/src/chain/blockchain.rs
+++ b/lampod/src/chain/blockchain.rs
@@ -174,20 +174,51 @@ impl FeeEstimator for LampoChainManager {
     }
 }
 
+/// How many times a failed broadcast is retried before giving up. LDK
+/// re-broadcasts pending claims on its own timer, so this only needs to
+/// cover transient backend failures (e.g. a bitcoind restart).
+const BROADCAST_ATTEMPTS: u32 = 3;
+const BROADCAST_RETRY_DELAY_SECS: u64 = 5;
+
 /// Brodcaster Interface implementation for Lampo.
 impl BroadcasterInterface for LampoChainManager {
     fn broadcast_transactions(&self, txs: &[(&Transaction, TransactionType)]) {
-        // FIXME: support brodcast_txs for multiple tx
-        // FIXME: we are missing any error in the brodcast_tx, we should
-        // fix that
-        for (tx, _) in txs.to_vec() {
-            let tx = tx.clone();
-            let backend = self.backend.clone();
-            tokio::spawn(async move {
-                let tx = tx.clone();
-                backend.brodcast_tx(&tx).await;
-            });
-        }
+        // When LDK hands over more than one transaction they form a
+        // package (a child paying for its parents, e.g. an anchor CPFP
+        // and its commitment) and must be relayed together, in order.
+        let txs: Vec<Transaction> = txs.iter().map(|(tx, _)| (*tx).clone()).collect();
+        let backend = self.backend.clone();
+        tokio::spawn(async move {
+            let txids = txs
+                .iter()
+                .map(|tx| tx.compute_txid().to_string())
+                .collect::<Vec<_>>()
+                .join(", ");
+            for attempt in 1..=BROADCAST_ATTEMPTS {
+                match backend.brodcast_txs(&txs).await {
+                    Ok(()) => return,
+                    Err(err) if attempt < BROADCAST_ATTEMPTS => {
+                        log::warn!(
+                            target: "lampo-chain",
+                            "broadcast of `{txids}` failed (attempt {attempt}/{BROADCAST_ATTEMPTS}): {err}"
+                        );
+                        tokio::time::sleep(std::time::Duration::from_secs(
+                            BROADCAST_RETRY_DELAY_SECS,
+                        ))
+                        .await;
+                    }
+                    Err(err) => {
+                        // This can be a commitment or HTLC transaction:
+                        // scream, do not whisper. LDK will retry pending
+                        // claims on its own rebroadcast timer.
+                        log::error!(
+                            target: "lampo-chain",
+                            "broadcast of `{txids}` failed after {BROADCAST_ATTEMPTS} attempts: {err}"
+                        );
+                    }
+                }
+            }
+        });
     }
 }
 
@@ -204,8 +235,12 @@ impl UtxoLookup for LampoChainManager {
 
 #[async_trait]
 impl Backend for LampoChainManager {
-    async fn brodcast_tx(&self, tx: &Transaction) {
-        self.backend.brodcast_tx(tx).await;
+    async fn brodcast_tx(&self, tx: &Transaction) -> lampo_common::error::Result<()> {
+        self.backend.brodcast_tx(tx).await
+    }
+
+    async fn brodcast_txs(&self, txs: &[Transaction]) -> lampo_common::error::Result<()> {
+        self.backend.brodcast_txs(txs).await
     }
 
     async fn fee_rate_estimation(&self, blocks: u64) -> lampo_common::error::Result<u32> {

--- a/lampod/src/chain/blockchain.rs
+++ b/lampod/src/chain/blockchain.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::sync::atomic::{AtomicU32, Ordering};
 use std::sync::Arc;
 
 use lampo_common::async_trait;
@@ -9,15 +10,46 @@ use lampo_common::bitcoin::Transaction;
 use lampo_common::error;
 use lampo_common::ldk::chain::chaininterface::{
     BroadcasterInterface, ConfirmationTarget, FeeEstimator, TransactionType,
+    FEERATE_FLOOR_SATS_PER_KW,
 };
 use lampo_common::ldk::routing::utxo::UtxoLookup;
 use lampo_common::ldk::util::wakers::Notifier;
 use lampo_common::wallet::WalletManager;
 
+/// How often the fee cache is refreshed from the backend.
+const FEE_REFRESH_INTERVAL_SECS: u64 = 60;
+
+/// Conservative defaults, in sats per 1000 weight units, used until the
+/// first successful refresh from the backend.
+const DEFAULT_URGENT_SAT_PER_KW: u32 = 5_000;
+const DEFAULT_NORMAL_SAT_PER_KW: u32 = 3_000;
+const DEFAULT_BACKGROUND_SAT_PER_KW: u32 = 1_000;
+
+/// Fee rates cached from the backend, in sats per 1000 weight units.
+///
+/// A value of `0` means "not fetched yet" and falls back to a conservative
+/// per-target default: [`FeeEstimator::get_est_sat_per_1000_weight`] is a
+/// synchronous callback invoked by LDK from commitment/HTLC signing paths,
+/// so it must never block on the backend.
+#[derive(Default)]
+struct FeeCache {
+    /// Confirmation within ~3 blocks, used for urgent on-chain sweeps.
+    urgent: AtomicU32,
+    /// Confirmation within ~6 blocks, used for commitment transactions.
+    normal: AtomicU32,
+    /// Confirmation within ~144 blocks, used where confirmation can wait
+    /// (channel close minimum, anchor commitments bumped via CPFP).
+    background: AtomicU32,
+    /// The backend's minimum mempool fee, used as the lower bound we
+    /// require from the counterparty's feerate.
+    mempool_min: AtomicU32,
+}
+
 #[derive(Clone)]
 pub struct LampoChainManager {
     pub backend: Arc<dyn Backend>,
     pub wallet_manager: Arc<dyn WalletManager>,
+    fees: Arc<FeeCache>,
 }
 
 /// Personal Lampo implementation
@@ -28,6 +60,34 @@ impl LampoChainManager {
         LampoChainManager {
             backend: client,
             wallet_manager,
+            fees: Arc::new(FeeCache::default()),
+        }
+    }
+
+    /// Refresh the fee cache from the backend. Each bucket is refreshed
+    /// independently so a single failing estimate does not blank the others.
+    async fn refresh_fee_cache(&self) {
+        let buckets = [
+            (&self.fees.urgent, 3u64, "urgent"),
+            (&self.fees.normal, 6u64, "normal"),
+            (&self.fees.background, 144u64, "background"),
+        ];
+        for (cell, blocks, label) in buckets {
+            match self.backend.fee_rate_estimation(blocks).await {
+                Ok(fee) => cell.store(fee.max(FEERATE_FLOOR_SATS_PER_KW), Ordering::Release),
+                Err(err) => {
+                    log::warn!(target: "lampo-chain", "fee estimation for `{label}` ({blocks} blocks) failed: {err}")
+                }
+            }
+        }
+        match self.backend.minimum_mempool_fee().await {
+            Ok(fee) => self
+                .fees
+                .mempool_min
+                .store(fee.max(FEERATE_FLOOR_SATS_PER_KW), Ordering::Release),
+            Err(err) => {
+                log::warn!(target: "lampo-chain", "minimum mempool fee estimation failed: {err}")
+            }
         }
     }
 
@@ -68,6 +128,13 @@ impl LampoChainManager {
     }
 
     pub fn listen(self: Arc<Self>) -> error::Result<()> {
+        let fee_refresher = self.clone();
+        tokio::spawn(async move {
+            loop {
+                fee_refresher.refresh_fee_cache().await;
+                tokio::time::sleep(std::time::Duration::from_secs(FEE_REFRESH_INTERVAL_SECS)).await;
+            }
+        });
         tokio::spawn(async move { self.backend.clone().listen().await });
         Ok(())
     }
@@ -77,9 +144,33 @@ impl LampoChainManager {
 #[async_trait]
 impl FeeEstimator for LampoChainManager {
     fn get_est_sat_per_1000_weight(&self, confirmation_target: ConfirmationTarget) -> u32 {
-        // FIXME: have the result in the cache to make easy the query of it.
-        // TODO: fix this
-        256
+        use ConfirmationTarget::*;
+
+        let (cell, default) = match confirmation_target {
+            MaximumFeeEstimate | UrgentOnChainSweep => {
+                (&self.fees.urgent, DEFAULT_URGENT_SAT_PER_KW)
+            }
+            OutputSpendingFee | NonAnchorChannelFee => {
+                (&self.fees.normal, DEFAULT_NORMAL_SAT_PER_KW)
+            }
+            AnchorChannelFee | ChannelCloseMinimum => {
+                (&self.fees.background, DEFAULT_BACKGROUND_SAT_PER_KW)
+            }
+            MinAllowedAnchorChannelRemoteFee | MinAllowedNonAnchorChannelRemoteFee => {
+                (&self.fees.mempool_min, FEERATE_FLOOR_SATS_PER_KW)
+            }
+        };
+        let value = cell.load(Ordering::Acquire);
+        let value = if value == 0 { default } else { value };
+        // `MaximumFeeEstimate` bounds the feerate we tolerate from the
+        // counterparty; LDK recommends adding headroom over the raw
+        // estimate so honest peers are not force-closed during fee spikes.
+        let value = if matches!(confirmation_target, MaximumFeeEstimate) {
+            value.saturating_mul(2)
+        } else {
+            value
+        };
+        value.max(FEERATE_FLOOR_SATS_PER_KW)
     }
 }
 

--- a/lampod/src/chain/blockchain.rs
+++ b/lampod/src/chain/blockchain.rs
@@ -292,6 +292,14 @@ impl Backend for LampoChainManager {
         self.backend.set_handler(arc);
     }
 
+    fn set_sweeper(
+        &self,
+        best_block: lampo_common::backend::BlockLocator,
+        sweeper: Arc<lampo_common::types::LampoSweeper>,
+    ) {
+        self.backend.set_sweeper(best_block, sweeper);
+    }
+
     fn set_stale_monitors(
         &self,
         monitors: Vec<(

--- a/lampod/src/chain/blockchain.rs
+++ b/lampod/src/chain/blockchain.rs
@@ -291,4 +291,18 @@ impl Backend for LampoChainManager {
     fn set_handler(&self, arc: Arc<dyn lampo_common::handler::Handler>) {
         self.backend.set_handler(arc);
     }
+
+    fn set_stale_monitors(
+        &self,
+        monitors: Vec<(
+            lampo_common::backend::BlockLocator,
+            lampo_common::types::LampoMonitorListener,
+        )>,
+    ) {
+        self.backend.set_stale_monitors(monitors);
+    }
+
+    async fn sync_chain(&self) -> lampo_common::error::Result<()> {
+        self.backend.sync_chain().await
+    }
 }

--- a/lampod/src/lib.rs
+++ b/lampod/src/lib.rs
@@ -202,6 +202,10 @@ impl LampoDaemon {
         self.wallet_manager.clone()
     }
 
+    pub fn logger(&self) -> Arc<LampoLogger> {
+        self.logger.clone()
+    }
+
     pub fn init_event_handler(&mut self) -> error::Result<()> {
         log::debug!(target: "lampod", "init inventory manager ...");
         let handler = LampoHandler::new(self);

--- a/lampod/src/lib.rs
+++ b/lampod/src/lib.rs
@@ -244,6 +244,30 @@ impl LampoDaemon {
         client.set_handler(self.handler());
         client.set_channel_manager(self.channel_manager().manager());
         client.set_chain_monitor(self.channel_manager().chain_monitor());
+        // On restart, hand the channel monitors read from disk to the
+        // backend: each one is synced from its own best block to the chain
+        // tip and registered with the chain monitor during `sync_chain`.
+        let broadcaster = self.onchain_manager()
+            as Arc<dyn ldk::chain::chaininterface::BroadcasterInterface + Send + Sync>;
+        let fee_estimator = self.onchain_manager()
+            as Arc<dyn ldk::chain::chaininterface::FeeEstimator + Send + Sync>;
+        let stale_monitors = self
+            .channel_manager()
+            .take_stale_monitors()
+            .into_iter()
+            .map(|(locator, monitor)| {
+                (
+                    locator,
+                    (
+                        monitor,
+                        broadcaster.clone(),
+                        fee_estimator.clone(),
+                        self.logger.clone(),
+                    ),
+                )
+            })
+            .collect::<Vec<_>>();
+        client.set_stale_monitors(stale_monitors);
         self.channel_manager().set_handler(self.handler());
         Ok(())
     }
@@ -273,15 +297,24 @@ impl LampoDaemon {
             self.logger.clone(),
         ));
 
-        log::info!(target: "lampo", "Stating onchaind");
-        let _ = self.onchain_manager().listen();
-        log::info!(target: "lampo", "Starting peer manager");
-        let shutdown = self.shutdown.clone();
-        let _ = self.peer_manager().run_with_shutdown(shutdown.clone());
-        log::info!(target: "lampo", "Starting channel manager");
-        let _ = self.channel_manager().listen();
-
         tokio::spawn(async move {
+            // Bring the channel manager, the chain monitor, and any channel
+            // monitors read from disk up to the chain tip *before* starting
+            // the peer manager or the event processor: nothing may mutate
+            // channel state while monitors are still catching up, and a
+            // node that cannot see the chain must not go live at all.
+            log::info!(target: "lampo", "Syncing to the chain tip");
+            self.onchain_manager().sync_chain().await.map_err(|err| {
+                log::error!(target: "lampo", "Initial chain sync failed: {err}");
+                io::Error::new(io::ErrorKind::Other, err.to_string())
+            })?;
+
+            log::info!(target: "lampo", "Stating onchaind");
+            let _ = self.onchain_manager().listen();
+            log::info!(target: "lampo", "Starting peer manager");
+            let shutdown = self.shutdown.clone();
+            let _ = self.peer_manager().run_with_shutdown(shutdown.clone());
+
             process_events_async(
                 self.persister.clone(),
                 |env| self.handler_ldk_events(env),

--- a/lampod/src/lib.rs
+++ b/lampod/src/lib.rs
@@ -70,6 +70,7 @@ pub struct LampoDaemon {
     persister: Arc<LampoPersistence>,
     handler: Option<Arc<LampoHandler>>,
     shutdown: Arc<AtomicBool>,
+    ready: Arc<AtomicBool>,
 }
 
 impl LampoDaemon {
@@ -87,6 +88,17 @@ impl LampoDaemon {
             offchain_manager: None,
             handler: None,
             shutdown: Arc::new(AtomicBool::new(false)),
+            ready: Arc::new(AtomicBool::new(false)),
+        }
+    }
+
+    /// Wait until the initial chain sync completed and every channel
+    /// monitor is registered with the chain monitor. The RPC surface must
+    /// not accept channel-mutating commands before this point: a monitor
+    /// update issued while the chain monitor is still empty is dropped.
+    pub async fn wait_ready(&self) {
+        while !self.ready.load(Ordering::Acquire) {
+            tokio::time::sleep(std::time::Duration::from_millis(100)).await;
         }
     }
 
@@ -286,6 +298,7 @@ impl LampoDaemon {
                 log::error!(target: "lampo", "Initial chain sync failed: {err}");
                 io::Error::new(io::ErrorKind::Other, err.to_string())
             })?;
+            self.ready.store(true, Ordering::Release);
 
             log::info!(target: "lampo", "Stating onchaind");
             let _ = self.onchain_manager().listen();

--- a/lampod/src/lib.rs
+++ b/lampod/src/lib.rs
@@ -48,34 +48,6 @@ use crate::utils::logger::LampoLogger;
 pub(crate) type P2PGossipSync =
     ldk::routing::gossip::P2PGossipSync<Arc<LampoGraph>, Arc<LampoChainManager>, Arc<LampoLogger>>;
 
-/// No-op [`ChangeDestinationSource`] used only to *name* the `OutputSweeper`
-/// type when passing `sweeper: None` to the background processor. Lampo does
-/// not run an output sweeper, so this is never constructed or called.
-///
-/// [`ChangeDestinationSource`]: lampo_common::ldk::sign::ChangeDestinationSource
-struct NoChangeDestinationSource;
-
-impl ldk::sign::ChangeDestinationSource for NoChangeDestinationSource {
-    fn get_change_destination_script<'a>(
-        &'a self,
-    ) -> impl std::future::Future<Output = Result<lampo_common::bitcoin::ScriptBuf, ()>> + Send + 'a
-    {
-        std::future::ready(Err(()))
-    }
-}
-
-/// Concrete `OutputSweeper` type matching lampo's chain-monitor wiring, used
-/// solely to type the `None` sweeper argument to [`process_events_async`].
-type LampoSweeper = ldk::util::sweep::OutputSweeper<
-    Arc<dyn ldk::chain::chaininterface::BroadcasterInterface + Send + Sync>,
-    Arc<NoChangeDestinationSource>,
-    Arc<dyn ldk::chain::chaininterface::FeeEstimator + Send + Sync>,
-    Arc<dyn ldk::chain::Filter + Send + Sync>,
-    Arc<LampoPersistence>,
-    Arc<LampoLogger>,
-    LampoKeysManager,
->;
-
 /// LampoDaemon is the main data structure that uses the facade
 /// pattern to hide the complexity of the LDK library. You can interact
 /// with the LampoDaemon's components through access
@@ -268,6 +240,12 @@ impl LampoDaemon {
             })
             .collect::<Vec<_>>();
         client.set_stale_monitors(stale_monitors);
+        // The sweeper follows the chain as an ongoing listener, starting
+        // from the best block its persisted state was last synced to.
+        client.set_sweeper(
+            self.channel_manager().sweeper_best_block(),
+            self.channel_manager().sweeper(),
+        );
         self.channel_manager().set_handler(self.handler());
         Ok(())
     }
@@ -324,7 +302,7 @@ impl LampoDaemon {
                 GossipSync::p2p(gossip_sync),
                 self.peer_manager().manager(),
                 NO_LIQUIDITY_MANAGER,
-                None::<Arc<LampoSweeper>>,
+                Some(self.channel_manager().sweeper()),
                 self.logger.clone(),
                 Some(self.channel_manager().scorer()),
                 |d| {
@@ -363,9 +341,19 @@ impl LampoDaemon {
         })
     }
 
-    // FIXME: what about replay event?
     async fn handler_ldk_events(&self, env: Event) -> Result<(), ReplayEvent> {
+        // Only `SpendableOutputs` is replayed on failure: its only failure
+        // mode is a transient persistence error, and dropping it would lose
+        // funds. Other handlers can fail permanently (peer disconnected,
+        // wallet without funds); LDK keeps a failed event at the head of
+        // the queue, so replaying those would block every later event
+        // forever.
+        let replay_on_failure = matches!(env, Event::SpendableOutputs { .. });
         if let Err(err) = self.handler().handle(env).await {
+            if replay_on_failure {
+                log::error!(target: "lampod", "Error handling event, will replay it: {:?}", err);
+                return Err(ReplayEvent());
+            }
             log::error!(target: "lampod", "Error handling event: {:?}", err);
         }
         Ok(())

--- a/lampod/src/ln/channel_manager.rs
+++ b/lampod/src/ln/channel_manager.rs
@@ -27,15 +27,21 @@ use lampo_common::ldk::routing::scoring::{
     ProbabilisticScorer, ProbabilisticScoringDecayParameters, ProbabilisticScoringFeeParameters,
 };
 use lampo_common::ldk::sign::{InMemorySigner, NodeSigner};
-use lampo_common::ldk::util::persist::read_channel_monitors;
+use lampo_common::ldk::util::persist::{
+    read_channel_monitors, KVStoreSync, OUTPUT_SWEEPER_PERSISTENCE_KEY,
+    OUTPUT_SWEEPER_PERSISTENCE_PRIMARY_NAMESPACE, OUTPUT_SWEEPER_PERSISTENCE_SECONDARY_NAMESPACE,
+};
 use lampo_common::ldk::util::ser::ReadableArgs;
+use lampo_common::ldk::util::sweep::OutputSweeper;
 use lampo_common::model::request;
 use lampo_common::model::response::{self, Channel, Channels};
 use lampo_common::types::LampoChannel;
 use lampo_common::types::LampoGraph;
 use lampo_common::types::LampoRouter;
 use lampo_common::types::LampoScorer;
+use lampo_common::types::LampoSweeper;
 use lampo_common::types::{LampoArcChannelManager, LampoChainMonitor};
+use lampo_common::wallet::LampoChangeDestination;
 
 use crate::actions::handler::LampoHandler;
 use crate::async_run;
@@ -52,6 +58,7 @@ pub struct LampoChannelManager {
     handler: OnceLock<Arc<LampoHandler>>,
     router: OnceLock<Arc<LampoRouter>>,
     stale_monitors: Mutex<Vec<(BlockLocator, ChannelMonitor<InMemorySigner>)>>,
+    sweeper: OnceLock<(BlockLocator, Arc<LampoSweeper>)>,
 
     pub(crate) onchain: Arc<LampoChainManager>,
     pub(crate) conf: LampoConf,
@@ -80,6 +87,7 @@ impl LampoChannelManager {
             score: OnceLock::new(),
             router: OnceLock::new(),
             stale_monitors: Mutex::new(Vec::new()),
+            sweeper: OnceLock::new(),
         }
     }
 
@@ -99,7 +107,79 @@ impl LampoChannelManager {
         } else {
             self.start().await?;
         }
+        self.init_sweeper()?;
         Ok(())
+    }
+
+    /// Build the [`LampoSweeper`], restoring its persisted state (tracked
+    /// spendable outputs and best block) when present.
+    fn init_sweeper(&self) -> error::Result<()> {
+        let broadcaster = self.onchain.clone() as Arc<dyn BroadcasterInterface + Send + Sync>;
+        let fee_estimator = self.onchain.clone() as Arc<dyn FeeEstimator + Send + Sync>;
+        let change_destination = Arc::new(LampoChangeDestination::new(
+            self.wallet_manager.clone(),
+            self.conf.network,
+        ));
+        let spender = self.wallet_manager.ldk_keys().keys_manager.clone();
+
+        let state = KVStoreSync::read(
+            &*self.persister,
+            OUTPUT_SWEEPER_PERSISTENCE_PRIMARY_NAMESPACE,
+            OUTPUT_SWEEPER_PERSISTENCE_SECONDARY_NAMESPACE,
+            OUTPUT_SWEEPER_PERSISTENCE_KEY,
+        );
+        let (best_block, sweeper) = match state {
+            Ok(bytes) => <(BlockLocator, LampoSweeper)>::read(
+                &mut std::io::Cursor::new(bytes),
+                (
+                    broadcaster,
+                    fee_estimator,
+                    None,
+                    spender,
+                    change_destination,
+                    self.persister.clone(),
+                    self.logger.clone(),
+                ),
+            )
+            .map_err(|err| error::anyhow!("failed to read the sweeper state: {err}"))?,
+            Err(err) if err.kind() == lampo_common::ldk::io::ErrorKind::NotFound => {
+                let best_block = self.manager().current_best_block();
+                let sweeper = OutputSweeper::new(
+                    best_block.clone(),
+                    broadcaster,
+                    fee_estimator,
+                    None,
+                    spender,
+                    change_destination,
+                    self.persister.clone(),
+                    self.logger.clone(),
+                );
+                (best_block, sweeper)
+            }
+            Err(err) => error::bail!("failed to read the sweeper state: {err}"),
+        };
+        self.sweeper
+            .set((best_block, Arc::new(sweeper)))
+            .unwrap_or_else(|_| panic!("sweeper already initialized"));
+        Ok(())
+    }
+
+    pub fn sweeper(&self) -> Arc<LampoSweeper> {
+        self.sweeper
+            .get()
+            .expect("sweeper not initialized")
+            .1
+            .clone()
+    }
+
+    /// The best block the sweeper state was persisted at: the chain backend
+    /// must replay blocks from here before going live.
+    pub fn sweeper_best_block(&self) -> BlockLocator {
+        self.sweeper
+            .get()
+            .expect("sweeper not initialized")
+            .0
+            .clone()
     }
 
     fn build_channel_monitor(&self) -> LampoChainMonitor {

--- a/lampod/src/ln/channel_manager.rs
+++ b/lampod/src/ln/channel_manager.rs
@@ -310,20 +310,48 @@ impl LampoChannelManager {
         graph: &Arc<LampoGraph>,
     ) -> ProbabilisticScorer<Arc<LampoGraph>, Arc<LampoLogger>> {
         let params = ProbabilisticScoringDecayParameters::default();
-        if let Ok(file) = File::open(path) {
-            let args = (params, Arc::clone(graph), self.logger.clone());
-            if let Ok(scorer) = ProbabilisticScorer::read(&mut BufReader::new(file), args) {
-                return scorer;
+        match File::open(path) {
+            Ok(file) => {
+                let args = (params, Arc::clone(graph), self.logger.clone());
+                match ProbabilisticScorer::read(&mut BufReader::new(file), args) {
+                    Ok(scorer) => return scorer,
+                    // A corrupt file on a datadir that persists channel
+                    // monitors deserves a loud warning, not a silent reset.
+                    Err(err) => log::error!(
+                        target: "lampod",
+                        "scorer at `{}` is unreadable ({err}); starting fresh. If this \
+                         was not expected, check the datadir for disk corruption",
+                        path.display()
+                    ),
+                }
             }
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
+            Err(err) => log::error!(
+                target: "lampod",
+                "failed to open scorer at `{}`: {err}; starting fresh",
+                path.display()
+            ),
         }
         ProbabilisticScorer::new(params, graph.clone(), self.logger.clone())
     }
 
     pub(crate) fn read_network(&self, path: &Path) -> Arc<LampoGraph> {
-        if let Ok(file) = File::open(path) {
-            if let Ok(graph) = NetworkGraph::read(&mut BufReader::new(file), self.logger.clone()) {
-                return Arc::new(graph);
-            }
+        match File::open(path) {
+            Ok(file) => match NetworkGraph::read(&mut BufReader::new(file), self.logger.clone()) {
+                Ok(graph) => return Arc::new(graph),
+                Err(err) => log::error!(
+                    target: "lampod",
+                    "network graph at `{}` is unreadable ({err}); starting fresh. If \
+                     this was not expected, check the datadir for disk corruption",
+                    path.display()
+                ),
+            },
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
+            Err(err) => log::error!(
+                target: "lampod",
+                "failed to open network graph at `{}`: {err}; starting fresh",
+                path.display()
+            ),
         }
         Arc::new(NetworkGraph::new(self.conf.network, self.logger.clone()))
     }

--- a/lampod/src/ln/channel_manager.rs
+++ b/lampod/src/ln/channel_manager.rs
@@ -266,8 +266,12 @@ impl LampoChannelManager {
                 .await
                 .ok_or(error::anyhow!("Channel close no event received"))?;
 
-            if let Event::OnChain(OnChainEvent::SendRawTransaction(tx)) = event {
-                break Some(tx);
+            match event {
+                Event::OnChain(OnChainEvent::SendRawTransaction(tx)) => break Some(tx),
+                Event::OnChain(OnChainEvent::BroadcastFailed(txid)) => {
+                    error::bail!("funding transaction `{txid}` failed to broadcast");
+                }
+                _ => continue,
             }
         };
 

--- a/lampod/src/ln/channel_manager.rs
+++ b/lampod/src/ln/channel_manager.rs
@@ -51,6 +51,7 @@ pub struct LampoChannelManager {
     score: OnceLock<Arc<Mutex<LampoScorer>>>,
     handler: OnceLock<Arc<LampoHandler>>,
     router: OnceLock<Arc<LampoRouter>>,
+    stale_monitors: Mutex<Vec<(BlockLocator, ChannelMonitor<InMemorySigner>)>>,
 
     pub(crate) onchain: Arc<LampoChainManager>,
     pub(crate) conf: LampoConf,
@@ -78,6 +79,7 @@ impl LampoChannelManager {
             graph: OnceLock::new(),
             score: OnceLock::new(),
             router: OnceLock::new(),
+            stale_monitors: Mutex::new(Vec::new()),
         }
     }
 
@@ -155,14 +157,20 @@ impl LampoChannelManager {
         Channels { channels }
     }
 
-    pub fn get_channel_monitors(&self) -> error::Result<Vec<ChannelMonitor<InMemorySigner>>> {
+    pub fn get_channel_monitors(
+        &self,
+    ) -> error::Result<Vec<(BlockLocator, ChannelMonitor<InMemorySigner>)>> {
         let keys = self.wallet_manager.ldk_keys().inner();
-        let mut monitors = read_channel_monitors(self.persister.clone(), keys.clone(), keys)?;
-        let mut channel_monitors = Vec::new();
-        for (_, monitor) in monitors.drain(..) {
-            channel_monitors.push(monitor);
-        }
-        Ok(channel_monitors)
+        let monitors = read_channel_monitors(self.persister.clone(), keys.clone(), keys)?;
+        Ok(monitors)
+    }
+
+    /// Take the channel monitors read from disk during [`Self::restart`],
+    /// each paired with the best block it was persisted at. They must be
+    /// synced to the chain tip and registered with the chain monitor via
+    /// `watch_channel` before the node connects new blocks.
+    pub fn take_stale_monitors(&self) -> Vec<(BlockLocator, ChannelMonitor<InMemorySigner>)> {
+        std::mem::take(&mut self.stale_monitors.lock().unwrap())
     }
 
     pub fn graph(&self) -> Arc<LampoGraph> {
@@ -313,7 +321,10 @@ impl LampoChannelManager {
 
         let _ = self.network_graph();
         let monitors = self.get_channel_monitors()?;
-        let monitors = monitors.iter().collect::<Vec<_>>();
+        let monitor_refs = monitors
+            .iter()
+            .map(|(_, monitor)| monitor)
+            .collect::<Vec<_>>();
 
         let default_message_router = DefaultMessageRouter::new(
             self.graph(),
@@ -331,7 +342,7 @@ impl LampoChannelManager {
             default_message_router,
             self.logger.clone(),
             self.conf.ldk_conf.clone(),
-            monitors,
+            monitor_refs,
         );
         let mut channel_manager_file = File::open(format!("{}/manager", self.conf.path()))?;
         let (_, channel_manager) =
@@ -340,6 +351,10 @@ impl LampoChannelManager {
         self.channeld
             .set(Arc::new(channel_manager))
             .unwrap_or_else(|_| panic!("channel manager already initialized"));
+        // Keep the monitors around: they still need to be synced to the
+        // chain tip and registered with the chain monitor before the node
+        // goes live. See `take_stale_monitors`.
+        *self.stale_monitors.lock().unwrap() = monitors;
         Ok(())
     }
 

--- a/tests/tests/src/lampo_tests.rs
+++ b/tests/tests/src/lampo_tests.rs
@@ -408,3 +408,72 @@ pub async fn decode_offer_hex() -> error::Result<()> {
     log::info!(target: &node1.info.node_id, "Payment completed successfully: {:?}", pay);
     Ok(())
 }
+
+/// After a channel closes, the funds return to a script derived from the
+/// LDK keys manager, which the on-chain BDK wallet does not track. The
+/// only way the node ever sees that money again is the output sweeper
+/// picking up `Event::SpendableOutputs` and sweeping it back into the
+/// wallet. Without the sweeper this test times out with the wallet
+/// balance stuck at its post-funding value: the closed channel's funds
+/// are lost.
+#[tokio_test_shutdown_timeout::test(5)]
+pub async fn sweep_funds_after_channel_close() -> error::Result<()> {
+    init();
+    let node1 = LampoTesting::tmp().await?;
+    let btc = node1.btc.clone();
+    let node2 = Arc::new(LampoTesting::new(btc.clone()).await?);
+
+    const CHANNEL_SAT: u64 = 1_000_000;
+    node1.fund_channel_with(node2.clone(), CHANNEL_SAT).await?;
+
+    // The sweep lands as a fresh wallet UTXO worth the channel balance
+    // minus close and sweep fees, i.e. somewhere in (CHANNEL_SAT / 2,
+    // CHANNEL_SAT). Nothing else in this test produces an output in that
+    // range: coinbases are ~50 BTC and the funding change is far larger.
+    let in_sweep_range = |utxo: &response::Utxo| {
+        let sat = utxo.amount_msat / 1000;
+        sat > CHANNEL_SAT / 2 && sat < CHANNEL_SAT
+    };
+    let funds: response::Utxos = node1.lampod().call("funds", json::json!({})).await?;
+    assert!(
+        !funds.transactions.iter().any(in_sweep_range),
+        "no sweep-sized utxo should exist before the close: {funds:?}"
+    );
+
+    let close: response::CloseChannel = node1
+        .lampod()
+        .call(
+            "close",
+            request::CloseChannel {
+                node_id: node2.info.node_id.clone(),
+                channel_id: None,
+            },
+        )
+        .await?;
+    log::info!(target: &node1.info.node_id, "channel closed: {close:?}");
+
+    // The closing transaction needs to confirm (plus LDK's anti-reorg
+    // delay of 6 blocks) before SpendableOutputs fires; the sweeper then
+    // broadcasts on the background processor's 30s timer and the sweep
+    // itself needs a confirmation. Keep mining and give it time.
+    async_wait!(
+        async {
+            node1.fund_wallet(2).await.unwrap();
+            tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+            let funds: response::Utxos =
+                node1.lampod().call("funds", json::json!({})).await.unwrap();
+            log::info!(
+                target: &node1.info.node_id,
+                "waiting for the sweep to land: {} utxos",
+                funds.transactions.len()
+            );
+            if funds.transactions.iter().any(in_sweep_range) {
+                Ok(())
+            } else {
+                Err(())
+            }
+        },
+        10
+    );
+    Ok(())
+}


### PR DESCRIPTION
## Summary

Make lampo safe to run on mainnet with real funds by closing every on-chain fund-loss hole found in a full audit of the tree. One commit per concern, each self-contained; the full audit, design decisions, and justification live in [`docs/designs/production-onchain-safety.md`](docs/designs/production-onchain-safety.md) (added by the last commit, together with the brainstorm that ranked the risks).

### Fund-loss holes closed

1. **Channel monitors were never registered on restart** — no `watch_channel` call existed anywhere in the tree. After any restart the `ChainMonitor` was empty: counterparty force-closes, revoked commitments, and on-chain HTLCs went undetected for every existing channel. Monitors are now synced each from its own persisted best block and registered before the node goes live; startup aborts if registration fails.
2. **`Event::SpendableOutputs` was dropped** — force-close outputs were never claimed. LDK's `OutputSweeper` is now wired end to end (persisted state, BDK change addresses, chain listener, background-processor timer). Persist failures replay the event instead of dropping it.
3. **`FeeEstimator` returned a hardcoded 256 sat/kW** for every target, and the funding path overpaid fees ~1000x from a sat/kvB-as-sat/vB unit mix-up. Feerates now come from a per-target cache refreshed from `estimatesmartfee`/`getmempoolinfo`, unified on sat-per-1000-weight, with headroom on `MaximumFeeEstimate`.
4. **No `BumpTransactionEventHandler`** despite anchors being negotiated by default — anchor commitments *rely* on CPFP to confirm. The handler is wired with coin selection from the BDK wallet; inbound anchor channels now require a 25k-sat confirmed reserve.
5. **Broadcast failures were silently swallowed**, and multi-tx broadcasts broke LDK's package contract. `brodcast_tx` returns `Result`, packages go through bitcoind's `submitpackage`, "already known" counts as success, bounded retries, and definitive failures emit a `BroadcastFailed` event so RPC callers stop hanging.
6. **Startup ordering**: pid lock now taken before any state is read; peers/events/RPC start only after the initial chain sync (and monitor registration) completes; `PaymentClaimable` no longer `unwrap()`s the preimage; corrupt graph/scorer files warn loudly; `accept-inbound-channels` config option added.

### Design

Follows the plan in `docs/brainstorms/2026-08-09-lampo-production-fund-safety.md` (Approach A: onchain safety first, reusing LDK components — `OutputSweeper`, `BumpTransactionEventHandler`, `Wallet`/`WalletSource` — behind thin `WalletManager` adapters, keeping lampo's facade/backend architecture). Two items of `docs/designs/unified-chain-sync.md` (per-listener locators, monitor registration) land here ahead of the coordinator work; the justification for that ordering is in the new design doc, and the unified-chain-sync doc carries a status note. VSS channel-state mirroring and the sync coordinator are the next phases and deliberately out of scope.

### Testing

- `cargo test --all`: unit tests pass; the `tests` crate shows pre-existing environment flakiness (`[43] libcurl` errors) that reproduces identically on `main` at 4a5afd8.
- Every commit compiles independently (`cargo check --workspace` was run per-commit during the rebase).
- An adversarial review pass against the pinned LDK 0.3 sources verified the sweeper `ReadableArgs` ordering, the restart flow against LDK's canonical init example, fee unit conversions, and absence of lock-across-await; the issues it found (package broadcast, blanket replay, missing anchor reserve, early RPC exposure) are fixed in this series.

### Follow-ups (tracked in the design doc)

VSS mirror for channel state, unified chain sync coordinator, anchor reserve *maintenance* (accept-time check only today), payment persistence, mnemonic encryption, and a regtest force-close-and-sweep integration test.


### Fund-loss reproduction (A/B on the new regression test)

`tests: Cover sweeping funds after channel close` opens a 1M-sat channel, cooperatively closes it, and waits for the closed channel's funds to reappear as a wallet UTXO.

- **On `main` (4a5afd8, with only the `/close` endpoint fix applied so the close can happen at all): FAILS in 165s.** The node logs the exact loss — LDK hands over the funds and lampo drops them:
  ```
  WARN lampo::handler unhandled ldk event: SpendableOutputs {
      outputs: [StaticOutput { value: 998828 SAT, ... }], ... }
  ```
  The 998,828 sats stay on the LDK-derived shutdown script forever; no component in the tree can ever spend them.
- **On this branch: PASSES in 91s.** The same event is tracked (`tracking 1 spendable output(s) ...`), the sweeper broadcasts (`Generating and broadcasting sweeping transaction 57860f...`), and the funds land back in the BDK wallet.

Writing this test also flushed out one more pre-existing bug, fixed here: the httpd `/close` endpoint discarded its request body (the body-less `post!` variant), so closing a channel through the HTTP API had never worked at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
