### PR TITLE
lampod: reconnect to channel counterparties automatically

### DIFF
--- a/lampod/src/actions/handler.rs
+++ b/lampod/src/actions/handler.rs
@@ -71,6 +71,10 @@ impl LampoHandler {
         Ok(())
     }
 
+    pub fn peer_manager(&self) -> Arc<LampoPeerManager> {
+        self.peer_manager.clone()
+    }
+
     /// Call any method supported by the lampod configuration. This includes
     /// a lot of handler code. This function serves as a broker pattern in some ways,
     /// but it may also function as a chain of responsibility pattern in certain cases.

--- a/lampod/src/ln/peer_manager.rs
+++ b/lampod/src/ln/peer_manager.rs
@@ -168,6 +168,57 @@ impl LampoPeerManager {
             .unwrap_or_else(|| "127.0.0.1".to_string());
         let bind_addr = format!("{bind_host}:{listen_port}");
 
+        // Reconnect to channel counterparties. LDK never redials anyone:
+        // after a restart (or any TCP drop) a node with live, ready channels
+        // sits at zero peers forever -- it stops forwarding and cannot be
+        // paid -- unless something above it re-establishes the connections.
+        // `ConnectionNeeded` does not cover this: it only fires when LDK has
+        // an onion message to deliver AND knows an address. This loop is
+        // lampo's equivalent of ldk-node's PEER_RECONNECTION_INTERVAL task:
+        // every tick, dial every disconnected channel counterparty at the
+        // address we last reached them on. Announced peers are already
+        // handled by `ConnectionNeeded`.
+        {
+            let peer_manager = peer_manager.clone();
+            let chan_manager = chan_manager.clone();
+            let shutdown = shutdown.clone();
+            let store_path = peer_store_path(&self.conf);
+            tokio::spawn(async move {
+                let mut interval = tokio::time::interval(Duration::from_secs(10));
+                interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+                loop {
+                    interval.tick().await;
+                    if shutdown.load(Ordering::Acquire) {
+                        break;
+                    }
+                    let known = load_peers(&store_path);
+                    for channel in chan_manager.manager().list_channels() {
+                        let peer = channel.counterparty.node_id;
+                        if peer_manager.peer_by_node_id(&peer).is_some() {
+                            continue;
+                        }
+                        let Some(host) = known
+                            .get(&peer.to_string())
+                            .and_then(|addr| addr.parse().ok())
+                        else {
+                            continue;
+                        };
+                        log::info!(
+                            target: "lampo",
+                            "reconnecting to channel peer `{peer}` at `{host}`"
+                        );
+                        // Bound each attempt so one hung TCP cannot stall
+                        // the rest of the channel list.
+                        let _ = tokio::time::timeout(
+                            Duration::from_secs(5),
+                            dial(peer_manager.clone(), peer, host),
+                        )
+                        .await;
+                    }
+                }
+            });
+        }
+
         tokio::spawn(async move {
             log::info!(target: "lampo", "Listening for in-bound connection on {bind_addr}");
             let listener = match tokio::net::TcpListener::bind(bind_addr.clone()).await {
@@ -272,30 +323,17 @@ impl LampoPeerManager {
     }
 
     pub async fn connect(&self, node_id: NodeId, host: SocketAddr) -> error::Result<()> {
-        let Some(close_callback) = net::connect_outbound(self.manager(), node_id, host).await
-        else {
-            log::warn!("impossible connect with the peer `{node_id}`");
-            error::bail!("impossible connect with the peer `{node_id}`");
-        };
-        let mut connection_closed_future = Box::pin(close_callback);
-        let manager = self.manager();
-        loop {
-            match futures::poll!(&mut connection_closed_future) {
-                std::task::Poll::Ready(_) => {
-                    log::info!("node `{node_id}` disconnected");
-                    return Ok(());
-                }
-                std::task::Poll::Pending => {}
-            }
-            // Avoid blocking the tokio context by sleeping a bit
-            match manager.peer_by_node_id(&node_id) {
-                Some(_) => return Ok(()),
-                None => tokio::time::sleep(Duration::from_millis(10)).await,
-            }
-        }
+        dial(self.manager(), node_id, host).await?;
+        // Remember where this peer lives. LDK does not redial anyone on
+        // restart, and a peer that never announced an address -- the common
+        // case for an unannounced node -- is unreachable through the network
+        // graph, so this file is the only durable record of how to get back
+        // to a channel counterparty. The reconnect loop reads it.
+        remember_peer(&peer_store_path(&self.conf), &node_id, &host);
+        Ok(())
     }
 
-    async fn disconnect(&self, node_id: NodeId) -> error::Result<()> {
+    pub async fn disconnect(&self, node_id: NodeId) -> error::Result<()> {
         //check the pubkey matches a valid connected peer
         if self.manager().peer_by_node_id(&node_id).is_none() {
             error::bail!("Error: Could not find peer `{node_id}`");
@@ -303,5 +341,60 @@ impl LampoPeerManager {
 
         self.manager().disconnect_by_node_id(node_id);
         Ok(())
+    }
+}
+
+/// Dial `host` and wait until the handshake completes. A close before
+/// that is a failed connect, not success. Shared by user-driven
+/// `connect` and the reconnect loop.
+async fn dial(
+    manager: Arc<InnerLampoPeerManager>,
+    node_id: NodeId,
+    host: SocketAddr,
+) -> error::Result<()> {
+    let Some(close_callback) = net::connect_outbound(manager.clone(), node_id, host).await else {
+        log::warn!(target: "lampo", "impossible connect with the peer `{node_id}`");
+        error::bail!("impossible connect with the peer `{node_id}`");
+    };
+    let mut connection_closed_future = Box::pin(close_callback);
+    loop {
+        match futures::poll!(&mut connection_closed_future) {
+            std::task::Poll::Ready(_) => {
+                log::info!(target: "lampo", "node `{node_id}` disconnected before handshake");
+                error::bail!("peer `{node_id}` closed before handshake");
+            }
+            std::task::Poll::Pending => {}
+        }
+        // Avoid blocking the tokio context by sleeping a bit
+        match manager.peer_by_node_id(&node_id) {
+            Some(_) => return Ok(()),
+            None => tokio::time::sleep(Duration::from_millis(10)).await,
+        }
+    }
+}
+
+/// Where the last-known address of every peer we dialled is kept:
+/// `<lampo dir>/peers.json`, a flat `node_id -> "host:port"` map.
+fn peer_store_path(conf: &LampoConf) -> std::path::PathBuf {
+    std::path::Path::new(&conf.path()).join("peers.json")
+}
+
+fn load_peers(path: &std::path::Path) -> std::collections::HashMap<String, String> {
+    std::fs::read_to_string(path)
+        .ok()
+        .and_then(|content| lampo_common::json::from_str(&content).ok())
+        .unwrap_or_default()
+}
+
+fn remember_peer(path: &std::path::Path, node_id: &NodeId, host: &SocketAddr) {
+    let mut peers = load_peers(path);
+    peers.insert(node_id.to_string(), host.to_string());
+    match lampo_common::json::to_string_pretty(&peers) {
+        Ok(json) => {
+            if let Err(err) = std::fs::write(path, json) {
+                log::warn!(target: "lampo", "failed to persist peer address: {err}");
+            }
+        }
+        Err(err) => log::warn!(target: "lampo", "failed to serialize peer store: {err}"),
     }
 }

--- a/tests/tests/src/lampo_tests.rs
+++ b/tests/tests/src/lampo_tests.rs
@@ -196,6 +196,52 @@ pub async fn fundchannel_honors_the_public_flag() -> error::Result<()> {
     Ok(())
 }
 
+/// A node must redial its channel counterparties on its own.
+///
+/// LDK never reconnects to anyone; without lampo's reconnect loop a node
+/// that loses a TCP connection (or restarts) sits at zero peers forever
+/// with a live channel -- it stops forwarding and cannot be paid. This
+/// was observed on a real deployment: two nodes with a ready channel,
+/// both restarted, both at `peers=0` indefinitely.
+///
+/// The loop dials from the persisted last-known address, so it works for
+/// unannounced peers too -- which is what this test exercises, since the
+/// nodes here have no announce address and the graph knows nothing.
+#[tokio_test_shutdown_timeout::test(60)]
+pub async fn channel_peer_reconnects_after_disconnect() -> error::Result<()> {
+    init();
+    let node1 = LampoTesting::tmp().await?;
+    let node2 = Arc::new(LampoTesting::new(node1.btc.clone()).await?);
+    node1.fund_channel_with(node2.clone(), 1_000_000).await?;
+
+    let peer = lampo_common::types::NodeId::from_str(&node2.info.node_id)?;
+    let peer_manager = node1.lampod().peer_manager();
+    assert!(
+        peer_manager.is_connected_with(peer),
+        "funding a channel should leave the peers connected"
+    );
+
+    peer_manager.disconnect(peer).await?;
+    assert!(
+        !peer_manager.is_connected_with(peer),
+        "disconnect should actually drop the connection"
+    );
+
+    // No RPC, no manual connect: the reconnect loop alone must bring the
+    // channel peer back (it ticks every 10s).
+    async_wait!(
+        async {
+            if node1.lampod().peer_manager().is_connected_with(peer) {
+                Ok(())
+            } else {
+                Err(())
+            }
+        },
+        5
+    );
+    Ok(())
+}
+
 #[tokio_test_shutdown_timeout::test(5)]
 pub async fn pay_invoice_simple_case_lampo() -> error::Result<()> {
     init();


### PR DESCRIPTION
## Summary

- LDK never redials anyone. After a restart or any TCP drop, a lampo node with live, ready channels sits at **zero peers forever** — it stops forwarding and cannot be paid until an operator manually re-issues `connect`. Observed live: two nodes with a ready channel, both restarted, both at `peers=0` indefinitely.
- `ConnectionNeeded` does not cover this: it fires only when LDK has an onion message to deliver *and* an address to hand us. It is a message-delivery hook, not a reconnect loop.
- Adds lampo's equivalent of ldk-node's `PEER_RECONNECTION_INTERVAL` task: every 10s, dial every disconnected channel counterparty at the last-known address in `peers.json`.
- Bound each attempt at 5s so one hung TCP cannot stall the rest of the channel list. A close before handshake is a failed connect, not success.
- Announced peers are already handled by `ConnectionNeeded`. The store is what matters for unannounced peers — the common case, and the observed incident.

## Reproduction

Two daemons on signet, one ready channel between them, both restarted:

```
peers before: swapd=0 r=0     # indefinitely, channel ready=True the whole time
```

A BOLT12 `fetchinvoice` then fails with "timeout while waiting for the invoice, the offer issuer may be offline" — with both nodes up and the channel fine. Manual `connect` fixes it instantly, which is exactly what software should be doing.

## Test

`channel_peer_reconnects_after_disconnect`: open a channel, sever the connection via `disconnect`, assert the node re-establishes it with no RPC and no manual dial. The nodes have no announce address, so the test specifically proves the persisted-store path.

- with the loop: `ok ... finished in 14.45s` (one ~10s tick)
- with the loop removed: `FAILED ... finished in 54.50s` (retries exhausted)

## Decision Log

**Hardest decision:** where addresses come from. ldk-node persists a peer store; the graph alone is tempting (no new file) but useless for unannounced peers — reconnect-via-graph would NOT have fixed the observed incident. So: `peers.json` written on every successful outbound connect. Graph walk dropped: `ConnectionNeeded` already dials announced TCP addrs.

**Alternatives rejected:**
- Reconnect on `PeerDisconnected` events instead of polling: no such reliable hook covers process restart, which is the main case.
- Persisting inbound peers' socket addresses: an inbound remote port is ephemeral, not their listening port — storing it would produce confident dials to a dead port.
- Graph as fallback: extra code that cannot reach the peers this feature exists for.

**Least confident about:** serial dials inside one tick. A stale stored address costs a TCP timeout per peer; the 5s bound keeps that from stalling the rest of the list.

## Test plan

- [ ] CI passes
- [x] New test red without the loop, green with it (verified both ways)
- [x] `cargo check` clean
