### PR TITLE
lampod: return RPC error instead of panicking on malformed fundchannel node_id

### DIFF
--- a/lampod/src/jsonrpc/open_channel.rs
+++ b/lampod/src/jsonrpc/open_channel.rs
@@ -1,7 +1,7 @@
 //! Open Channel RPC Method implementation
 
 use lampo_common::json;
-use lampo_common::jsonrpc::Error;
+use lampo_common::jsonrpc::{Error, RpcError};
 use lampo_common::model::request;
 
 use crate::LampoDaemon;
@@ -15,11 +15,15 @@ pub async fn json_fundchannel(
 
     // LDK's `create_channel()` doesn't check if you are currently connected
     // to the given peer so we need to check ourselves
-    // FIXME: remove unwrap!
-    if !ctx
-        .peer_manager()
-        .is_connected_with(request.node_id().unwrap())
-    {
+    //
+    // A malformed `node_id` must surface as an RPC error, not panic the
+    // actix worker: found by the regtest soak simulation, where a caller
+    // sending `"node_id": ""` killed the worker thread
+    // (`called Result::unwrap() on an Err value: malformed public key`).
+    let node_id = request
+        .node_id()
+        .map_err(|err| crate::rpc_error!("invalid `node_id` provided: {err}"))?;
+    if !ctx.peer_manager().is_connected_with(node_id) {
         log::trace!("we are not connected with the peer {}", request.node_id);
         let conn = request::Connect::try_from(request.clone())?;
         let conn = json::to_value(conn)?;


### PR DESCRIPTION
## Problem

Found by the new regtest soak simulation (deployed on the debian server): sending `fundchannel` with a malformed public key (e.g. an empty `node_id`) panicked the actix worker thread:

```
thread 'actix-server worker 2' panicked at lampod/src/jsonrpc/open_channel.rs:21:46:
called `Result::unwrap()` on an `Err` value: malformed public key
```

The caller received an empty reply (connection reset) and the worker thread died.

## Fix

`OpenChannel::node_id()` already returns `error::Result<NodeId>` — propagate it as a proper JSON-RPC error instead of unwrapping.

## Verification (rebuilt + retested on the sim server)

Before (main @ e65bd89): empty reply + panic in node log.
After (this branch):
```
$ curl -X POST :8109/fundchannel -d '{"node_id":"",...}'
{"code":-1,"data":null,"message":"invalid `node_id` provided: malformed public key"}   # HTTP 500
```
Node stays alive, 0 panics in log.