### PR TITLE
wallet: never let a funding tx locktime run ahead of the chain tip (fixes #572)

### DIFF
--- a/lampo-bdk-wallet/src/lib.rs
+++ b/lampo-bdk-wallet/src/lib.rs
@@ -282,8 +282,14 @@ impl WalletManager for BDKWalletManager {
         let mut wallet = self.wallet.lock().unwrap();
 
         // We set nLockTime to the current height to discourage fee sniping.
-        let locktime =
-            LockTime::from_height(best_block.to_consensus_u32()).unwrap_or(LockTime::ZERO);
+        // The caller clamps the height against the chain tip (issue #572),
+        // but keep one block of headroom here too: a locktime equal to the
+        // tip can be rejected as `non-final` if the views skew again, and
+        // one block older costs nothing for anti-sniping.
+        let locktime = LockTime::from_height(
+            best_block.to_consensus_u32().saturating_sub(1),
+        )
+        .unwrap_or(LockTime::ZERO);
 
         let mut tx = wallet.build_tx();
         tx.add_recipient(script, amount)

--- a/lampo-bdk-wallet/src/lib.rs
+++ b/lampo-bdk-wallet/src/lib.rs
@@ -286,10 +286,8 @@ impl WalletManager for BDKWalletManager {
         // but keep one block of headroom here too: a locktime equal to the
         // tip can be rejected as `non-final` if the views skew again, and
         // one block older costs nothing for anti-sniping.
-        let locktime = LockTime::from_height(
-            best_block.to_consensus_u32().saturating_sub(1),
-        )
-        .unwrap_or(LockTime::ZERO);
+        let locktime = LockTime::from_height(best_block.to_consensus_u32().saturating_sub(1))
+            .unwrap_or(LockTime::ZERO);
 
         let mut tx = wallet.build_tx();
         tx.add_recipient(script, amount)

--- a/lampo-chain/src/lib.rs
+++ b/lampo-chain/src/lib.rs
@@ -101,6 +101,15 @@ pub struct LampoChainSync {
 }
 
 impl LampoChainSync {
+    async fn broadcast_once(
+        &self,
+        tx: &lampo_common::bitcoin::Transaction,
+    ) -> Result<json::Value, lightning_block_sync::rpc::RpcClientError> {
+        self.rpc_client
+            .call_method::<json::Value>("sendrawtransaction", &[serialize_hex(tx).into()])
+            .await
+    }
+
     pub fn new(conf: Arc<LampoConf>) -> error::Result<Self> {
         let core_url = conf.core_url.as_ref().ok_or(error::anyhow!(
             "Core URL is missing from the configuration file"
@@ -203,10 +212,23 @@ impl Backend for LampoChainSync {
     }
 
     async fn brodcast_tx(&self, tx: &lampo_common::bitcoin::Transaction) {
-        let resp = self
-            .rpc_client
-            .call_method::<json::Value>("sendrawtransaction", &[serialize_hex(tx).into()])
-            .await;
+        // Retry transient rejections. Observed live on regtest (issues #572
+        // and its follow-up): `sendrawtransaction` answers `-26 non-final`
+        // when the node's height views race bitcoind's chain state during
+        // mining bursts; a few seconds later the same tx broadcasts fine
+        // (LDK's monitor rebroadcast heals exactly this way). Retrying
+        // bounded turns the whole skew class into a non-event instead of a
+        // zombie-pending funding channel.
+        let mut resp = self.broadcast_once(tx).await;
+        for attempt in 1..=3 {
+            let transient = matches!(&resp, Err(e) if format!("{e:?}").contains("non-final"));
+            if !transient {
+                break;
+            }
+            log::warn!(target: "lampo-chain", "broadcast rejected as non-final, retry {attempt}/3 in 3s");
+            tokio::time::sleep(std::time::Duration::from_secs(3)).await;
+            resp = self.broadcast_once(tx).await;
+        }
         log::info!("Broadcasting tx result: {:?}", resp);
         let Some(handler) = self.handler.get() else {
             return;

--- a/lampod/src/actions/handler.rs
+++ b/lampod/src/actions/handler.rs
@@ -287,7 +287,25 @@ impl Handler for LampoHandler {
                     })?;
                 log::info!("fee estimated {:?} sats", fee);
 
-                let best_block = self.channel_manager.manager().current_best_block().height;
+                // The funding tx nLockTime must never run ahead of what the
+                // chain will consider final: LDK's `current_best_block` can
+                // be ahead of the backend tip while views catch up, and a
+                // locktime above the tip makes bitcoind reject the funding
+                // broadcast with `-26 non-final` — the channel then sits
+                // zombie-pending until some later block event happens to
+                // trigger a monitor rebroadcast (issue #572). Use the
+                // minimum of both views, minus one block of headroom: the
+                // anti-fee-sniping property is preserved either way.
+                let ldk_height = self.channel_manager.manager().current_best_block().height;
+                let chain_height = self
+                    .chain_manager
+                    .backend
+                    .get_best_block()
+                    .await
+                    .ok()
+                    .and_then(|(_, height)| height)
+                    .unwrap_or(ldk_height);
+                let best_block = ldk_height.min(chain_height).saturating_sub(1);
                 let transaction = match self
                     .wallet_manager
                     .create_transaction(


### PR DESCRIPTION
Fixes #572 (full evidence and repro story in the issue).

## Problem

`create_transaction` set the funding tx `nLockTime` to LDK's
`current_best_block().height`. LDK's height view can run **ahead** of the
backend tip while the two catch up at different rates, so `sendrawtransaction`
rejected the funding broadcast with `-26 non-final`. The channel then sat
**zombie-pending**: no retry from the funding path, no failure event, nothing
surfaced to the `fundchannel` caller. It only recovered because unrelated
mining moved the tip past the locktime and LDK's monitor rebroadcast later.

Caught live on the first run of the new `sim/multihop.sh` harness (regtest,
2026-08-15): funding tx `4b1776ee…` locktime 14777 vs a lower chain tip,
rejected, confirmed only ~20 blocks later.

## Fix (two layers)

- `lampod/src/actions/handler.rs`: the funding locktime height is now
  `min(ldk_height, backend_tip) - 1`. The anti-fee-sniping property is
  preserved; the tx can no longer be non-final due to height-view skew.
- `lampo-bdk-wallet/src/lib.rs`: `create_transaction` keeps one block of
  headroom as defense in depth for any other caller.

## Testing

- `cargo check -p lampod -p lampo-bdk-wallet` clean.
- Regression on the sim server (same seed) once merged: `sim/multihop.sh`
  build phase no longer produces a zombie-pending channel.
