### PR TITLE
lampod: support push_msat in fundchannel

### DIFF
--- a/lampo-common/src/model/open_channel.rs
+++ b/lampo-common/src/model/open_channel.rs
@@ -14,6 +14,8 @@ pub mod request {
         pub addr: Option<String>,
         pub port: Option<u64>,
         pub amount: u64,
+        #[serde(default)]
+        pub push_msat: Option<u64>,
         pub public: bool,
     }
 

--- a/lampo-testing/src/lib.rs
+++ b/lampo-testing/src/lib.rs
@@ -305,6 +305,7 @@ impl LampoTesting {
                     public: true,
                     port: None,
                     addr: None,
+                    push_msat: None,
                 },
             )
             .await

--- a/lampod/src/ln/channel_manager.rs
+++ b/lampod/src/ln/channel_manager.rs
@@ -252,11 +252,12 @@ impl LampoChannelManager {
         // its channels existed.
         let mut config = self.conf.ldk_conf.clone();
         config.channel_handshake_config.announce_for_forwarding = open_channel.public;
+        let push_msat = open_channel.push_msat.unwrap_or(0);
         self.manager()
             .create_channel(
                 open_channel.node_id()?,
                 open_channel.amount,
-                0,
+                push_msat,
                 0,
                 None,
                 Some(config),
@@ -288,7 +289,7 @@ impl LampoChannelManager {
             node_id: open_channel.node_id,
             amount: open_channel.amount,
             public: open_channel.public,
-            push_msat: 0,
+            push_msat: open_channel.push_msat.unwrap_or(0),
             to_self_delay: 2016,
             tx,
             txid,

--- a/tests/tests/src/lampo_cln_tests.rs
+++ b/tests/tests/src/lampo_cln_tests.rs
@@ -75,6 +75,7 @@ pub async fn fund_a_simple_channel_from_lampo_to_cln() -> error::Result<()> {
                 amount: 100000,
                 public: true,
                 addr: Some("127.0.0.1".to_owned()),
+                push_msat: None,
             },
         )
         .await?;
@@ -292,6 +293,7 @@ pub fn decode_cln_offer_from_lampo() {
                 amount: 500_000_000,
                 public: true,
                 addr: Some("127.0.0.1".to_owned()),
+                push_msat: None,
             },
         )
         // Wait a little bit that the open channel will finish!
@@ -399,6 +401,7 @@ pub fn decode_cln_offer_from_lampo_minimal_offer() {
                 amount: 500_000_000,
                 public: true,
                 addr: Some("127.0.0.1".to_owned()),
+                push_msat: None,
             },
         )
         // Wait a little bit that the open channel will finish!
@@ -500,6 +503,7 @@ pub fn fetchinvoice_cln_offer_from_lampo() {
                 amount: 500_000_000,
                 public: true,
                 addr: Some("127.0.0.1".to_owned()),
+                push_msat: None,
             },
         )
         // Wait a little bit that the open channel will finish!
@@ -707,6 +711,7 @@ pub fn pay_invoice_to_cln() {
                 amount: 500_000_000,
                 public: true,
                 addr: Some("127.0.0.1".to_owned()),
+                push_msat: None,
             },
         )
         // Wait a little bit that the open channel will finish!
@@ -813,6 +818,7 @@ fn be_able_to_kesend_payments() {
                 amount: 1_500_000_000,
                 public: true,
                 addr: Some("127.0.0.1".to_owned()),
+                push_msat: None,
             },
         )
         .unwrap();
@@ -866,6 +872,7 @@ fn be_able_to_kesend_payments() {
         request::KeySend {
             destination: info_cln.id.clone(),
             amount_msat: 100_00_000,
+            timeout: Default::default(),
         },
     );
     assert!(result.is_ok(), "{:?}", result);
@@ -907,6 +914,7 @@ fn test_closing_two_channels_without_channelid_fails() {
                 amount: 1_500_000_000,
                 public: true,
                 addr: Some("127.0.0.1".to_owned()),
+                push_msat: None,
             },
         )
         .unwrap();
@@ -921,6 +929,7 @@ fn test_closing_two_channels_without_channelid_fails() {
                 amount: 1_000_000_000,
                 public: true,
                 addr: Some("127.0.0.1".to_owned()),
+                push_msat: None,
             },
         )
         .unwrap();
@@ -1015,6 +1024,7 @@ fn test_lampo_to_cln_close_channel_with_channel_id_success() {
                 amount: 1_500_000_000,
                 public: true,
                 addr: Some("127.0.0.1".to_owned()),
+                push_msat: None,
             },
         )
         .unwrap();
@@ -1117,6 +1127,7 @@ fn test_lampo_to_cln_close_channel_without_channel_id_success() {
                 amount: 1_500_000_000,
                 public: true,
                 addr: Some("127.0.0.1".to_owned()),
+                push_msat: None,
             },
         )
         .unwrap();

--- a/tests/tests/src/lampo_tests.rs
+++ b/tests/tests/src/lampo_tests.rs
@@ -71,6 +71,7 @@ pub async fn fund_a_simple_channel_from() -> error::Result<()> {
                 public: true,
                 port: None,
                 addr: None,
+                push_msat: None,
             },
         )
         .await
@@ -157,6 +158,7 @@ pub async fn fundchannel_honors_the_public_flag() -> error::Result<()> {
                     public: announce,
                     port: None,
                     addr: None,
+                    push_msat: None,
                 },
             )
             .await
@@ -274,6 +276,7 @@ pub async fn pay_invoice_simple_case_lampo() -> error::Result<()> {
                 invoice_str: invoice.bolt11,
                 amount: None,
                 bolt12: None,
+                timeout: Default::default(),
             },
         )
         .await?;
@@ -322,6 +325,7 @@ pub async fn pay_offer_simple_case_lampo() -> error::Result<()> {
                 invoice_str: offer.bolt12,
                 amount: None,
                 bolt12: None,
+                timeout: Default::default(),
             },
         )
         .await?;
@@ -386,6 +390,7 @@ pub async fn pay_offer_minimal_offer() -> error::Result<()> {
                 invoice_str: offer.bolt12,
                 amount: Some(100_000),
                 bolt12: None,
+                timeout: Default::default(),
             },
         )
         .await?;
@@ -449,6 +454,7 @@ pub async fn decode_invoice() -> error::Result<()> {
                 invoice_str: invoice.bolt11,
                 amount: None,
                 bolt12: None,
+                timeout: Default::default(),
             },
         )
         .await?;
@@ -519,6 +525,7 @@ pub async fn decode_offer_hex() -> error::Result<()> {
                 invoice_str: offer.bolt12,
                 amount: None,
                 bolt12: None,
+                timeout: Default::default(),
             },
         )
         .await?;


### PR DESCRIPTION
## Problem

Closes #566. `fundchannel` had no `push_msat`, so every channel opened 100% on the opener's side. On small channels the counterparty's received funds sit entirely **below the ~1% channel reserve** — spendable stays 0 forever and every reverse payment fails with `SendingFailed(RouteNotFound)`. Observed live on the mutinynet soak leg: a 30k sat channel where the payee could never send a single msat back. Two-way micro-channels were impossible.

## Change

- `OpenChannel` request: optional `push_msat` (serde default `None` → 0 = current behaviour, fully backward compatible)
- pass it to LDK's `create_channel` (LDK enforces `push_msat <= channel value`)
- return the real value in the response (was hardcoded `0`)

## Validation

Regression on the mutinynet leg after ship: channel opened with `push_msat` = half the channel value; alternating m1→m2→m1 payments both succeed (previously m2 could never pay back). Details in the sim run log.
