### PR TITLE
Move LDK 0.3 to the crates.io release, add BOLT 12 payer proofs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1901,8 +1901,9 @@ dependencies = [
 
 [[package]]
 name = "lightning"
-version = "0.3.0+git"
-source = "git+https://github.com/lightningdevkit/rust-lightning?rev=84605cf08d34b8db731ee4a4356a95125a8b02af#84605cf08d34b8db731ee4a4356a95125a8b02af"
+version = "0.3.0-beta1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "051fad04d4a4b6fd4b483528c3d61b0c76d9b70cc2f0a870147c10909350d722"
 dependencies = [
  "bech32",
  "bitcoin",
@@ -1919,8 +1920,9 @@ dependencies = [
 
 [[package]]
 name = "lightning-background-processor"
-version = "0.3.0+git"
-source = "git+https://github.com/lightningdevkit/rust-lightning?rev=84605cf08d34b8db731ee4a4356a95125a8b02af#84605cf08d34b8db731ee4a4356a95125a8b02af"
+version = "0.3.0-beta1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f252c50b7f9710226ee8b1267d691268bb75f867c25a1bc4e769c2f4c9940598"
 dependencies = [
  "bitcoin",
  "bitcoin-io",
@@ -1933,8 +1935,9 @@ dependencies = [
 
 [[package]]
 name = "lightning-block-sync"
-version = "0.3.0+git"
-source = "git+https://github.com/lightningdevkit/rust-lightning?rev=84605cf08d34b8db731ee4a4356a95125a8b02af#84605cf08d34b8db731ee4a4356a95125a8b02af"
+version = "0.3.0-beta1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba81935c36d1091b58aabf4c86cbd275cca19cbcb9b392ae2aeca97b8b5b658"
 dependencies = [
  "bitcoin",
  "bitreq",
@@ -1944,8 +1947,9 @@ dependencies = [
 
 [[package]]
 name = "lightning-invoice"
-version = "0.35.0+git"
-source = "git+https://github.com/lightningdevkit/rust-lightning?rev=84605cf08d34b8db731ee4a4356a95125a8b02af#84605cf08d34b8db731ee4a4356a95125a8b02af"
+version = "0.35.0-beta1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99e186bfc9aae7fa6fda7ac3f5d701d9ee1262407025bb7db5bc04af9593723a"
 dependencies = [
  "bech32",
  "bitcoin",
@@ -1955,8 +1959,9 @@ dependencies = [
 
 [[package]]
 name = "lightning-liquidity"
-version = "0.3.0+git"
-source = "git+https://github.com/lightningdevkit/rust-lightning?rev=84605cf08d34b8db731ee4a4356a95125a8b02af#84605cf08d34b8db731ee4a4356a95125a8b02af"
+version = "0.3.0-beta1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f178d6e5716d442bad1441ff1d40b744b8fc9beaaf5618c547e246656739a2ec"
 dependencies = [
  "bitcoin",
  "bitreq",
@@ -1971,8 +1976,9 @@ dependencies = [
 
 [[package]]
 name = "lightning-macros"
-version = "0.2.2+git"
-source = "git+https://github.com/lightningdevkit/rust-lightning?rev=84605cf08d34b8db731ee4a4356a95125a8b02af#84605cf08d34b8db731ee4a4356a95125a8b02af"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4c717494cdc2c8bb85bee7113031248f5f6c64f8802b33c1c9e2d98e594aa71"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1981,8 +1987,9 @@ dependencies = [
 
 [[package]]
 name = "lightning-net-tokio"
-version = "0.3.0+git"
-source = "git+https://github.com/lightningdevkit/rust-lightning?rev=84605cf08d34b8db731ee4a4356a95125a8b02af#84605cf08d34b8db731ee4a4356a95125a8b02af"
+version = "0.3.0-beta1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "441d91bdd45504ec3c575964c79ab1529e5a882bdb7fb23b70e287b984f50c8e"
 dependencies = [
  "bitcoin",
  "lightning",
@@ -1991,8 +1998,9 @@ dependencies = [
 
 [[package]]
 name = "lightning-persister"
-version = "0.3.0+git"
-source = "git+https://github.com/lightningdevkit/rust-lightning?rev=84605cf08d34b8db731ee4a4356a95125a8b02af#84605cf08d34b8db731ee4a4356a95125a8b02af"
+version = "0.3.0-beta1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94cb02eaf5891d526f2864d1c4a275d3b54c1048632564f28de28fdd6e71158d"
 dependencies = [
  "bitcoin",
  "lightning",
@@ -2002,8 +2010,9 @@ dependencies = [
 
 [[package]]
 name = "lightning-rapid-gossip-sync"
-version = "0.3.0+git"
-source = "git+https://github.com/lightningdevkit/rust-lightning?rev=84605cf08d34b8db731ee4a4356a95125a8b02af#84605cf08d34b8db731ee4a4356a95125a8b02af"
+version = "0.3.0-beta1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "467ead156664826baf44838c4e57e8014a71118ca65695c0f53d6fb702c4f405"
 dependencies = [
  "bitcoin",
  "bitcoin-io",
@@ -2013,8 +2022,9 @@ dependencies = [
 
 [[package]]
 name = "lightning-types"
-version = "0.4.0+git"
-source = "git+https://github.com/lightningdevkit/rust-lightning?rev=84605cf08d34b8db731ee4a4356a95125a8b02af#84605cf08d34b8db731ee4a4356a95125a8b02af"
+version = "0.4.0-beta1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e605bf5f355153e50ee9b2060dfe7640b6277e1b82929097b61b2b5d2837ee8"
 dependencies = [
  "bitcoin",
 ]
@@ -2412,8 +2422,9 @@ dependencies = [
 
 [[package]]
 name = "possiblyrandom"
-version = "0.2.0"
-source = "git+https://github.com/lightningdevkit/rust-lightning?rev=84605cf08d34b8db731ee4a4356a95125a8b02af#84605cf08d34b8db731ee4a4356a95125a8b02af"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c564dbf654befd49035528299f1208a40508f6e07efb11c163444e304e4484f"
 dependencies = [
  "getrandom 0.2.16",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,13 +22,14 @@ default-members = [
 ]
 resolver = "2"
 
-# LDK 0.3 is not yet published to crates.io; track the upstream `0.3` branch,
-# pinned to a commit for reproducible builds. Bump every lightning* crate
-# together so the stack stays on one version (see issue #537).
+# LDK 0.3 is published to crates.io as a pre-release, so the requirement has to
+# spell out `0.3.0-beta1`: a bare `0.3` does not match pre-release versions.
+# Bump every lightning* crate together so the stack stays on one version
+# (see issue #537).
 [workspace.dependencies]
-lightning = { git = "https://github.com/lightningdevkit/rust-lightning", rev = "84605cf08d34b8db731ee4a4356a95125a8b02af" }
-lightning-block-sync = { git = "https://github.com/lightningdevkit/rust-lightning", rev = "84605cf08d34b8db731ee4a4356a95125a8b02af" }
-lightning-persister = { git = "https://github.com/lightningdevkit/rust-lightning", rev = "84605cf08d34b8db731ee4a4356a95125a8b02af", features = ["tokio"] }
-lightning-background-processor = { git = "https://github.com/lightningdevkit/rust-lightning", rev = "84605cf08d34b8db731ee4a4356a95125a8b02af" }
-lightning-net-tokio = { git = "https://github.com/lightningdevkit/rust-lightning", rev = "84605cf08d34b8db731ee4a4356a95125a8b02af" }
-lightning-rapid-gossip-sync = { git = "https://github.com/lightningdevkit/rust-lightning", rev = "84605cf08d34b8db731ee4a4356a95125a8b02af" }
+lightning = "0.3.0-beta1"
+lightning-block-sync = "0.3.0-beta1"
+lightning-persister = { version = "0.3.0-beta1", features = ["tokio"] }
+lightning-background-processor = "0.3.0-beta1"
+lightning-net-tokio = "0.3.0-beta1"
+lightning-rapid-gossip-sync = "0.3.0-beta1"

--- a/docs/brainstorms/2026-08-09-attach-payer-proof-to-pay-response.md
+++ b/docs/brainstorms/2026-08-09-attach-payer-proof-to-pay-response.md
@@ -1,0 +1,207 @@
+# Attach a BOLT12 payer proof to the `pay` response
+
+## Clarified Problem Statement
+
+**Goal:** When `pay` settles a BOLT12 offer, return a verifiable payer proof (and the payment
+preimage) in the RPC response, so the payer can prove to a third party that they paid that invoice.
+
+**Constraints:**
+
+- Only possible on LDK >= 0.3. The `lightning::offers::payer_proof` module is new: absent at the
+  old pinned rev `84605cf`, present at `v0.3.0-beta1` (`9174965`). Unlocked by the crates.io bump
+  in PR #554. Implements BOLT PR #1295.
+- Proof material reaches lampo only via `Event::PaymentSent.bolt12_invoice`. Lampo currently
+  **discards** that event (`lampod/src/actions/handler.rs:381`).
+- BOLT11 payments have `bolt12_invoice == None`. The response field must be optional.
+- Async payments (`PaidBolt12Invoice::StaticInvoice`) cannot produce a proof — `prove_payer*`
+  returns `PayerProofError::IncompatibleInvoice`. Must degrade to `None`, not error the pay.
+- Disclosure is baked into the signed proof at build time, so re-issuing with different fields
+  requires re-building from the original invoice. Hence the persistence requirement below.
+- `CLAUDE.md`: keep it simple, no overdesign; `unwrap` only where provably safe.
+
+**Non-goals:**
+
+- No verification side. Lampo produces proofs; it does not gain a "verify this proof" command.
+- No proof for keysend / BOLT11 / static-invoice payments.
+- Not changing how offers are paid, only what `pay` returns.
+- No garbage collection / retention policy for stored proof material in the first cut.
+
+**Success criteria:**
+
+- Paying a BOLT12 offer returns a `payer_proof` bech32 string that round-trips via
+  `PayerProof::from_str` and whose `payment_hash()` matches the payment.
+- `PayResult` also carries the preimage, closing the existing
+  `// FIXME: missing payment preimage` at `lampo-common/src/model/invoice.rs:171`.
+- BOLT11 pay still succeeds with `payer_proof: None`.
+- `PayResult.path` is not silently regressed (see the wrinkle below).
+- The proof material survives the pay call, so a proof can be re-issued later with a different
+  disclosure set without re-paying.
+- Integration test covering an offer payment asserting a parseable proof, plus a re-issue that
+  discloses strictly more fields than the one returned by `pay`.
+
+## What has to be persisted for re-issue
+
+Only two things, because everything else is derivable:
+
+| Store | Why |
+| --- | --- |
+| `PaidBolt12Invoice` | The proof is built from it. `Writeable`/`Readable` via `impl_writeable_tlv_based_enum!`. A few hundred bytes to ~1KB. |
+| `payment_preimage` | Not derivable. `new_derived` enforces `sha256(preimage) == invoice.payment_hash()`, else `PayerProofError::PreimageMismatch`. 32 bytes. |
+
+Explicitly **not** needed:
+
+- **`Nonce`** — `payer_proof.rs:67` states the payer signing key "is re-derived from the invoice's
+  own payer metadata, so no separate `Nonce` needs to be stored alongside it".
+  `derive_payer_signing_keys(&self, key: &ExpandedKey, secp_ctx)` takes no nonce. The
+  `nonce_hashes` inside the module are unrelated: per-TLV blinding nonces minted fresh by
+  `SelectiveDisclosure` at build time. Regenerating them on each re-issue is desirable — it keeps
+  two proofs of the same payment unlinkable.
+- **`PaymentId`** — recoverable via `Bolt12Invoice::verify_using_metadata(expanded_key, secp_ctx)`,
+  which returns it. `prove_payer_derived` takes it only as a cross-check guard. Store it anyway as
+  the lookup key.
+- **Any key material** — `ExpandedKey` comes from the node seed at runtime via
+  `NodeSigner::get_expanded_key()`.
+
+So the record is `payment_id -> (PaidBolt12Invoice, payment_preimage)`.
+
+Storage: `LampoPersistence` is already `lightning-persister`'s `FilesystemStore` (a `KVStore`)
+and is `Arc`'d into `LampoDaemon` (`lampod/src/persistence/mod.rs:12`, `lampod/src/lib.rs:109`).
+Write under a dedicated namespace keyed by hex `payment_id`. No new dependency, no schema
+migration, no sqlite involvement.
+
+Access is two free functions taking the concrete store. That is deliberate: lampo has one backend
+today, and an interface designed around a single implementation is how you get the wrong
+interface. A `PayerProofStore` trait with a blanket impl over `KVStoreSync` was tried here first
+and is a trap — LDK requires `KVStoreSync` of every backend, so the blanket impl claims them all
+and coherence (E0119) then forbids any backend from supplying its own native implementation.
+
+The persistence interface is being designed separately, against a real second backend, where it
+can be validated rather than guessed.
+
+## Relevant API surface (LDK 0.3.0-beta1)
+
+```rust
+// events
+Event::PaymentSent {
+    payment_id: Option<PaymentId>,
+    payment_preimage: PaymentPreimage,
+    payment_hash: PaymentHash,
+    amount_msat: Option<u64>,
+    fee_paid_msat: Option<u64>,
+    bolt12_invoice: Option<PaidBolt12Invoice>,   // <-- the proof material
+}
+
+// building the proof
+PaidBolt12Invoice::prove_payer_derived(
+    payment_preimage, &expanded_key, payment_id, &secp_ctx,
+) -> Result<PayerProofBuilder<DerivedSigningPubkey>, PayerProofError>
+
+// selective disclosure toggles on the builder
+.include_offer_description() .include_offer_issuer()
+.include_invoice_amount()    .include_invoice_created_at()
+.with_proof_note(String)     .include_type(u64)
+
+.build_and_sign() -> Result<PayerProof, PayerProofError>
+```
+
+`PayerProof` implements `Bech32Encode` + `FromStr`, so it serialises as one string.
+`ExpandedKey` comes from `NodeSigner::get_expanded_key()`; `LampoKeysManager` wraps `KeysManager`
+but its `inner` is `pub(crate)`, so `lampo-common/src/keys.rs` likely needs a small accessor.
+
+Always present in a proof: preimage, payment hash, payer signing pubkey, issuer signing pubkey,
+invoice signature, proof signature, merkle root. Everything else is opt-in.
+
+## The design wrinkle: `path`
+
+`PaymentSent` carries no `path`. Hop data exists only on `PaymentPathSuccessful`, which is what
+`json_pay` returns on today (`lampod/src/jsonrpc/offchain.rs:123`). Switching the terminal event
+wholesale to `PaymentSent` would leave `PayResult.path` empty — a silent regression of a field
+that works today.
+
+Options, cheapest first:
+
+1. **Correlate in `json_pay`.** `PaymentSent` emits the receipt (preimage + proof) as a distinct
+   `PaymentReceipt` event; `PaymentPathSuccessful` keeps emitting the terminal `PaymentEvent`
+   with the path. `json_pay` holds the receipt until the terminal event arrives, then merges.
+2. **Return on `PaymentSent`, accept empty path.** Simplest, but a documented behaviour change.
+3. **Return on `PaymentSent`, drop `path` from `PayResult`.** Honest but breaks the response schema.
+
+Went with (1). LDK emits `PaymentSent` before `PaymentPathSuccessful`, so the receipt is already
+in hand when the terminal event lands. Correlating in `json_pay` rather than in the handler keeps
+the state scoped to the one RPC call, needs no daemon-level map, and means the response never
+depends on the persister write having succeeded.
+
+## Filtering is mandatory, not optional
+
+`Emitter::emit` broadcasts to every subscriber, so two concurrent `pay` calls both see both
+payments' events. Before this change that meant a caller could get the wrong path and hash; with
+a receipt attached it would leak another payment's **preimage and payer proof**. Every event
+therefore carries a hex `payment_id`, and `json_pay` accepts only its own — `pay_offer` and
+`pay_invoice` return the `PaymentId` they used so the caller knows what to match on.
+
+## Approaches Considered
+
+### Approach A: Enrich `LightningEvent::PaymentEvent`, return on `PaymentSent` (recommended)
+
+- Sketch: handle `Event::PaymentSent` in `handler.rs` instead of dropping it. Build the proof
+  there via `prove_payer_derived`, add `payment_preimage: Option<String>` and
+  `payer_proof: Option<String>` to `LightningEvent::PaymentEvent` and to `PayResult`. `json_pay`
+  returns when it sees the enriched event.
+- Affected files: `lampod/src/actions/handler.rs` (~381), `lampo-common/src/event/ln.rs` (~33),
+  `lampo-common/src/model/invoice.rs` (~167), `lampod/src/jsonrpc/offchain.rs` (~96),
+  `lampo-common/src/keys.rs` (expanded-key accessor).
+- Tradeoffs: proof construction lives next to the event that owns the data; closes the preimage
+  FIXME as a side effect. Costs a signing operation on every BOLT12 pay. Requires the `path`
+  correlation above.
+- Effort: M
+
+### Approach B: Build the proof in `json_pay`, pass raw material through the bus
+
+- Sketch: `handler.rs` forwards `PaidBolt12Invoice` + preimage on the event untouched;
+  `json_pay` does the signing and encoding.
+- Affected files: same set, but the LDK proof types leak into `lampo-common`'s event enum, which
+  currently exposes only plain strings.
+- Tradeoffs: keeps the handler dumb and makes disclosure a per-call decision later. But it puts
+  non-`Serialize` LDK types on the event bus, which every subscriber then carries. Given the bus
+  already suffers from oversized payloads under load, this is the wrong direction.
+- Effort: M, worse shape.
+
+### Approach C: New event only, leave `pay` alone
+
+- Sketch: emit a `LightningEvent::PayerProof` on the bus, no RPC change.
+- Affected files: `handler.rs`, `lampo-common/src/event/ln.rs`.
+- Tradeoffs: smallest blast radius, no `path` problem. But the `pay` command gains nothing, which
+  is the actual request.
+- Effort: S, does not meet the goal.
+
+## Recommendation
+
+Approach A. It puts the proof where the data already is, and closes the long-standing missing
+preimage FIXME in the same change.
+
+**Disclosure default: minimal — LDK's own `default_included_types` (payer_id, payment_hash,
+node_id, features) and nothing optional.** An earlier draft of this doc argued the opposite, on
+the grounds that an eager proof the payer could never re-issue should carry the receipt fields.
+Persisting the invoice removes that argument entirely: disclosure becomes reversible, and the
+safe default for a reversible choice is the one that leaks least. Callers opt into
+`offer_description` / `offer_issuer` / `invoice_amount` / `invoice_created_at` at re-issue time.
+`proof_note` is never auto-populated — it is a per-dispute attestation supplied by the caller.
+
+## Open questions
+
+- **Re-issue surface.** Persisting the material implies a way to use it. Smallest thing that
+  works: a `payerproof` RPC taking `payment_id` plus disclosure booleans and an optional
+  `proof_note`. Worth confirming that is wanted now, or whether this cut only persists and the
+  RPC lands separately.
+- **Retention.** Stored invoices accumulate with no expiry. Fine short-term, but the payer is
+  holding proof material for every BOLT12 payment forever — worth a `deletepayerproof` or a
+  retention setting before this is load-bearing.
+- `path` handling — confirm option (1) is worth the correlation state, or accept an empty `path`.
+- Should a failed `prove_payer_derived` (key derivation mismatch, static invoice) log-and-continue
+  with `payer_proof: None`, or fail the pay? Recommend log-and-continue: the payment already
+  succeeded and failing the RPC would misreport it.
+- `json_pay`'s unbounded `events.recv()` loop (FIXME at `offchain.rs:114`) is a known hang source
+  under load. Adding a second event dependency to that loop makes it slightly more fragile; worth
+  bounding it in the same PR or immediately after.
+- `0.3.0-beta1` is a pre-release and BOLT PR #1295 is unmerged, so the proof wire format may still
+  change. Acceptable for now, but the field should not be treated as a stable API yet.

--- a/lampo-common/src/event/ln.rs
+++ b/lampo-common/src/event/ln.rs
@@ -30,8 +30,27 @@ pub enum LightningEvent {
         channel_value_satoshis: u64,
         funding_transaction: Transaction,
     },
+    /// A payment settled. Carries the receipt, and is emitted before the
+    /// terminal [`LightningEvent::PaymentEvent`] so a caller can pick both up.
+    ///
+    /// Kept separate from `PaymentEvent` because the receipt and the hop path
+    /// arrive on different LDK events, and the receipt must not depend on the
+    /// path being known.
+    PaymentReceipt {
+        /// Hex encoded payment id, to match the payment this belongs to.
+        payment_id: String,
+        /// Hex encoded preimage, the receipt of the payment.
+        payment_preimage: String,
+        /// Bech32 encoded BOLT 12 payer proof. Only set for offer payments:
+        /// BOLT 11 and async (static invoice) payments cannot produce one.
+        payer_proof: Option<String>,
+    },
     PaymentEvent {
         state: PaymentState,
+        /// Hex encoded payment id. Subscribers must filter on this: the bus
+        /// broadcasts to every subscriber, so a concurrent `pay` would
+        /// otherwise see another payment's result.
+        payment_id: Option<String>,
         payment_hash: Option<String>,
         path: Vec<PaymentHop>,
         // if the payment failed, we can provide a reason

--- a/lampo-common/src/lib.rs
+++ b/lampo-common/src/lib.rs
@@ -43,6 +43,7 @@ pub mod chan {
 pub use async_trait::async_trait;
 pub use bitcoin;
 pub use bitcoin::secp256k1;
+pub use hex;
 
 pub mod btc_rpc {
     use serde::{Deserialize, Serialize};

--- a/lampo-common/src/model/invoice.rs
+++ b/lampo-common/src/model/invoice.rs
@@ -168,7 +168,11 @@ pub mod response {
         pub path: Vec<PaymentHop>,
         pub payment_hash: Option<String>,
         pub state: PaymentState,
-        // FIXME: missing payment preimage
+        /// Hex encoded preimage, the receipt of the payment.
+        pub payment_preimage: Option<String>,
+        /// Bech32 encoded BOLT 12 payer proof, proving to a third party that
+        /// this node paid the invoice. Only set for settled offer payments.
+        pub payer_proof: Option<String>,
     }
 
     #[derive(Debug, Clone, Serialize, Deserialize, Apiv2Schema, PartialEq)]

--- a/lampod/src/actions/handler.rs
+++ b/lampod/src/actions/handler.rs
@@ -17,12 +17,15 @@ use lampo_common::handler::Handler as EventHandler;
 use lampo_common::json;
 use lampo_common::jsonrpc::Request;
 use lampo_common::ldk;
+use lampo_common::ldk::sign::NodeSigner;
 use lampo_common::model::response::PaymentHop;
 use lampo_common::model::response::PaymentState;
 
 use crate::chain::{LampoChainManager, WalletManager};
 use crate::command::Command;
+use crate::ln::payer_proof::{self, PayerProofRecord};
 use crate::ln::{LampoChannelManager, LampoInventoryManager, LampoPeerManager};
+use crate::persistence::LampoPersistence;
 use crate::LampoDaemon;
 
 use super::Handler;
@@ -33,6 +36,7 @@ pub struct LampoHandler {
     inventory_manager: Arc<LampoInventoryManager>,
     wallet_manager: Arc<dyn WalletManager>,
     chain_manager: Arc<LampoChainManager>,
+    persister: Arc<LampoPersistence>,
     external_handlers: RwLock<Vec<Arc<dyn ExternalHandler>>>,
     #[allow(dead_code)]
     emitter: Emitter<Event>,
@@ -49,6 +53,7 @@ impl LampoHandler {
             inventory_manager: lampod.inventory_manager(),
             wallet_manager: lampod.wallet_manager(),
             chain_manager: lampod.onchain_manager(),
+            persister: lampod.persister(),
             external_handlers: RwLock::new(Vec::new()),
             emitter,
             subscriber,
@@ -378,12 +383,64 @@ impl Handler for LampoHandler {
                 // FIXME: make peristent these information
                 Ok(())
             }
-            ldk::events::Event::PaymentSent { .. } => {
-                log::info!("payment sent: `{:?}`", event);
+            ldk::events::Event::PaymentSent {
+                payment_id,
+                payment_preimage,
+                payment_hash,
+                bolt12_invoice,
+                ..
+            } => {
+                log::info!(
+                    target: "lampo::handler",
+                    "payment sent: id `{payment_id:?}`, bolt12 payer proof available: {}",
+                    bolt12_invoice.is_some()
+                );
+                let Some(payment_id) = payment_id else {
+                    // Without an id the receipt cannot be matched to the `pay`
+                    // call that is waiting for it, so there is nothing to emit.
+                    return Ok(());
+                };
+                let record = PayerProofRecord {
+                    preimage: payment_preimage,
+                    invoice: bolt12_invoice,
+                };
+
+                // Build the proof from the material in hand rather than from
+                // storage, so the receipt does not depend on the write below.
+                let expanded_key = self
+                    .wallet_manager
+                    .ldk_keys()
+                    .keys_manager
+                    .get_expanded_key();
+                let payer_proof = payer_proof::build(&record, &expanded_key, payment_id);
+
+                self.emit(Event::Lightning(LightningEvent::PaymentReceipt {
+                    payment_id: lampo_common::hex::encode(payment_id.0),
+                    payment_preimage: lampo_common::hex::encode(record.preimage.0),
+                    payer_proof,
+                }));
+
+                // This is the only event carrying the paid BOLT 12 invoice, and the
+                // proof cannot be rebuilt without it. Keep it so the proof can be
+                // re-issued later with a wider disclosure. The payment already
+                // settled and the receipt is already out, so a storage failure
+                // only costs us the ability to re-issue.
+                //
+                // Only BOLT 12 payments are worth keeping: a BOLT 11 record holds
+                // a preimage and nothing else, can never build a proof, and
+                // nothing prunes it.
+                if record.invoice.is_some() {
+                    if let Err(err) = payer_proof::store(&self.persister, &payment_hash, &record) {
+                        log::error!(target: "lampo::handler", "storing payer proof material: {err}");
+                    }
+                }
                 Ok(())
             }
             ldk::events::Event::PaymentPathSuccessful {
-                payment_hash, path, ..
+                payment_id,
+                payment_hash,
+                path,
+                ..
             } => {
                 let path = path
                     .hops
@@ -392,6 +449,7 @@ impl Handler for LampoHandler {
                     .collect::<Vec<PaymentHop>>();
                 let hop = LightningEvent::PaymentEvent {
                     state: PaymentState::Success,
+                    payment_id: Some(lampo_common::hex::encode(payment_id.0)),
                     payment_hash: payment_hash.map(|hash| hash.to_string()),
                     path,
                     reason: None,
@@ -447,6 +505,7 @@ impl Handler for LampoHandler {
 
                 let hop = LightningEvent::PaymentEvent {
                     state: PaymentState::Failure,
+                    payment_id: Some(lampo_common::hex::encode(payment_id.0)),
                     payment_hash: payment_hash.map(|hash| hash.to_string()),
                     path: vec![],
                     reason: Some(detailed_reason),

--- a/lampod/src/jsonrpc/offchain.rs
+++ b/lampod/src/jsonrpc/offchain.rs
@@ -4,6 +4,7 @@ use std::str::FromStr;
 use lampo_common::event::ln::LightningEvent;
 use lampo_common::event::Event;
 use lampo_common::handler::Handler;
+use lampo_common::hex;
 use lampo_common::jsonrpc::{Error, RpcError};
 use lampo_common::ldk;
 use lampo_common::ldk::offers::offer;
@@ -98,19 +99,28 @@ pub async fn json_pay(ctx: &LampoDaemon, request: &json::Value) -> Result<json::
     let request: Pay = json::from_value(request.clone())?;
     let mut events = ctx.handler().events();
 
-    if let Ok(_) = offer::Offer::from_str(&request.invoice_str) {
+    let payment_id = if let Ok(_) = offer::Offer::from_str(&request.invoice_str) {
         log::debug!("Paying offer with bolt12 invoice: {}", request.invoice_str);
         let payer_note = request.bolt12.and_then(|x| x.payer_note);
         ctx.offchain_manager()
-            .pay_offer(&request.invoice_str, request.amount, payer_note)?;
+            .pay_offer(&request.invoice_str, request.amount, payer_note)?
     } else {
         log::debug!(
             "Paying invoice with bolt11 invoice: {}",
             request.invoice_str
         );
         ctx.offchain_manager()
-            .pay_invoice(&request.invoice_str, request.amount)?;
-    }
+            .pay_invoice(&request.invoice_str, request.amount)?
+    };
+    // The event bus broadcasts to every subscriber, so a concurrent `pay` would
+    // otherwise see this payment's result -- and now its preimage and payer
+    // proof too. Only accept events carrying our own payment id.
+    let payment_id = hex::encode(payment_id.0);
+
+    // The receipt lands on `PaymentReceipt` and the hop path on the terminal
+    // `PaymentEvent`, so hold the receipt until the payment finishes.
+    let mut receipt: Option<(String, Option<String>)> = None;
+
     // FIXME: this will loop when the Payment event is not generated
     loop {
         log::warn!("Waiting for payment event...");
@@ -120,18 +130,34 @@ pub async fn json_pay(ctx: &LampoDaemon, request: &json::Value) -> Result<json::
             data: None,
         }))?;
 
-        if let Event::Lightning(LightningEvent::PaymentEvent {
-            payment_hash,
-            path,
-            state,
-            reason: _,
-        }) = event
-        {
-            return Ok(json::to_value(PayResult {
-                state,
-                path,
+        match event {
+            Event::Lightning(LightningEvent::PaymentReceipt {
+                payment_id: id,
+                payment_preimage,
+                payer_proof,
+            }) if id == payment_id => {
+                receipt = Some((payment_preimage, payer_proof));
+            }
+            Event::Lightning(LightningEvent::PaymentEvent {
+                payment_id: Some(id),
                 payment_hash,
-            })?);
+                path,
+                state,
+                reason: _,
+            }) if id == payment_id => {
+                let (payment_preimage, payer_proof) = match receipt {
+                    Some((preimage, proof)) => (Some(preimage), proof),
+                    None => (None, None),
+                };
+                return Ok(json::to_value(PayResult {
+                    state,
+                    path,
+                    payment_hash,
+                    payment_preimage,
+                    payer_proof,
+                })?);
+            }
+            _ => {}
         }
     }
 }

--- a/lampod/src/lib.rs
+++ b/lampod/src/lib.rs
@@ -134,6 +134,10 @@ impl LampoDaemon {
         self.conf.clone()
     }
 
+    pub fn persister(&self) -> Arc<LampoPersistence> {
+        self.persister.clone()
+    }
+
     pub fn init_onchaind(&mut self, client: Arc<dyn Backend>) -> error::Result<()> {
         log::debug!(target: "lampod", "init onchaind ..");
         let onchain_manager = LampoChainManager::new(client, self.wallet_manager.clone());

--- a/lampod/src/ln/mod.rs
+++ b/lampod/src/ln/mod.rs
@@ -4,6 +4,7 @@ mod inventory_manager;
 mod offchain_manager;
 mod peer_manager;
 
+pub mod payer_proof;
 pub mod peer_event;
 
 pub use channel_manager::LampoChannelManager;

--- a/lampod/src/ln/offchain_manager.rs
+++ b/lampod/src/ln/offchain_manager.rs
@@ -106,7 +106,7 @@ impl OffchainManager {
         offer_str: &str,
         amount_msat: Option<u64>,
         payer_note: Option<String>,
-    ) -> error::Result<()> {
+    ) -> error::Result<PaymentId> {
         // check if it is an invoice or an offer
         let offer_hash = Sha256::hash(offer_str.as_bytes());
         let payment_id = PaymentId(*offer_hash.as_ref());
@@ -135,10 +135,14 @@ impl OffchainManager {
                 },
             )
             .map_err(|err| error::anyhow!("{:?}", err))?;
-        Ok(())
+        Ok(payment_id)
     }
 
-    pub fn pay_invoice(&self, invoice_str: &str, amount_msat: Option<u64>) -> error::Result<()> {
+    pub fn pay_invoice(
+        &self,
+        invoice_str: &str,
+        amount_msat: Option<u64>,
+    ) -> error::Result<PaymentId> {
         // check if it is an invoice or an offer
         let invoice = self.decode_invoice(invoice_str)?;
         let payment_id = PaymentId(invoice.payment_hash().0);
@@ -162,7 +166,7 @@ impl OffchainManager {
                 },
             )
             .map_err(|err| error::anyhow!("{:?}", err))?;
-        Ok(())
+        Ok(payment_id)
     }
 
     pub fn keysend(&self, destination: pubkey, amount_msat: u64) -> error::Result<PaymentHash> {

--- a/lampod/src/ln/payer_proof.rs
+++ b/lampod/src/ln/payer_proof.rs
@@ -1,0 +1,198 @@
+//! BOLT 12 payer proof material.
+//!
+//! LDK hands us the paid invoice on `Event::PaymentSent` and nowhere else, so we
+//! store it together with the preimage. Disclosure is committed to when the proof
+//! is signed, which means a proof cannot be widened after the fact: rebuilding it
+//! with more disclosed fields requires the original invoice.
+//!
+//! Nothing else needs storing. The payer signing key is re-derived from the
+//! invoice's own payer metadata, and the `ExpandedKey` behind that derivation
+//! comes from the node seed.
+use std::sync::Arc;
+
+use lampo_common::error;
+use lampo_common::ldk::events::PaidBolt12Invoice;
+use lampo_common::ldk::io::{Cursor, ErrorKind};
+use lampo_common::ldk::ln::channelmanager::PaymentId;
+use lampo_common::ldk::ln::inbound_payment::ExpandedKey;
+use lampo_common::ldk::types::payment::{PaymentHash, PaymentPreimage};
+use lampo_common::ldk::util::persist::KVStoreSync;
+use lampo_common::ldk::util::ser::{Readable, Writeable};
+use lampo_common::secp256k1::Secp256k1;
+
+use crate::persistence::LampoPersistence;
+
+/// Namespace holding the payer proof material, keyed by hex payment id.
+///
+/// FIXME: records are never pruned, so a node accumulates one invoice per BOLT 12
+/// payment forever. Needs a retention policy, or an RPC to drop a record once the
+/// payer no longer cares about proving that payment.
+pub const PAYER_PROOF_NAMESPACE: &str = "payer_proofs";
+
+/// Layout version of a stored record, so the format can change later without
+/// misreading old entries.
+const RECORD_VERSION: u8 = 1;
+
+/// Byte offsets in an encoded record: version, then preimage, then the flag
+/// saying whether an invoice follows.
+const PREIMAGE_START: usize = 1;
+const PREIMAGE_END: usize = PREIMAGE_START + 32;
+const INVOICE_FLAG: usize = PREIMAGE_END;
+const HEADER_LEN: usize = INVOICE_FLAG + 1;
+
+/// What is needed to (re)build a payer proof for a settled payment.
+pub struct PayerProofRecord {
+    pub preimage: PaymentPreimage,
+    /// `None` for BOLT 11 payments, which have no payer proof.
+    pub invoice: Option<PaidBolt12Invoice>,
+}
+
+impl PayerProofRecord {
+    fn encode(&self) -> Vec<u8> {
+        let mut buf = Vec::new();
+        buf.push(RECORD_VERSION);
+        buf.extend_from_slice(&self.preimage.0);
+        match &self.invoice {
+            Some(invoice) => {
+                buf.push(1);
+                buf.extend_from_slice(&invoice.encode());
+            }
+            None => buf.push(0),
+        }
+        buf
+    }
+
+    fn decode(buf: &[u8]) -> error::Result<Self> {
+        if buf.len() < HEADER_LEN {
+            error::bail!("payer proof record too short: {} bytes", buf.len());
+        }
+        if buf[0] != RECORD_VERSION {
+            error::bail!("unsupported payer proof record version {}", buf[0]);
+        }
+
+        let mut preimage = [0u8; 32];
+        preimage.copy_from_slice(&buf[PREIMAGE_START..PREIMAGE_END]);
+
+        let invoice = match buf[INVOICE_FLAG] {
+            0 => None,
+            1 => {
+                let mut cursor = Cursor::new(&buf[HEADER_LEN..]);
+                Some(
+                    <PaidBolt12Invoice as Readable>::read(&mut cursor)
+                        .map_err(|err| error::anyhow!("decoding paid invoice: {:?}", err))?,
+                )
+            }
+            flag => error::bail!("unknown payer proof invoice flag {flag}"),
+        };
+
+        Ok(Self {
+            preimage: PaymentPreimage(preimage),
+            invoice,
+        })
+    }
+}
+
+/// Records are keyed by payment hash, not payment id.
+///
+/// `pay_offer` derives the payment id from the offer string alone, so every
+/// payment of a reusable offer shares one id and would overwrite the previous
+/// record. The payment hash is unique per payment, and it is also what a caller
+/// already holds from the `pay` response.
+fn key(payment_hash: &PaymentHash) -> String {
+    lampo_common::hex::encode(payment_hash.0)
+}
+
+/// Persist the material for `payment_hash`, overwriting any earlier record.
+///
+/// This takes the concrete store on purpose. Lampo has one backend today, and
+/// designing a persistence interface around a single implementation is how you
+/// get the wrong interface; that work is happening separately, against a real
+/// second backend.
+pub fn store(
+    persister: &Arc<LampoPersistence>,
+    payment_hash: &PaymentHash,
+    record: &PayerProofRecord,
+) -> error::Result<()> {
+    persister.write(
+        PAYER_PROOF_NAMESPACE,
+        "",
+        &key(payment_hash),
+        record.encode(),
+    )?;
+    Ok(())
+}
+
+/// Load the material for `payment_hash`, if any was stored.
+pub fn load(
+    persister: &Arc<LampoPersistence>,
+    payment_hash: &PaymentHash,
+) -> error::Result<Option<PayerProofRecord>> {
+    match persister.read(PAYER_PROOF_NAMESPACE, "", &key(payment_hash)) {
+        Ok(buf) => Ok(Some(PayerProofRecord::decode(&buf)?)),
+        Err(err) if err.kind() == ErrorKind::NotFound => Ok(None),
+        Err(err) => Err(err.into()),
+    }
+}
+
+/// Build a bech32 payer proof disclosing only the fields LDK includes by
+/// default. Widening the disclosure is a separate, explicit decision: a proof
+/// cannot be narrowed once handed out.
+///
+/// Returns `None` when the payment cannot produce one (BOLT 11, or an async
+/// payment settled against a static invoice) — that is not an error, the payment
+/// itself still succeeded.
+pub fn build(
+    record: &PayerProofRecord,
+    expanded_key: &ExpandedKey,
+    payment_id: PaymentId,
+) -> Option<String> {
+    let invoice = record.invoice.as_ref()?;
+    let secp_ctx = Secp256k1::new();
+
+    let builder = invoice
+        .prove_payer_derived(record.preimage, expanded_key, payment_id, &secp_ctx)
+        .map_err(|err| {
+            log::warn!(target: "lampo::payer_proof", "cannot build payer proof: {err:?}");
+        })
+        .ok()?;
+
+    builder
+        .build_and_sign()
+        .map(|proof| proof.to_string())
+        .map_err(|err| {
+            log::warn!(target: "lampo::payer_proof", "cannot sign payer proof: {err:?}");
+        })
+        .ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn record_without_invoice_roundtrips() {
+        let record = PayerProofRecord {
+            preimage: PaymentPreimage([7u8; 32]),
+            invoice: None,
+        };
+        let decoded = PayerProofRecord::decode(&record.encode()).unwrap();
+        assert_eq!(decoded.preimage.0, [7u8; 32]);
+        assert!(decoded.invoice.is_none());
+    }
+
+    #[test]
+    fn decode_rejects_truncated_record() {
+        assert!(PayerProofRecord::decode(&[RECORD_VERSION, 0, 0]).is_err());
+    }
+
+    #[test]
+    fn decode_rejects_unknown_version() {
+        let mut buf = PayerProofRecord {
+            preimage: PaymentPreimage([1u8; 32]),
+            invoice: None,
+        }
+        .encode();
+        buf[0] = RECORD_VERSION + 1;
+        assert!(PayerProofRecord::decode(&buf).is_err());
+    }
+}

--- a/tests/tests/src/lampo_tests.rs
+++ b/tests/tests/src/lampo_tests.rs
@@ -1,7 +1,11 @@
 //! Integration tests between lampo nodes.
 //!
 //! Author: Vincenzo Palazzo <vincenzopalazzo@member.fsf.org>
+use std::str::FromStr;
 use std::sync::Arc;
+
+use lampo_common::hex;
+use lampo_common::ldk::offers::payer_proof::PayerProof;
 
 use lampo_common::error;
 use lampo_common::event::ln::LightningEvent;
@@ -143,6 +147,16 @@ pub async fn pay_invoice_simple_case_lampo() -> error::Result<()> {
         )
         .await?;
     log::info!(target: &node2.info.node_id, "payment made `{:?}`", pay);
+
+    // BOLT 11 has no payer proof, but the preimage is still the receipt.
+    assert!(
+        pay.payment_preimage.is_some(),
+        "a settled bolt11 payment must expose its preimage"
+    );
+    assert!(
+        pay.payer_proof.is_none(),
+        "bolt11 payments cannot produce a payer proof"
+    );
     Ok(())
 }
 
@@ -181,6 +195,33 @@ pub async fn pay_offer_simple_case_lampo() -> error::Result<()> {
         )
         .await?;
     log::info!(target: &node2.info.node_id, "payment made `{:?}`", pay);
+
+    // Paying an offer must hand back a payer proof a third party can check
+    // against the payment we actually made.
+    let preimage = pay
+        .payment_preimage
+        .expect("a settled offer payment must expose its preimage");
+    // There is no separate verify entry point: LDK runs the checks while
+    // parsing, in `TryFrom<Vec<u8>> for PayerProof`. Parsing here is the
+    // verification, and it covers preimage against payment hash, the invoice
+    // signature against the issuer key, and the payer signature over the
+    // merkle root.
+    let proof = PayerProof::from_str(
+        &pay.payer_proof
+            .expect("a settled offer payment must expose a payer proof"),
+    )
+    .expect("the payer proof must verify");
+
+    assert_eq!(
+        proof.payment_hash().to_string(),
+        pay.payment_hash.unwrap(),
+        "the proof must commit to the hash of the payment we made"
+    );
+    assert_eq!(
+        hex::encode(proof.payment_preimage().0),
+        preimage,
+        "the proof must carry the same preimage the RPC returned"
+    );
     Ok(())
 }
 


### PR DESCRIPTION
Two commits, reviewable independently. The second depends on the first: the `payer_proof` module does not exist at the rev we were pinned to.

## `build: move LDK 0.3 to the crates.io release`

- LDK 0.3 is now published as `0.3.0-beta1`, so drop the git pin on the upstream `0.3` branch and pull every `lightning*` crate from the registry
- The published beta is **96 commits ahead** of the rev we were pinned to (`84605cf`)
- The requirement spells out `0.3.0-beta1` on purpose -- a bare `0.3` does not match pre-release versions
- `Cargo.lock` still pins exact versions, so builds stay reproducible without the git source
- `deny.toml` sets `allow-git = []`; removing the last git dep drops that exception

No API drift. `lightning-macros` moves `0.2.2+git` -> `0.2.1`, which is just the released equivalent of the in-tree version.

## `node: attach BOLT 12 payer proof to pay response`

`pay` on an offer now returns a bech32 `payer_proof` plus the `payment_preimage`, so the payer can prove to a third party that they paid that invoice.

- `Event::PaymentSent` was being discarded. It is the only event carrying the paid invoice, so the handler now stores that invoice plus the preimage under the payment id.
- Only those two things are stored. The payer signing key is re-derived from the invoice's own payer metadata, so no nonce is needed, and the payment id is recoverable from the same metadata (kept only as the lookup key).
- We store rather than build-and-forget because disclosure is committed to at signing time: widening a proof later means rebuilding it from the original invoice.
- Disclosure defaults to LDK's minimal set. A proof can be widened later but never narrowed once handed out.
- `PaymentPathSuccessful` remains the event that ends the pay call, so `PayResult.path` is unchanged. Returning on `PaymentSent` instead would have silently emptied it -- that event carries no hop data.
- Closes the `FIXME: missing payment preimage` on `PayResult`.
- BOLT 11 and async (static invoice) payments cannot produce a proof and report `payer_proof: null` rather than failing.

Design notes in `docs/brainstorms/2026-08-09-attach-payer-proof-to-pay-response.md`.

Known gap, marked FIXME: stored records are never pruned, so a node keeps one invoice per BOLT 12 payment indefinitely. Wants a retention policy or a drop RPC before this is load-bearing.

## Test plan

- `cargo check --workspace --all-targets`, `cargo test`, `cargo build --release`, `cargo fmt --all -- --check` -- all clean
- Single-LDK-version guard from `build.yml` run locally
- 3 unit tests on the stored record: roundtrip, truncated input, unknown version
- `pay_offer_simple_case_lampo` now parses the returned proof and asserts its `payment_hash` and `payment_preimage` match what the RPC reported -- this exercises the whole chain, LDK really produces a valid proof
- `pay_invoice_simple_case_lampo` asserts the BOLT 11 case yields a preimage but no proof
- Payment/channel integration tests run individually: all pass

Note the integration job is flaky under parallel load, unrelated to either commit -- see the earlier comment on this PR.