### PR TITLE
handler: don't hold the external_handlers read guard across an await (startup hang, #576)

### DIFF
--- a/lampod/src/actions/handler.rs
+++ b/lampod/src/actions/handler.rs
@@ -108,11 +108,18 @@ impl EventHandler for LampoHandler {
 impl Handler for LampoHandler {
     // FIXME: this is not needed anymore? we can assume that all command are external?
     async fn react(&self, event: crate::command::Command) -> error::Result<json::Value> {
-        let handler = self.external_handlers.read().await;
+        // Never hold the read guard across the `handle().await`: a parked
+        // external handler (e.g. a replayed command after an unclean
+        // shutdown whose reply path never completes) would keep the guard
+        // forever and starve `add_external_handler`'s write() — observed
+        // live as a full startup hang (issue #576: log stops before
+        // `Starting Server`, API never binds, pid lock held). Cloning the
+        // Arc list keeps the critical section await-free.
+        let external_handlers = self.external_handlers.read().await.clone();
         match event {
             Command::ExternalCommand(req) => {
-                log::debug!(target: "lampo", "external handler size {}", handler.len());
-                for handler in handler.iter() {
+                log::debug!(target: "lampo", "external handler size {}", external_handlers.len());
+                for handler in external_handlers.iter() {
                     if let Some(resp) = handler.handle(&req).await? {
                         return Ok(resp);
                     }


### PR DESCRIPTION
Relates to #576 (likely fixes the starvation mechanism observed there).

## Problem

`LampoHandler::react` (`lampod/src/actions/handler.rs`) took the
`external_handlers` RwLock **read guard** and held it across
`handler.handle(&req).await`. If an external handler's await never
completes, the guard is held forever, and `add_external_handler`'s
`write().await` — called during startup, before the `Starting Server`
log — starves.

Observed live by the sim harness (stress cycle `term-midpay`, issue #576):
after a mid-payment SIGTERM, the next launch hangs forever — log stops at
`Loading from existing wallet`, ctrl-c thread already installed, API never
binds, pid lock held, main future parked, all tokio workers idle.

## Fix

Clone the `Arc` list out under the lock and run the `handle().await` loop
outside any critical section. Cloning a small `Vec<Arc<...>>` is cheap;
the guard is now held only for microseconds.

## Testing

- `cargo check` + `cargo fmt` clean.
- Repro data dir preserved at `vincenzopalazzo@debian:~/lampo-repro-576-hs`;
  regression via `sim/recover.sh` stress (`STRESS_CYCLES=8 SEED=1337`) —
  the exact fault class (`term-midpay`) is part of the seeded mix.
