### PR TITLE
httpd: register the keysend route and return a real payment result

### DIFF
--- a/lampo-common/src/model/keysend.rs
+++ b/lampo-common/src/model/keysend.rs
@@ -1,13 +1,24 @@
 //! keysend model
 
 pub mod request {
-    use bitcoin::secp256k1::PublicKey;
+    use std::str::FromStr;
+
+    use paperclip::actix::Apiv2Schema;
     use serde::{Deserialize, Serialize};
 
-    #[derive(Serialize, Deserialize)]
+    use crate::bitcoin::secp256k1::PublicKey;
+    use crate::error;
+    #[derive(Serialize, Deserialize, Apiv2Schema)]
     pub struct KeySend {
-        pub destination: PublicKey,
+        pub destination: String,
         pub amount_msat: u64,
+    }
+
+    impl KeySend {
+        pub fn destination(&self) -> error::Result<PublicKey> {
+            let destination = PublicKey::from_str(&self.destination)?;
+            Ok(destination)
+        }
     }
 }
 

--- a/lampo-httpd/src/commands/offchain.rs
+++ b/lampo-httpd/src/commands/offchain.rs
@@ -5,7 +5,7 @@ use paste::paste;
 
 use lampo_common::json;
 use lampo_common::model::{request, response};
-use lampod::jsonrpc::offchain::{json_decode, json_invoice, json_offer, json_pay};
+use lampod::jsonrpc::offchain::{json_decode, json_invoice, json_keysend, json_offer, json_pay};
 
 use crate::{post, AppState, ResultJson};
 
@@ -14,3 +14,4 @@ post!(offer, request: request::GenerateOffer, response: response::Offer);
 // FIXME(vincenzopalazzo): the decode should be generic over any kind of string
 post!(decode, request: request::DecodeInvoice, response: response::Decode);
 post!(pay, request: request::Pay, response: response::PayResult);
+post!(keysend, request: request::KeySend, response: response::PayResult);

--- a/lampo-httpd/src/lib.rs
+++ b/lampo-httpd/src/lib.rs
@@ -15,7 +15,7 @@ use lampod::LampoDaemon;
 
 use commands::daemon::rest_stop;
 use commands::inventory::{rest_funds, rest_getinfo, rest_networkchannels};
-use commands::offchain::{rest_decode, rest_invoice, rest_pay};
+use commands::offchain::{rest_decode, rest_invoice, rest_keysend, rest_pay};
 use commands::onchain::rest_new_addr;
 use commands::peer::{rest_channels, rest_close, rest_connect, rest_fundchannel};
 
@@ -127,6 +127,7 @@ pub async fn run<T: ToSocketAddrs + Display>(
             .service(rest_offer)
             .service(rest_decode)
             .service(rest_pay)
+            .service(rest_keysend)
             .service(rest_funds)
             .service(rest_new_addr)
             .service(rest_stop)

--- a/lampod/src/jsonrpc/offchain.rs
+++ b/lampod/src/jsonrpc/offchain.rs
@@ -116,7 +116,18 @@ pub async fn json_pay(ctx: &LampoDaemon, request: &json::Value) -> Result<json::
     // otherwise see this payment's result -- and now its preimage and payer
     // proof too. Only accept events carrying our own payment id.
     let payment_id = hex::encode(payment_id.0);
+    wait_for_payment_result(events, &payment_id).await
+}
 
+/// Hold the `PaymentReceipt` (preimage, payer proof) until the terminal
+/// `PaymentEvent` for `payment_id` arrives, and build the `PayResult`.
+/// The event bus broadcasts to every subscriber, so only events carrying
+/// our own payment id are accepted -- a concurrent payment must not leak
+/// its result into ours.
+async fn wait_for_payment_result(
+    mut events: lampo_common::chan::UnboundedReceiver<Event>,
+    payment_id: &str,
+) -> Result<json::Value, Error> {
     // The receipt lands on `PaymentReceipt` and the hop path on the terminal
     // `PaymentEvent`, so hold the receipt until the payment finishes.
     let mut receipt: Option<(String, Option<String>)> = None;
@@ -163,10 +174,15 @@ pub async fn json_pay(ctx: &LampoDaemon, request: &json::Value) -> Result<json::
 }
 
 pub async fn json_keysend(ctx: &LampoDaemon, request: &json::Value) -> Result<json::Value, Error> {
-    log::debug!("call for `keysend` with request `{:?}`", request);
+    log::info!("call for `keysend` with request `{:?}`", request);
     let request: KeySend = json::from_value(request.clone())?;
-    ctx.offchain_manager()
-        .keysend(request.destination, request.amount_msat)?;
-    // FIXME: return a better response
-    Ok(json::json!({}))
+    let destination = request.destination()?;
+    let mut events = ctx.handler().events();
+    let payment_id = ctx
+        .offchain_manager()
+        .keysend(destination, request.amount_msat)?;
+    // Same id semantics as `pay`: the hex payment hash identifies the
+    // payment on the event bus.
+    let payment_id = hex::encode(payment_id.0);
+    wait_for_payment_result(events, &payment_id).await
 }

--- a/tests/tests/src/lampo_cln_tests.rs
+++ b/tests/tests/src/lampo_cln_tests.rs
@@ -864,7 +864,7 @@ fn be_able_to_kesend_payments() {
     let result: error::Result<json::Value> = lampo.call(
         "keysend",
         request::KeySend {
-            destination: PublicKey::from_str(info_cln.id.as_str()).unwrap(),
+            destination: info_cln.id.clone(),
             amount_msat: 100_00_000,
         },
     );


### PR DESCRIPTION
## What

- `POST /keysend` was never registered in `lampo-httpd`, so REST clients got actix-web's default 404 — which has an **empty body** — while the jsonrpc core executed keysend payments fine. REST-driven tooling recorded these as payments that "return nothing in ~0s".
- `json_keysend` returned `{}` (old FIXME): it now waits for the payment events and returns the same `PayResult` shape as `pay` (`state`, `path`, `payment_hash`, `payment_preimage`), sharing the wait loop with `json_pay` via `wait_for_payment_result`.
- `request::KeySend.destination` is now a string node id (like `OpenChannel::node_id`) with a `destination()` parser helper; cln integration test adapted.

## Evidence (pre-production soak on the debian server)

- main-next smoke, round 2: `n3 -> n2 keysend state=none dur=0s`, raw response empty; manual replay: 8 ms empty reply, **no jsonrpc inventory log line** → request never reached the handler → unregistered route / empty 404 body.
- After this patch: `/keysend` reaches `json_keysend`, sends the payment and long-polls for the terminal event (validated live on the regtest cluster).

Found by the `sim/main-next` pre-production simulation harness (`sim/`, see `docs/simulation/2026-08-15-main-next-simulation-plan.md`).