### PR TITLE
lampod: add a listpayments RPC backed by an in-memory payment history

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1847,6 +1847,7 @@ dependencies = [
  "lampo-common",
  "log",
  "once_cell",
+ "serde",
  "time",
  "tokio",
 ]

--- a/lampo-common/src/event/ln.rs
+++ b/lampo-common/src/event/ln.rs
@@ -57,6 +57,18 @@ pub enum LightningEvent {
         // to help the user understand what went wrong.
         reason: Option<String>,
     },
+    /// A payment was received and claimed (one of our invoices or a
+    /// keysend to us got paid). Emitted by the LDK `PaymentClaimed`
+    /// handler so subscribers (e.g. the payment history behind
+    /// `listpayments`) can record inbound payments too.
+    PaymentReceived {
+        /// Hex encoded payment hash.
+        payment_hash: String,
+        /// Amount received, in msat.
+        amount_msat: u64,
+        /// Hex encoded preimage, when the purpose carried one.
+        payment_preimage: Option<String>,
+    },
     ChannelEvent {
         state: String,
         message: String,

--- a/lampo-httpd/src/commands/offchain.rs
+++ b/lampo-httpd/src/commands/offchain.rs
@@ -5,7 +5,9 @@ use paste::paste;
 
 use lampo_common::json;
 use lampo_common::model::{request, response};
-use lampod::jsonrpc::offchain::{json_decode, json_invoice, json_keysend, json_offer, json_pay};
+use lampod::jsonrpc::offchain::{
+    json_decode, json_invoice, json_keysend, json_listpayments, json_offer, json_pay,
+};
 
 use crate::{post, AppState, ResultJson};
 
@@ -15,3 +17,4 @@ post!(offer, request: request::GenerateOffer, response: response::Offer);
 post!(decode, request: request::DecodeInvoice, response: response::Decode);
 post!(pay, request: request::Pay, response: response::PayResult);
 post!(keysend, request: request::KeySend, response: response::PayResult);
+post!(listpayments, request: json::Value, response: json::Value);

--- a/lampo-httpd/src/lib.rs
+++ b/lampo-httpd/src/lib.rs
@@ -15,7 +15,9 @@ use lampod::LampoDaemon;
 
 use commands::daemon::rest_stop;
 use commands::inventory::{rest_funds, rest_getinfo, rest_networkchannels};
-use commands::offchain::{rest_decode, rest_invoice, rest_keysend, rest_pay};
+use commands::offchain::{
+    rest_decode, rest_invoice, rest_keysend, rest_listpayments, rest_pay,
+};
 use commands::onchain::rest_new_addr;
 use commands::peer::{rest_channels, rest_close, rest_connect, rest_fundchannel};
 
@@ -128,6 +130,7 @@ pub async fn run<T: ToSocketAddrs + Display>(
             .service(rest_decode)
             .service(rest_pay)
             .service(rest_keysend)
+            .service(rest_listpayments)
             .service(rest_funds)
             .service(rest_new_addr)
             .service(rest_stop)

--- a/lampod/Cargo.toml
+++ b/lampod/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2021"
 [dependencies]
 tokio = { version = "^1.50.0", features = ["rt-multi-thread", "parking_lot", "macros", "time"] }
 lampo-common = { path = "../lampo-common" }
+serde = { version = "1", features = ["derive"] }
 log = "0.4.17"
 time = "0.3.43"
 futures = "0.3.28"

--- a/lampod/src/actions/handler.rs
+++ b/lampod/src/actions/handler.rs
@@ -405,6 +405,12 @@ impl Handler for LampoHandler {
                 };
                 log::warn!("please note the payments are not make persistent for the moment");
                 // FIXME: make peristent these information
+                self.emit(Event::Lightning(LightningEvent::PaymentReceived {
+                    payment_hash: lampo_common::hex::encode(payment_hash.0),
+                    amount_msat,
+                    payment_preimage: payment_preimage
+                        .map(|preimage| lampo_common::hex::encode(preimage.0)),
+                }));
                 Ok(())
             }
             ldk::events::Event::PaymentSent {

--- a/lampod/src/jsonrpc/offchain.rs
+++ b/lampod/src/jsonrpc/offchain.rs
@@ -186,3 +186,13 @@ pub async fn json_keysend(ctx: &LampoDaemon, request: &json::Value) -> Result<js
     let payment_id = hex::encode(payment_id.0);
     wait_for_payment_result(events, &payment_id).await
 }
+
+/// List the in-memory payment history (issue #567): every terminal sent
+/// payment and every claimed inbound payment since node start.
+pub async fn json_listpayments(
+    ctx: &LampoDaemon,
+    _request: &json::Value,
+) -> Result<json::Value, Error> {
+    log::info!("call for `listpayments`");
+    Ok(json::to_value(ctx.payments().list())?)
+}

--- a/lampod/src/lib.rs
+++ b/lampod/src/lib.rs
@@ -16,6 +16,7 @@ pub mod chain;
 pub mod command;
 pub mod jsonrpc;
 pub mod ln;
+pub mod payments;
 pub mod persistence;
 
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -98,6 +99,7 @@ pub struct LampoDaemon {
     logger: Arc<LampoLogger>,
     persister: Arc<LampoPersistence>,
     handler: Option<Arc<LampoHandler>>,
+    payments: crate::payments::PaymentHistory,
     shutdown: Arc<AtomicBool>,
     chain_sync: Arc<ChainSyncCoordinator>,
 }
@@ -118,6 +120,7 @@ impl LampoDaemon {
             onchain_manager: None,
             channel_manager: None,
             inventory_manager: None,
+            payments: crate::payments::PaymentHistory::new(),
             wallet_manager,
             offchain_manager: None,
             handler: None,
@@ -150,6 +153,10 @@ impl LampoDaemon {
 
     pub fn persister(&self) -> Arc<LampoPersistence> {
         self.persister.clone()
+    }
+
+    pub fn payments(&self) -> &crate::payments::PaymentHistory {
+        &self.payments
     }
 
     pub fn init_onchaind(&mut self, client: Arc<dyn Backend>) -> error::Result<()> {
@@ -296,6 +303,9 @@ impl LampoDaemon {
         let _ = self.peer_manager().run_with_shutdown(shutdown.clone());
         log::info!(target: "lampo", "Starting channel manager");
         let _ = self.channel_manager().listen();
+
+        // Record every terminal/received payment for the `listpayments` RPC.
+        tokio::spawn(crate::payments::record_payments(self.clone()));
 
         tokio::spawn(async move {
             process_events_async(

--- a/lampod/src/payments.rs
+++ b/lampod/src/payments.rs
@@ -1,0 +1,141 @@
+//! In-memory payment history backing the `listpayments` RPC (issue #567).
+//!
+//! Records every terminal sent payment (from [`LightningEvent::PaymentEvent`],
+//! with the preimage attached from the preceding [`LightningEvent::PaymentReceipt`])
+//! and every claimed inbound payment (from [`LightningEvent::PaymentReceived`]).
+//!
+//! This is a best-effort, boot-scoped history: it is not persisted across
+//! restarts and it is capped, so it is a debugging/audit surface, not an
+//! accounting source of truth.
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use serde::{Deserialize, Serialize};
+
+use lampo_common::event::ln::LightningEvent;
+use lampo_common::event::Event;
+use lampo_common::handler::Handler;
+use lampo_common::model::response::PaymentHop;
+
+use crate::LampoDaemon;
+
+/// How many records to keep; the oldest are dropped first.
+const HISTORY_CAP: usize = 1000;
+
+#[derive(Clone, Serialize, Deserialize, Debug)]
+pub struct PaymentRecord {
+    /// "sent" or "received".
+    pub direction: String,
+    /// Hex encoded payment id (sent payments only).
+    pub payment_id: Option<String>,
+    /// Hex encoded payment hash, when known.
+    pub payment_hash: Option<String>,
+    /// "Success" for received payments; the terminal state otherwise.
+    pub state: String,
+    /// Amount in msat (received payments only; the sent-payment events do
+    /// not carry the amount).
+    pub amount_msat: Option<u64>,
+    /// Hex encoded preimage, when known.
+    pub preimage: Option<String>,
+    /// Failure reason, for failed sent payments.
+    pub reason: Option<String>,
+    /// Hop path of a sent payment, when known.
+    pub path: Vec<PaymentHop>,
+    /// Unix seconds.
+    pub timestamp: u64,
+}
+
+#[derive(Clone, Default)]
+pub struct PaymentHistory {
+    records: Arc<Mutex<Vec<PaymentRecord>>>,
+}
+
+impl PaymentHistory {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    fn push(&self, record: PaymentRecord) {
+        let mut records = self.records.lock().unwrap();
+        records.push(record);
+        let len = records.len();
+        if len > HISTORY_CAP {
+            records.drain(0..len - HISTORY_CAP);
+        }
+    }
+
+    pub fn list(&self) -> Vec<PaymentRecord> {
+        self.records.lock().unwrap().clone()
+    }
+}
+
+/// Subscribe to the event bus forever, recording payments into
+/// [`LampoDaemon::payments`].
+pub async fn record_payments(ctx: Arc<LampoDaemon>) -> ! {
+    let mut events = ctx.handler().events();
+    // PaymentReceipt arrives just before the terminal PaymentEvent; hold the
+    // preimage here until the terminal event for the same payment id lands.
+    let mut preimages: HashMap<String, String> = HashMap::new();
+    loop {
+        let Some(event) = events.recv().await else {
+            // The event bus closed; nothing more will ever arrive. Spin
+            // idly rather than busy-loop so the task stays parked.
+            tokio::time::sleep(std::time::Duration::from_secs(3600)).await;
+            continue;
+        };
+        let timestamp = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_secs())
+            .unwrap_or(0);
+        match event {
+            Event::Lightning(LightningEvent::PaymentReceipt {
+                payment_id,
+                payment_preimage,
+                ..
+            }) => {
+                preimages.insert(payment_id, payment_preimage);
+            }
+            Event::Lightning(LightningEvent::PaymentEvent {
+                state,
+                payment_id,
+                payment_hash,
+                path,
+                reason,
+            }) => {
+                let preimage = payment_id
+                    .as_ref()
+                    .and_then(|id| preimages.remove(id.as_str()));
+                ctx.payments().push(PaymentRecord {
+                    direction: "sent".to_owned(),
+                    payment_id,
+                    payment_hash,
+                    state: format!("{state:?}"),
+                    amount_msat: None,
+                    preimage,
+                    reason,
+                    path,
+                    timestamp,
+                });
+            }
+            Event::Lightning(LightningEvent::PaymentReceived {
+                payment_hash,
+                amount_msat,
+                payment_preimage,
+            }) => {
+                ctx.payments().push(PaymentRecord {
+                    direction: "received".to_owned(),
+                    payment_id: None,
+                    payment_hash: Some(payment_hash),
+                    state: "Success".to_owned(),
+                    amount_msat: Some(amount_msat),
+                    preimage: payment_preimage,
+                    reason: None,
+                    path: Vec::new(),
+                    timestamp,
+                });
+            }
+            _ => {}
+        }
+    }
+}


### PR DESCRIPTION
## Problem

Refs #567 (the remaining half): once `pay`/`keysend` returned, payment outcomes were no longer observable anywhere over RPC — no way to list payments, no way to audit what a node sent/received. The LDK `PaymentClaimed` handler carried the FIXME "make persistent these information".

## Change

- New `PaymentReceived` event emitted from the `PaymentClaimed` handler (hash, amount, preimage when available) so inbound payments reach the event bus
- A subscriber task (`lampod::payments::record_payments`) keeps a **capped (1000), in-memory** history:
  - **sent**: terminal `PaymentEvent` (state, hash, path, failure reason) with the preimage attached from the preceding `PaymentReceipt`
  - **received**: `PaymentReceived` (hash, amount, preimage)
- New `listpayments` RPC (JSON-RPC + HTTP route)

Boot-scoped by design — an audit/debug surface, not an accounting source of truth (persistence intentionally out of scope). Sent-payment events don't carry the amount, so only received records have `amount_msat`.

## Validation

After ship: `listpayments` on a soaking node returns the expected records with real preimages, in both directions (regression logged in the sim run log).
