### PR TITLE
lampod: register persisted channel monitors on restart — re-land the fix lost in the refactor (fixes #579, #563)

### DIFF
--- a/lampod/src/ln/channel_manager.rs
+++ b/lampod/src/ln/channel_manager.rs
@@ -18,7 +18,7 @@ use lampo_common::ldk::block_sync::BlockSource;
 use lampo_common::ldk::chain::chaininterface::{BroadcasterInterface, FeeEstimator};
 use lampo_common::ldk::chain::chainmonitor::ChainMonitor;
 use lampo_common::ldk::chain::channelmonitor::ChannelMonitor;
-use lampo_common::ldk::chain::BlockLocator;
+use lampo_common::ldk::chain::{BlockLocator, Watch};
 use lampo_common::ldk::ln::channelmanager::{ChainParameters, ChannelManagerReadArgs};
 use lampo_common::ldk::onion_message::messenger::DefaultMessageRouter;
 use lampo_common::ldk::routing::gossip::NetworkGraph;
@@ -320,7 +320,6 @@ impl LampoChannelManager {
 
         let _ = self.network_graph();
         let monitors = self.get_channel_monitors()?;
-        let monitors = monitors.iter().collect::<Vec<_>>();
 
         let default_message_router = DefaultMessageRouter::new(
             self.graph(),
@@ -338,12 +337,35 @@ impl LampoChannelManager {
             default_message_router,
             self.logger.clone(),
             self.conf.ldk_conf.clone(),
-            monitors,
+            monitors.iter().collect(),
         );
         let mut channel_manager_file = File::open(format!("{}/manager", self.conf.path()))?;
         let (_, channel_manager) =
             <(BlockLocator, LampoChannel)>::read(&mut channel_manager_file, read_args)
                 .map_err(|err| error::anyhow!("{err}"))?;
+
+        // Move the persisted channel monitors into the `ChainMonitor`, as
+        // required by LDK when restoring a node from disk (see the
+        // `ChannelManagerReadArgs` documentation). Without this the monitor
+        // of every channel that predates the restart is missing from the
+        // `ChainMonitor`, so the first monitor update fails with
+        // `no such monitor registered` and the restored channels are left
+        // silently broken: payments stall without a failure event and the
+        // peers keep reconnecting without making progress (issue #563).
+        for monitor in monitors {
+            let channel_id = monitor.channel_id();
+            match self.chain_monitor().watch_channel(channel_id, monitor) {
+                Ok(status) => log::info!(
+                    target: "lampod",
+                    "restored channel monitor for channel `{channel_id}` ({status:?})"
+                ),
+                Err(()) => log::error!(
+                    target: "lampod",
+                    "unable to register the persisted channel monitor for channel `{channel_id}`"
+                ),
+            }
+        }
+
         self.channeld
             .set(Arc::new(channel_manager))
             .unwrap_or_else(|_| panic!("channel manager already initialized"));


### PR DESCRIPTION
Fixes #579 (and re-fixes #563, whose fix was lost in the restart refactor).

## Root cause

`LampoChannelManager::restart()` reads the persisted monitors and passes
them into `ChannelManagerReadArgs` **by reference** — but LDK's `read()`
does **not** register them into the `ChainMonitor`: the `ChannelManagerReadArgs`
docs state the caller must move the monitors in via `chain::Watch::watch_channel`.
Nothing did, so after **any** restart:

```
ERROR ldk chainmonitor Failed to update channel monitor: no such monitor registered.
```

and the first payment through the node stalls forever with no terminal
PaymentEvent (the node otherwise looks healthy — `getinfo`/`channels` fine).

Reproduced by the recovery harness on a clean SIGINT restart (binary 651bdaa,
artifacts `20260815-102538`, issue #579): manager read succeeds
(`Successfully loaded … against monitor …`), zero registration lines, first
channel update 22 s later fails.

## Why this looks "flaky" but is not

The original registration loop was written for #563 (commit f713b60, sim
branch lineage) but never landed on main / was dropped when `restart()` was
refactored. Any build off current main carries the regression; builds from
the sim branch lineage do not — mixed-lineage testing made it appear
intermittent.

## Fix

Re-land the loop after `read()`: iterate the owned monitors returned by
`get_channel_monitors()` and `watch_channel` each one, logging success or
failure per channel. Cherry-picked from f713b60, adapted to the current
code shape, `cargo check` + `fmt` clean.

## Verification

- Harness regression on the debian server after rebuild:
  `run-mh.sh recover` → R01 (clean SIGINT) probe must pass, and the log must
  show `restored channel monitor for channel …` lines on every restart.
