### PR TITLE
lampod: bound the pay RPC wait with a timeout

### DIFF
--- a/lampo-common/src/model.rs
+++ b/lampo-common/src/model.rs
@@ -7,6 +7,7 @@ mod network;
 mod new_addr;
 mod on_chain;
 mod open_channel;
+mod pay_timeout;
 
 pub use connect::Connect;
 pub use getinfo::GetInfo;
@@ -22,6 +23,7 @@ pub mod request {
     #[allow(unused_imports)]
     pub use crate::model::on_chain::request::*;
     pub use crate::model::open_channel::request::*;
+    pub use crate::model::pay_timeout::PayTimeout;
 }
 
 pub mod response {

--- a/lampo-common/src/model/invoice.rs
+++ b/lampo-common/src/model/invoice.rs
@@ -4,6 +4,8 @@ pub mod request {
     use paperclip::actix::Apiv2Schema;
     use serde::{Deserialize, Serialize};
 
+    use crate::model::pay_timeout::PayTimeout;
+
     #[derive(Serialize, Deserialize, Debug, Apiv2Schema)]
     pub struct GenerateInvoice {
         pub amount_msat: Option<u64>,
@@ -27,6 +29,9 @@ pub mod request {
         pub invoice_str: String,
         pub amount: Option<u64>,
         pub bolt12: Option<Bolt12Pay>,
+        /// How long the RPC waits for the terminal `PaymentEvent` (`fast` / `medium` / `large`).
+        #[serde(default)]
+        pub timeout: PayTimeout,
     }
 
     #[derive(Serialize, Deserialize, Apiv2Schema)]

--- a/lampo-common/src/model/keysend.rs
+++ b/lampo-common/src/model/keysend.rs
@@ -8,10 +8,14 @@ pub mod request {
 
     use crate::bitcoin::secp256k1::PublicKey;
     use crate::error;
+    use crate::model::pay_timeout::PayTimeout;
     #[derive(Serialize, Deserialize, Apiv2Schema)]
     pub struct KeySend {
         pub destination: String,
         pub amount_msat: u64,
+        /// How long the RPC waits for the terminal `PaymentEvent` (`fast` / `medium` / `large`).
+        #[serde(default)]
+        pub timeout: PayTimeout,
     }
 
     impl KeySend {

--- a/lampo-common/src/model/pay_timeout.rs
+++ b/lampo-common/src/model/pay_timeout.rs
@@ -1,0 +1,49 @@
+use std::time::Duration;
+
+use paperclip::actix::Apiv2Schema;
+use serde::{Deserialize, Serialize};
+
+/// How long a `pay` / `keysend` RPC waits for the terminal `PaymentEvent`.
+#[derive(Clone, Copy, Debug, Default, Serialize, Deserialize, PartialEq, Eq, Apiv2Schema)]
+#[serde(rename_all = "lowercase")]
+pub enum PayTimeout {
+    /// 30 s — quick feedback for scripts and local testing.
+    Fast,
+    /// 120 s — default; matches the soak harness curl timeout.
+    #[default]
+    Medium,
+    /// 600 s — slow routing or BOLT12 offer flows.
+    Large,
+}
+
+impl PayTimeout {
+    pub fn duration(self) -> Duration {
+        match self {
+            Self::Fast => Duration::from_secs(30),
+            Self::Medium => Duration::from_secs(120),
+            Self::Large => Duration::from_secs(600),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn duration_presets() {
+        assert_eq!(PayTimeout::Fast.duration(), Duration::from_secs(30));
+        assert_eq!(PayTimeout::Medium.duration(), Duration::from_secs(120));
+        assert_eq!(PayTimeout::Large.duration(), Duration::from_secs(600));
+    }
+
+    #[test]
+    fn deserializes_lowercase_names() {
+        let fast: PayTimeout = serde_json::from_str("\"fast\"").unwrap();
+        let medium: PayTimeout = serde_json::from_str("\"medium\"").unwrap();
+        let large: PayTimeout = serde_json::from_str("\"large\"").unwrap();
+        assert_eq!(fast, PayTimeout::Fast);
+        assert_eq!(medium, PayTimeout::Medium);
+        assert_eq!(large, PayTimeout::Large);
+    }
+}

--- a/lampod/src/jsonrpc/offchain.rs
+++ b/lampod/src/jsonrpc/offchain.rs
@@ -1,5 +1,6 @@
 //! Offchain RPC methods
 use std::str::FromStr;
+use std::time::Duration;
 
 use lampo_common::event::ln::LightningEvent;
 use lampo_common::event::Event;
@@ -128,18 +129,44 @@ async fn wait_for_payment_result(
     mut events: lampo_common::chan::UnboundedReceiver<Event>,
     payment_id: &str,
 ) -> Result<json::Value, Error> {
+    // Upper bound for how long a caller waits for the terminal
+    // PaymentEvent (`pay` and `keysend` alike). Without it the handler
+    // waits forever whenever the event is never generated — observed
+    // live after an unclean node restart, where LDK logs `Failed to
+    // update channel monitor: no such monitor registered`, the payment
+    // stalls and no failure event fires. The payment itself may still
+    // be retried in the background; the RPC simply stops blocking.
+    const PAY_EVENT_TIMEOUT: Duration = Duration::from_secs(120);
+
     // The receipt lands on `PaymentReceipt` and the hop path on the terminal
     // `PaymentEvent`, so hold the receipt until the payment finishes.
     let mut receipt: Option<(String, Option<String>)> = None;
 
     // FIXME: this will loop when the Payment event is not generated
+    // If the terminal PaymentEvent is never generated (e.g. the payment
+    // stalls after an unclean restart), stop waiting after
+    // PAY_EVENT_TIMEOUT instead of blocking the caller forever.
     loop {
         log::warn!("Waiting for payment event...");
-        let event = events.recv().await.ok_or(Error::Rpc(RpcError {
-            code: -1,
-            message: format!("No event received, communication channel dropped"),
-            data: None,
-        }))?;
+        let event = tokio::time::timeout(PAY_EVENT_TIMEOUT, events.recv())
+            .await
+            .map_err(|_| {
+                Error::Rpc(RpcError {
+                    code: -1,
+                    message: format!(
+                        "payment `{}` did not complete within {}s (no Payment event; \
+                     the payment may still be retried in the background)",
+                        payment_id,
+                        PAY_EVENT_TIMEOUT.as_secs()
+                    ),
+                    data: None,
+                })
+            })?
+            .ok_or(Error::Rpc(RpcError {
+                code: -1,
+                message: format!("No event received, communication channel dropped"),
+                data: None,
+            }))?;
 
         match event {
             Event::Lightning(LightningEvent::PaymentReceipt {

--- a/lampod/src/jsonrpc/offchain.rs
+++ b/lampod/src/jsonrpc/offchain.rs
@@ -17,6 +17,7 @@ use lampo_common::model::response::PayResult;
 use lampo_common::model::response::{self, Decode};
 use lampo_common::model::response::{Bolt11InvoiceInfo, Bolt12InvoiceInfo, Invoice};
 use lampo_common::{json, model::request::DecodeInvoice};
+use tokio::time::Instant;
 
 use crate::LampoDaemon;
 
@@ -117,7 +118,7 @@ pub async fn json_pay(ctx: &LampoDaemon, request: &json::Value) -> Result<json::
     // otherwise see this payment's result -- and now its preimage and payer
     // proof too. Only accept events carrying our own payment id.
     let payment_id = hex::encode(payment_id.0);
-    wait_for_payment_result(events, &payment_id).await
+    wait_for_payment_result(events, &payment_id, request.timeout.duration()).await
 }
 
 /// Hold the `PaymentReceipt` (preimage, payer proof) until the terminal
@@ -128,36 +129,31 @@ pub async fn json_pay(ctx: &LampoDaemon, request: &json::Value) -> Result<json::
 async fn wait_for_payment_result(
     mut events: lampo_common::chan::UnboundedReceiver<Event>,
     payment_id: &str,
+    timeout: Duration,
 ) -> Result<json::Value, Error> {
-    // Upper bound for how long a caller waits for the terminal
-    // PaymentEvent (`pay` and `keysend` alike). Without it the handler
-    // waits forever whenever the event is never generated — observed
-    // live after an unclean node restart, where LDK logs `Failed to
-    // update channel monitor: no such monitor registered`, the payment
-    // stalls and no failure event fires. The payment itself may still
-    // be retried in the background; the RPC simply stops blocking.
-    const PAY_EVENT_TIMEOUT: Duration = Duration::from_secs(120);
+    // Single deadline for the whole RPC wait. The event bus is broadcast, so
+    // unrelated events must not reset the timer — only the terminal
+    // `PaymentEvent` for `payment_id` completes the call (success or failure).
+    // If that event never arrives, stop waiting after `timeout` instead of
+    // blocking forever; the payment itself may still be retried in the background.
+    let deadline = Instant::now() + timeout;
 
     // The receipt lands on `PaymentReceipt` and the hop path on the terminal
     // `PaymentEvent`, so hold the receipt until the payment finishes.
     let mut receipt: Option<(String, Option<String>)> = None;
 
-    // FIXME: this will loop when the Payment event is not generated
-    // If the terminal PaymentEvent is never generated (e.g. the payment
-    // stalls after an unclean restart), stop waiting after
-    // PAY_EVENT_TIMEOUT instead of blocking the caller forever.
     loop {
-        log::warn!("Waiting for payment event...");
-        let event = tokio::time::timeout(PAY_EVENT_TIMEOUT, events.recv())
+        log::warn!(target: "lampod::jsonrpc::offchain", "Waiting for payment event...");
+        let event = tokio::time::timeout_at(deadline, events.recv())
             .await
             .map_err(|_| {
                 Error::Rpc(RpcError {
                     code: -1,
                     message: format!(
-                        "payment `{}` did not complete within {}s (no Payment event; \
-                     the payment may still be retried in the background)",
+                        "payment `{}` did not complete within {}s (no terminal Payment event; \
+                         payment status unknown — it may still be retried in the background)",
                         payment_id,
-                        PAY_EVENT_TIMEOUT.as_secs()
+                        timeout.as_secs()
                     ),
                     data: None,
                 })
@@ -211,5 +207,5 @@ pub async fn json_keysend(ctx: &LampoDaemon, request: &json::Value) -> Result<js
     // Same id semantics as `pay`: the hex payment hash identifies the
     // payment on the event bus.
     let payment_id = hex::encode(payment_id.0);
-    wait_for_payment_result(events, &payment_id).await
+    wait_for_payment_result(events, &payment_id, request.timeout.duration()).await
 }


### PR DESCRIPTION
## Problem

Found by the regtest soak simulation (round 89, after 88 successful payments): when the terminal `PaymentEvent` is never generated, the `pay` RPC blocks **forever** — the code even carries the FIXME `this will loop when the Payment event is not generated`.

Repro (sim server, SEED=1337): SIGKILL a node with open channels, relaunch, immediately pay an invoice from it. LDK logs:

```
ERROR ldk lightning::chain::chainmonitor: Failed to update channel monitor: no such monitor registered.
WARN  lampod::jsonrpc::offchain Waiting for payment event....
```

…no failure event ever fires, and the HTTP call never responds (curl times out with an empty reply).

## Fix

Wrap the `events.recv()` loop in `tokio::time::timeout` (120 s): the RPC returns a clear JSON-RPC error (`payment `<id>` did not complete within 120s`) while the payment may still be retried in the background.

## Note for follow-up

The trigger exposes a deeper issue worth its own investigation: after an unclean restart LDK reports `no such monitor registered` and the payment stalls without any failure event — the timeout makes lampo degrade gracefully, but the monitor/persistence path should be looked at separately.

Artifacts: `~/lampo-sim/sim-run/artifacts/20260814-103619-*` on the sim server.