### PR TITLE
lampod: handle ConnectionNeeded so BOLT12 offers can be delivered

### DIFF
--- a/lampod/src/actions/handler.rs
+++ b/lampod/src/actions/handler.rs
@@ -1,4 +1,5 @@
 //! Handler module implementation that
+use std::net::SocketAddr;
 use std::sync::Arc;
 
 use lampo_common::bitcoin::absolute::Height;
@@ -523,6 +524,51 @@ impl Handler for LampoHandler {
                     reason: Some(detailed_reason),
                 };
                 self.emit(Event::Lightning(hop));
+                Ok(())
+            }
+            ldk::events::Event::ConnectionNeeded { node_id, addresses } => {
+                // LDK cannot deliver an onion message to a node it has no
+                // connection to, and asks us to open one. Dropping this is
+                // why BOLT12 offers failed with `InvoiceRequestExpired`
+                // whenever the blinded path's introduction node was not
+                // already a peer: the invoice request was never sent at all.
+                //
+                // Connecting blocks until the peer disconnects, so it runs on
+                // its own task -- the event handler must not stall the whole
+                // LDK event loop on a single dial. Addresses are tried in
+                // order, stopping at the first that connects, as ldk-node does.
+                let peer_manager = self.peer_manager.clone();
+                tokio::spawn(async move {
+                    for address in addresses {
+                        // Only the plain TCP forms can be dialled directly.
+                        // Onion and hostname addresses need a proxy/resolver
+                        // lampo does not have, so they are skipped rather than
+                        // counted as a failure to connect.
+                        let host = match address {
+                            ldk::ln::msgs::SocketAddress::TcpIpV4 { addr, port } => {
+                                SocketAddr::from((std::net::Ipv4Addr::from(addr), port))
+                            }
+                            ldk::ln::msgs::SocketAddress::TcpIpV6 { addr, port } => {
+                                SocketAddr::from((std::net::Ipv6Addr::from(addr), port))
+                            }
+                            other => {
+                                log::warn!(target: "lampo::handler", "cannot dial `{other:?}` for `{node_id}`: unsupported address type");
+                                continue;
+                            }
+                        };
+                        log::info!(target: "lampo::handler", "connecting to `{node_id}` at `{host}` to deliver an onion message");
+                        // `Ok` is shadowed by `lampo_common::error::Ok` (a
+                        // function) in this module, so the variant has to be
+                        // spelled out in pattern position.
+                        match peer_manager.connect(node_id, host).await {
+                            std::result::Result::Ok(()) => return,
+                            Err(err) => {
+                                log::warn!(target: "lampo::handler", "failed to connect to `{node_id}` at `{host}`: {err}");
+                            }
+                        }
+                    }
+                    log::error!(target: "lampo::handler", "no reachable address for `{node_id}`; an onion message to it will not be delivered");
+                });
                 Ok(())
             }
             _ => {


### PR DESCRIPTION
## Summary

- LDK emits `ConnectionNeeded` when it has an onion message for a node it is not connected to. lampo fell through to the catch-all arm, logged `unhandled ldk event`, and dropped it — so the invoice request was never sent and the payment died with `InvoiceRequestExpired`.
- This makes **any BOLT12 offer unpayable whenever the blinded path's introduction node is not already a peer**, which is the normal case for a multi-hop payment. Offers only ever worked between two directly-connected nodes, which is exactly the shape the existing tests cover.
- Handles the event by dialling the supplied addresses, matching [ldk-node](https://github.com/lightningdevkit/ldk-node/blob/main/src/event.rs).

## Reproduction

Three-node regtest topology, S → M → R, liquidity pointing at R on both hops.

A bolt11 invoice from R routes fine:

```
PASS: payment routed S -> M -> R (preimage 0dcc9a5f6bd71b4f...)
```

An offer from the same node, over the same channels, fails:

```
offer pay result: {"path":[],"payment_hash":null,"state":"Failure",...}
payment failed with reason: Some(InvoiceRequestExpired)
```

`payment_hash` is null — it never becomes a payment at all, it dies in the onion-message round trip. On the payer:

```
WARN lampo::handler unhandled ldk event: ConnectionNeeded {
    node_id: PublicKey(...), addresses: [TcpIpV4 { addr: [127, 0, 0, 1] ... }]
}
```

LDK supplied a working address and lampo ignored it. With this patch the same run settles:

```
PASS: BOLT12 offer routed S -> M -> R (preimage aeecf8a0a38d7413...)
```

Verified the handler is what did it, rather than assuming: the payer ends the run with **2 peers** (it is only ever told to connect to M — the second peer is R, dialled on LDK's request), and the `unhandled ldk event` line is gone.

Note that reproducing this needs the node announcements to have propagated first. Attempting the offer immediately after the channels go ready yields `addresses: []`, because lampo's announcer ticks once a minute and only fires once a channel is announced — that empty list is a gossip race, not this bug.

## Decision Log

**Hardest decision:** whether to dial inline or spawn. `peer_manager::connect` does not return until the peer disconnects, so awaiting it inside the event handler would park the LDK event loop for the lifetime of the connection. Spawning is what ldk-node does and is the only workable option, but it means a failed dial surfaces only in the log rather than back to LDK — which is also true of ldk-node.

**Alternatives rejected:**
- Convert via a `SocketAddr: TryFrom<SocketAddress>` impl: no such impl exists in LDK 0.3, so the variants are matched explicitly.
- Treat onion/hostname addresses as connection failures: they are skipped with a distinct warning instead, since lampo has no proxy or resolver to dial them and conflating the two would misreport why delivery failed.

**Least confident about:** repeated `ConnectionNeeded` events for the same node spawning overlapping dials. `connect_outbound` returning early when a peer already exists makes that cheap rather than harmful, but I have not stress-tested a burst of offers to the same unconnected introduction node.

## Test plan

- [ ] CI passes
- [x] Multi-hop offer fails with `InvoiceRequestExpired` before this patch
- [x] Same topology settles with a real preimage after it
- [x] Payer gains the expected extra peer; no `unhandled ldk event` remains
- [ ] Existing offer tests (`pay_offer_simple_case_lampo`, `pay_offer_minimal_offer`) still pass — they are direct-channel cases this path does not touch
