### PR TITLE
httpd: bind the close RPC request body

### DIFF
--- a/lampo-httpd/src/commands/peer.rs
+++ b/lampo-httpd/src/commands/peer.rs
@@ -12,6 +12,6 @@ use lampod::jsonrpc::peer_control::*;
 use crate::{post, AppState, ResultJson};
 
 post!(connect, request: request::Connect, response: request::Connect);
-post!(close, response: response::CloseChannel);
+post!(close, request: request::CloseChannel, response: response::CloseChannel);
 post!(channels, request: json::Value, response: json::Value);
 post!(fundchannel, request: request::OpenChannel, response: json::Value);


### PR DESCRIPTION
## Problem

`rest_close` was registered without a request binding, so the request body never reached `json_close` — it decoded an empty object and every HTTP `close` call failed with `JSON decode error: missing field `node_id``, leaving the channel open.

Found while cooperatively closing a channel on the mutinynet soak leg. Side finding: the regtest `churn` chaos event never actually closed a channel — it only opened new ones (node channel counts grew over the run).

## Fix

`post!(close, request: request::CloseChannel, response: response::CloseChannel);` — same pattern as the other routes.

## Validation

After ship: `close` over HTTP returns success and the channel actually closes (mutinynet leg regression, logged in the sim run log).