### PR TITLE
chain: return sats/vB from fee_rate_estimation, not sats/kvB

### DIFF
--- a/lampo-chain/src/lib.rs
+++ b/lampo-chain/src/lib.rs
@@ -245,8 +245,14 @@ impl Backend for LampoChainSync {
         let Some(feerate) = resp.feerate else {
             return Err(error::anyhow!("No fee rate estimation available").into());
         };
-        // estimate fee rate in BTC/kvB
-        Ok((feerate * (100_000_000 as f64)) as u32)
+        // bitcoind returns BTC/kvB. The callers expect sat/vB (see
+        // `FeeRate::from_sat_per_vb_unchecked` in the channel funding path),
+        // so convert: BTC/kvB * 1e8 sat/BTC / 1000 vB/kvB = * 1e5 sat/vB.
+        // Returning sat/kvB here (a plain * 1e8) inflated fees by 1000x and
+        // made small wallets fail every channel open with "Insufficient
+        // funds" (found on the mutinynet leg: 7 sat/vB used as 7092 sat/vB).
+        let sats_per_vb = feerate * 100_000.0;
+        Ok(sats_per_vb.ceil() as u32)
     }
 
     async fn get_transaction(

--- a/lampo-common/src/backend.rs
+++ b/lampo-common/src/backend.rs
@@ -47,6 +47,8 @@ pub trait Backend: Send + Sync {
 
     /// Fetch feerate give a number of blocks
     ///
+    /// Returns the feerate in **sats/vbyte**.
+    ///
     /// FIXME: use `FeeRate` instead of `u32`
     async fn fee_rate_estimation(&self, blocks: u64) -> error::Result<u32>;
 


### PR DESCRIPTION
## Problem

Found by the mutinynet (signet) leg of the pre-production soak: opening a **30,000 sat** channel from a 50,000 sat wallet failed with

```
Failed to create funding transaction: Insufficient funds: 0 BTC available of 0.00409422 BTC needed
```

and lampo's own log showed `fee estimated 7092 sats` while bitcoind's `estimatesmartfee` on the same network returned ~7 sat/vB.

## Root cause

`fee_rate_estimation` in `lampo-chain` multiplies bitcoind's **BTC/kvB** feerate by `1e8`, yielding **sats/kvB**. The only consumer — the channel funding path in `lampod/src/actions/handler.rs` — feeds the value directly into

```rust
FeeRate::from_sat_per_vb_unchecked(fee as u64)
```

which expects **sats/vB**. Every funding transaction is built with a feerate **1000x too high**. Small wallets then fail every channel open (`needed = value + 1000x-fee > balance`); wallets that can afford it overpay fees by ~1000x. This would hit mainnet channel opens and any wallet-driven tx using this estimator.

## Fix

Convert properly (BTC/kvB * 1e5 = sats/vB, rounded up so tiny feerates never round to zero) and document the unit on the `Backend` trait.

## Validation

- Signet: `estimatesmartfee(6)` = 0.00007092 BTC/kvB → now returns 8 sats/vB (was 7092)
- The mutinynet leg then funds and opens its 30k sat channel from the 50k wallet (regression re-run logged in the sim run log)
- Regtest unaffected (hardcoded 256)
