### PR TITLE
lampod: honor the public flag in fundchannel

### DIFF
--- a/lampod/src/ln/channel_manager.rs
+++ b/lampod/src/ln/channel_manager.rs
@@ -244,6 +244,14 @@ impl LampoChannelManager {
         &self,
         open_channel: request::OpenChannel,
     ) -> error::Result<response::OpenChannel> {
+        // The caller decides whether this channel is announced. Passing the
+        // global config unmodified here silently dropped `public`: LDK's
+        // `announce_for_forwarding` defaults to false, so every channel came
+        // up unannounced no matter what the caller asked for, and a payment
+        // could never route *through* a lampo node — gossip never learned
+        // its channels existed.
+        let mut config = self.conf.ldk_conf.clone();
+        config.channel_handshake_config.announce_for_forwarding = open_channel.public;
         self.manager()
             .create_channel(
                 open_channel.node_id()?,
@@ -251,7 +259,7 @@ impl LampoChannelManager {
                 0,
                 0,
                 None,
-                Some(self.conf.ldk_conf.clone()),
+                Some(config),
             )
             .map_err(|err| error::anyhow!("{:?}", err))?;
 

--- a/tests/tests/src/lampo_tests.rs
+++ b/tests/tests/src/lampo_tests.rs
@@ -111,6 +111,91 @@ pub async fn fund_a_simple_channel_from() -> error::Result<()> {
     Ok(())
 }
 
+/// `fundchannel` must honor the `public` flag it accepts.
+///
+/// This used to fail: `open_channel` parsed `public` into the request and
+/// then handed LDK the global `ldk_conf`, whose `announce_for_forwarding`
+/// is false by default. Every channel came up unannounced no matter what
+/// the caller asked for, so gossip never learned the channel existed and
+/// nothing could be routed *through* a lampo node -- while `fundchannel`
+/// returned success and reported the channel as whatever was requested.
+///
+/// `public` on the channel list is LDK's own `ChannelDetails::is_announced`
+/// ("true if this channel is (or will be) publicly-announced"), so this
+/// asserts the negotiated state rather than echoing the request back.
+#[tokio_test_shutdown_timeout::test(5)]
+pub async fn fundchannel_honors_the_public_flag() -> error::Result<()> {
+    init();
+
+    // Both directions are pinned: asserting only the announced case would
+    // still pass if the flag were hardcoded the other way.
+    for announce in [true, false] {
+        let node1 = LampoTesting::tmp().await?;
+        let node2 = Arc::new(LampoTesting::new(node1.btc.clone()).await?);
+
+        let _: response::Connect = node2
+            .lampod()
+            .call(
+                "connect",
+                request::Connect {
+                    node_id: node1.info.node_id.clone(),
+                    addr: "127.0.0.1".to_owned(),
+                    port: node1.port,
+                },
+            )
+            .await
+            .unwrap();
+
+        let mut events = node2.lampod().events();
+        let response: json::Value = node1
+            .lampod()
+            .call(
+                "fundchannel",
+                request::OpenChannel {
+                    node_id: node2.info.node_id.clone(),
+                    amount: 100000,
+                    public: announce,
+                    port: None,
+                    addr: None,
+                },
+            )
+            .await
+            .unwrap();
+        assert!(response.get("tx").is_some());
+        node2.fund_wallet(10).await.unwrap();
+
+        async_wait!(async {
+            while let Some(event) = events.recv().await {
+                if let Event::Lightning(LightningEvent::ChannelReady { .. }) = event {
+                    return Ok(());
+                }
+                let channels: response::Channels = node1
+                    .lampod()
+                    .call("channels", json::json!({}))
+                    .await
+                    .unwrap();
+                if channels.channels.iter().any(|chan| chan.ready) {
+                    return Ok(());
+                }
+            }
+            Err(())
+        });
+
+        // The opener is the side that chose the flag, so assert there.
+        let channels: response::Channels = node1.lampod().call("channels", json::json!({})).await?;
+        let channel = channels
+            .channels
+            .first()
+            .expect("the channel we just opened should be listed");
+        assert_eq!(
+            channel.public, announce,
+            "asked for public={announce}, got public={} -- the flag was ignored",
+            channel.public
+        );
+    }
+    Ok(())
+}
+
 #[tokio_test_shutdown_timeout::test(5)]
 pub async fn pay_invoice_simple_case_lampo() -> error::Result<()> {
     init();


### PR DESCRIPTION
## Summary

- `fundchannel` accepted a `public` flag and silently ignored it: `open_channel` parsed it into the request and then handed LDK the global `ldk_conf`, whose `announce_for_forwarding` is false by default. Every channel came up unannounced regardless of what the caller asked for.
- Consequence: gossip never learned the channel existed, so nothing could be routed *through* a lampo node — while `fundchannel` returned success with no error or warning.
- Fix derives the handshake config from the request, matching ldk-node's approach in [`src/lib.rs`](https://github.com/lightningdevkit/ldk-node/blob/main/src/lib.rs) (`user_config.channel_handshake_config.announce_for_forwarding = announce_for_forwarding;` before `create_channel`).
- Adds a regression test asserting both directions.

## How it was found

Running a three-node routing topology (S → M → R). The route was found and the first hop accepted, but the second hop failed permanently:

```
PaymentPathFailed { failure: OnPath {
  ChannelFailure { short_channel_id: 1099628412933, is_permanent: true } } }
payment failed with reason: Some(RouteNotFound)
```

M's real channels were scid `4056098394931201` and `4064894487953408` — the route's second hop referenced neither, because with no announced channels the only candidate path came from the invoice's route hint. Liquidity was never the issue: M held `available_balance_for_send_msat: 989340000` against a 50 000 sat payment.

After the fix, the same topology settles a real two-hop payment:

```
PASS: payment routed S -> M -> R (preimage 9818741d3d992c9d...)
```

## Why the existing tests missed it

`fund_a_simple_channel_from` already opens with `public: true` — it just never asserted the result. The new test reads `channels[].public`, which maps to LDK's `ChannelDetails::is_announced` ("true if this channel is (or will be) publicly-announced"), so it checks negotiated state rather than echoing the request back. It asserts both `true` and `false` so the flag is pinned, not just this one bug.

Verified both ways:

- fix reverted → `assertion failed: asked for public=true, got public=false -- the flag was ignored`
- fix applied → `test result: ok. 1 passed`

## Decision Log

**Hardest decision:** whether to also port ldk-node's `may_announce_channel` guard, which refuses to open an announced channel unless the node has both a `node_alias` and a listening address, and degrades `default_user_config` to unannounced when it can't announce. I left it out. It is a real gap — announcing from a node with no advertised address publishes an edge saying "route through me" to somewhere unreachable — but it is a separate behavioural change with its own config surface, and bundling it would make a three-line correctness fix into a policy decision. Worth a follow-up issue.

**Alternatives rejected:**
- Set `announce_for_forwarding` globally from config instead of per-channel: loses the per-channel choice the API already advertises, and diverges from ldk-node.
- Reject `public: true` outright as unsupported: honest, but strictly worse — announced channels demonstrably work, as the routed payment above shows.

**Least confident about:** interaction with `force_announced_channel_preference` on the acceptor side. `lampod-cli` already sets it to `false` in both startup paths, so peers accept either preference and this fix cannot make previously-working opens start failing. I checked that specifically before committing, but it is the place a subtle regression would hide.

## Test plan

- [ ] CI passes
- [x] `fundchannel_honors_the_public_flag` fails without the fix, passes with it
- [x] Multi-hop payment S → M → R settles with a real preimage on regtest
- [ ] Note: the full suite run in parallel is flaky on macOS with `libcurl … bad argument` in `fund_wallet`. This reproduces on **clean main** (4/9 failed there, unrelated to this change), so it is pre-existing contention, not a regression from this PR. Individually, the affected tests pass.
