### PR TITLE
Fix OpenVuln findings: BOLT-8 seed, DNS-rebinding, CSRF, DoS, anchor close-tx

### DIFF
--- a/lampo-chain/src/lib.rs
+++ b/lampo-chain/src/lib.rs
@@ -218,7 +218,14 @@ impl Backend for LampoChainSync {
             Err(err) => {
                 let msg = format!("Failed to broadcast transaction: {err}");
                 log::error!(target: "lampo-chain", "{}", msg);
-                handler.emit(Event::OnChain(OnChainEvent::FundingChannelFailed(msg)));
+                // Tag with txid so an `open_channel` waiter waiting on this
+                // funding broadcast can fail without reacting to unrelated
+                // (e.g. unilateral-close) broadcast errors.
+                handler.emit(Event::OnChain(OnChainEvent::FundingChannelFailed {
+                    temporary_channel_id: None,
+                    txid: Some(tx.compute_txid()),
+                    reason: msg,
+                }));
             }
         }
     }

--- a/lampo-common/src/event/onchain.rs
+++ b/lampo-common/src/event/onchain.rs
@@ -14,7 +14,15 @@ pub enum OnChainEvent {
     /// Emitted when funding a channel fails (e.g. insufficient funds),
     /// so that the `open_channel` wait loop can return an error
     /// instead of blocking forever.
-    FundingChannelFailed(String),
+    ///
+    /// Waiters must filter on `temporary_channel_id` and/or `txid`: the
+    /// event bus is process-wide, so an unrelated open's fee failure or a
+    /// non-funding broadcast error must not abort a different waiter.
+    FundingChannelFailed {
+        temporary_channel_id: Option<String>,
+        txid: Option<Txid>,
+        reason: String,
+    },
     ConfirmedTransaction((Transaction, u32, Header, Height)),
     DiscardedTransaction(Txid),
     UnconfirmedTransaction(Txid),
@@ -26,18 +34,25 @@ impl Debug for OnChainEvent {
             Self::ConfirmedTransaction((tx, idx, header, height)) => write!(
                 f,
                 "ConfirmedTransaction(txid: {}, idx {idx}, block: {:?}, height: {height})",
-                tx.txid(),
+                tx.compute_txid(),
                 header
             ),
             Self::NewBestBlock((header, height)) => {
                 write!(f, "NewBestBlock({}, {height})", header.block_hash())
             }
             Self::NewBlock(block) => write!(f, "NewBlock({})", block.block_hash()),
-            Self::SendRawTransaction(tx) => write!(f, "SendRawTransaction({})", tx.txid()),
-            Self::UnconfirmedTransaction(tx) => write!(f, "UnconfirmedTransaction({})", tx),
-            Self::FundingChannelFailed(reason) => {
-                write!(f, "FundingChannelFailed({})", reason)
+            Self::SendRawTransaction(tx) => {
+                write!(f, "SendRawTransaction({})", tx.compute_txid())
             }
+            Self::UnconfirmedTransaction(tx) => write!(f, "UnconfirmedTransaction({})", tx),
+            Self::FundingChannelFailed {
+                temporary_channel_id,
+                txid,
+                reason,
+            } => write!(
+                f,
+                "FundingChannelFailed(channel={temporary_channel_id:?}, txid={txid:?}, {reason})"
+            ),
             _ => write!(f, "Debug fmt not unsupported"),
         }
     }

--- a/lampo-httpd/src/commands/daemon.rs
+++ b/lampo-httpd/src/commands/daemon.rs
@@ -1,3 +1,4 @@
+use paperclip::actix::web::Json;
 use paperclip::actix::{self, web};
 
 use lampo_common::json;
@@ -6,7 +7,14 @@ use crate::AppState;
 
 #[actix::api_v2_operation]
 #[actix::post("stop")]
-pub async fn rest_stop(state: web::Data<AppState>) -> actix_web::HttpResponse {
+pub async fn rest_stop(
+    state: web::Data<AppState>,
+    // Require a JSON body so this shutdown endpoint cannot be triggered by a
+    // cross-origin "simple request". `application/json` is not CORS-safelisted,
+    // so a browser must send a preflight the API never answers -- closing the
+    // CSRF hole that let any page the operator visited kill the daemon.
+    _body: Json<json::Value>,
+) -> actix_web::HttpResponse {
     log::info!(target: "httpd", "Stop request received via API");
     state.lampod.shutdown();
     actix_web::HttpResponse::Ok().json(json::json!({"status": "shutting_down"}))

--- a/lampo-httpd/src/commands/onchain.rs
+++ b/lampo-httpd/src/commands/onchain.rs
@@ -1,4 +1,5 @@
 use paperclip::actix::web;
+use paperclip::actix::web::Json;
 use paperclip::actix::{self, CreatedJson};
 use paste::paste;
 

--- a/lampo-httpd/src/lib.rs
+++ b/lampo-httpd/src/lib.rs
@@ -326,6 +326,15 @@ macro_rules! post {
             #[actix::post($name)]
             pub async fn [<rest_$name>](
                 state: web::Data<AppState>,
+                // Even though the backend takes no input, require a JSON body.
+                // The `Json` extractor rejects any request without
+                // `Content-Type: application/json`, and that content type is
+                // not CORS-safelisted -- so a cross-origin page cannot reach
+                // this endpoint with a "simple request" (it forces a preflight,
+                // which the API answers with no CORS headers). Without this,
+                // these bodyless endpoints (e.g. `/stop`) are trivially
+                // CSRF-able from any page the operator visits.
+                _body: Json<json::Value>,
             ) -> ResultJson<$res_ty> {
                 log::debug!(target: "httpd", "request with empty json body");
                 let response = [<json_$name>](&state.lampod, &json::json!({})).await;

--- a/lampo-httpd/src/lib.rs
+++ b/lampo-httpd/src/lib.rs
@@ -6,7 +6,10 @@ use std::net::ToSocketAddrs;
 use std::{fmt::Display, sync::Arc};
 
 use actix::{web, HttpResponseWrapper, OpenApiExt};
-use actix_web::{App, HttpResponse, HttpServer, ResponseError};
+use actix_web::body::MessageBody;
+use actix_web::dev::{ServiceRequest, ServiceResponse};
+use actix_web::middleware::{from_fn, Next};
+use actix_web::{App, Error, HttpResponse, HttpServer, ResponseError};
 use paperclip::actix::{self, CreatedJson};
 
 use lampo_common::error;
@@ -100,6 +103,122 @@ impl AppState {
     }
 }
 
+/// DNS-rebinding guard configuration shared with the [`reject_rebinding`]
+/// middleware.
+#[derive(Clone)]
+struct HostGuard {
+    /// Host part of the address the API is bound to (no port).
+    bind_host: String,
+    /// Whether to enforce the `Host` header check. Empty bind hosts skip
+    /// it; wildcard binds still enforce, but allow IP-literal Host headers
+    /// rather than matching `0.0.0.0` / `::` (no client sends those).
+    enforce: bool,
+}
+
+impl HostGuard {
+    fn is_ip(host: &str) -> bool {
+        host.parse::<std::net::IpAddr>().is_ok()
+    }
+
+    fn is_wildcard(host: &str) -> bool {
+        host == "0.0.0.0" || host == "::"
+    }
+
+    fn is_loopback(host: &str) -> bool {
+        host.eq_ignore_ascii_case("localhost")
+            || host
+                .parse::<std::net::IpAddr>()
+                .map(|ip| ip.is_loopback())
+                .unwrap_or(false)
+    }
+
+    /// Strip an optional `:port` from a Host header value without mangling
+    /// bracketed IPv6 literals (`[::1]` / `[::1]:7979`).
+    fn host_without_port(header: &str) -> &str {
+        if let Some(rest) = header.strip_prefix('[') {
+            if let Some(end) = rest.find(']') {
+                return &rest[..end];
+            }
+        }
+        header.rsplit_once(':').map(|(h, _)| h).unwrap_or(header)
+    }
+
+    /// Compare Host names: IP literals via parsed equality (IPv6 hex is
+    /// case-insensitive), DNS names via ASCII case-insensitive equality.
+    fn hosts_equal(a: &str, b: &str) -> bool {
+        match (a.parse::<std::net::IpAddr>(), b.parse::<std::net::IpAddr>()) {
+            (Ok(ia), Ok(ib)) => ia == ib,
+            _ => a.eq_ignore_ascii_case(b),
+        }
+    }
+
+    /// Returns whether a request's `Host` header is allowed to reach the API.
+    fn allows(&self, req: &ServiceRequest) -> bool {
+        if !self.enforce {
+            return true;
+        }
+        let Some(header) = req
+            .headers()
+            .get(actix_web::http::header::HOST)
+            .and_then(|value| value.to_str().ok())
+        else {
+            // A missing/undecodable Host header on an enforced bind is not a
+            // legitimate client; reject it.
+            return false;
+        };
+        let host = Self::host_without_port(header);
+        if Self::hosts_equal(host, &self.bind_host) {
+            return true;
+        }
+        // Loopback bind (`127.0.0.1`, `::1`, or `localhost`): allow the
+        // other loopback aliases. Binding `localhost` must still accept
+        // `Host: 127.0.0.1` (and vice versa).
+        if Self::is_loopback(&self.bind_host) && Self::is_loopback(host) {
+            return true;
+        }
+        // Wildcard bind: a domain Host is the DNS-rebinding signature.
+        // Literal IPs (and localhost) are how a real client addresses an
+        // interface-wildcard socket, so they stay allowed.
+        if Self::is_wildcard(&self.bind_host) && (Self::is_ip(host) || Self::is_loopback(host)) {
+            return true;
+        }
+        false
+    }
+}
+
+/// Reject requests whose `Host` header does not match the bound address.
+///
+/// This is the server-side defence against DNS-rebinding: the loopback-only
+/// default bind is the API's *only* access control, and a rebinding attack
+/// turns any page the operator visits into a same-origin client of the
+/// unauthenticated control plane. actix routes purely on `(method, path)` and
+/// never inspects `Host`, so without this middleware `http://evil.tld:7979`
+/// re-resolved to `127.0.0.1` reaches every fund-moving endpoint. A rebound
+/// request still carries the attacker's `Host`, so matching it against the
+/// bind address blocks the attack while leaving genuine loopback clients
+/// (`127.0.0.1`, `localhost`) untouched.
+async fn reject_rebinding(
+    guard: web::Data<HostGuard>,
+    req: ServiceRequest,
+    next: Next<impl MessageBody + 'static>,
+) -> Result<ServiceResponse<impl MessageBody + 'static>, Error> {
+    if guard.allows(&req) {
+        Ok(next.call(req).await?.map_into_boxed_body())
+    } else {
+        let host = req
+            .headers()
+            .get(actix_web::http::header::HOST)
+            .and_then(|value| value.to_str().ok())
+            .unwrap_or("<none>")
+            .to_owned();
+        log::warn!(
+            target: "httpd",
+            "rejecting request with disallowed Host header `{host}` (DNS-rebinding guard)"
+        );
+        Ok(req.into_response(HttpResponse::Forbidden().finish()))
+    }
+}
+
 pub async fn run<T: ToSocketAddrs + Display>(
     lampod: Arc<LampoDaemon>,
     host: T,
@@ -108,13 +227,31 @@ pub async fn run<T: ToSocketAddrs + Display>(
     let host_str = format!("{host}");
     log::info!("httpd api running on `{host_str}`");
 
+    // Host part of the bind address, used by the DNS-rebinding guard.
+    let bind_host = host_str
+        .rsplit_once(':')
+        .map(|(h, _)| h)
+        .unwrap_or(host_str.as_str())
+        .trim_matches(|c| c == '[' || c == ']')
+        .to_string();
+    // Enforce even on wildcard binds: skipping the check is how DNS
+    // rebinding reaches a LAN-exposed unauthenticated API. The matcher
+    // treats wildcards as "IP-literal Host only", not "allow anything".
+    let enforce_host = !bind_host.is_empty();
+
     let server = HttpServer::new(move || {
         let state = AppState::new(lampod.clone(), host_str.clone(), open_api_url.clone()).unwrap();
+        let host_guard = HostGuard {
+            bind_host: bind_host.clone(),
+            enforce: enforce_host,
+        };
         // FIXME: It is possible to avoid mapping the service in here?
         // it ispossible to init the app outside the callback and
         // use the macros to do add services?
         App::new()
             .app_data(web::Data::new(state))
+            .app_data(web::Data::new(host_guard))
+            .wrap(from_fn(reject_rebinding))
             .wrap_api()
             .service(swagger_api)
             .service(rest_getinfo)
@@ -232,4 +369,150 @@ macro_rules! post {
             }
         }
     };
+}
+
+#[cfg(test)]
+mod tests {
+    use actix_web::http::StatusCode;
+    use actix_web::middleware::from_fn;
+    use actix_web::{test, web, App, HttpResponse};
+
+    use super::{reject_rebinding, HostGuard};
+
+    async fn ok_handler() -> HttpResponse {
+        HttpResponse::Ok().finish()
+    }
+
+    async fn status_for(guard: HostGuard, host: Option<&str>) -> StatusCode {
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::new(guard))
+                .wrap(from_fn(reject_rebinding))
+                .route("/getinfo", web::post().to(ok_handler)),
+        )
+        .await;
+
+        let mut req = test::TestRequest::post().uri("/getinfo");
+        if let Some(host) = host {
+            req = req.insert_header(("Host", host));
+        }
+        test::call_service(&app, req.to_request()).await.status()
+    }
+
+    fn loopback_guard() -> HostGuard {
+        HostGuard {
+            bind_host: "127.0.0.1".to_string(),
+            enforce: true,
+        }
+    }
+
+    // A rebound origin (`http://evil.tld:7979` re-resolved to 127.0.0.1) still
+    // carries the attacker's Host header, so it must be rejected.
+    #[actix_web::test]
+    async fn rejects_foreign_host() {
+        assert_eq!(
+            status_for(loopback_guard(), Some("evil.attacker.tld")).await,
+            StatusCode::FORBIDDEN
+        );
+        assert_eq!(
+            status_for(loopback_guard(), Some("evil.attacker.tld:7979")).await,
+            StatusCode::FORBIDDEN
+        );
+    }
+
+    // A missing Host header on an enforced bind is not a legitimate client.
+    #[actix_web::test]
+    async fn rejects_missing_host() {
+        assert_eq!(
+            status_for(loopback_guard(), None).await,
+            StatusCode::FORBIDDEN
+        );
+    }
+
+    // Genuine loopback clients keep working (bind IP, `localhost`, `::1`).
+    #[actix_web::test]
+    async fn allows_loopback_hosts() {
+        for host in [
+            "127.0.0.1",
+            "127.0.0.1:7979",
+            "localhost:7979",
+            "[::1]",
+            "[::1]:7979",
+        ] {
+            assert_eq!(
+                status_for(loopback_guard(), Some(host)).await,
+                StatusCode::OK,
+                "host `{host}` should be allowed"
+            );
+        }
+    }
+
+    // DNS Host comparison is ASCII case-insensitive (RFC 4343).
+    #[actix_web::test]
+    async fn allows_case_insensitive_dns_hosts() {
+        let guard = HostGuard {
+            bind_host: "localhost".to_string(),
+            enforce: true,
+        };
+        for host in ["LOCALHOST", "LocalHost:7979", "localhost"] {
+            assert_eq!(
+                status_for(guard.clone(), Some(host)).await,
+                StatusCode::OK,
+                "host `{host}` should be allowed"
+            );
+        }
+        let named = HostGuard {
+            bind_host: "api.example".to_string(),
+            enforce: true,
+        };
+        assert_eq!(
+            status_for(named.clone(), Some("API.EXAMPLE:7979")).await,
+            StatusCode::OK
+        );
+        assert_eq!(
+            status_for(named, Some("evil.EXAMPLE")).await,
+            StatusCode::FORBIDDEN
+        );
+    }
+
+    // Binding `localhost` must still accept loopback IP Host headers.
+    #[actix_web::test]
+    async fn localhost_bind_allows_loopback_ips() {
+        let guard = HostGuard {
+            bind_host: "localhost".to_string(),
+            enforce: true,
+        };
+        for host in ["localhost:7979", "127.0.0.1:7979", "[::1]:7979"] {
+            assert_eq!(
+                status_for(guard.clone(), Some(host)).await,
+                StatusCode::OK,
+                "host `{host}` should be allowed"
+            );
+        }
+        assert_eq!(
+            status_for(guard, Some("evil.attacker.tld")).await,
+            StatusCode::FORBIDDEN
+        );
+    }
+
+    // Wildcard binds still reject domain Host headers (DNS rebinding)
+    // and only accept IP literals / localhost.
+    #[actix_web::test]
+    async fn wildcard_bind_rejects_domain_hosts() {
+        let guard = HostGuard {
+            bind_host: "0.0.0.0".to_string(),
+            enforce: true,
+        };
+        assert_eq!(
+            status_for(guard.clone(), Some("anything.tld")).await,
+            StatusCode::FORBIDDEN
+        );
+        for host in ["192.168.1.5:7979", "127.0.0.1:7979", "localhost:7979"] {
+            assert_eq!(
+                status_for(guard.clone(), Some(host)).await,
+                StatusCode::OK,
+                "host `{host}` should be allowed on a wildcard bind"
+            );
+        }
+    }
 }

--- a/lampod/src/actions/handler.rs
+++ b/lampod/src/actions/handler.rs
@@ -271,20 +271,50 @@ impl Handler for LampoHandler {
                 }));
 
                 log::info!("propagate funding transaction for open a channel with `{counterparty_node_id}`");
+                // Drop the outbound channel when funding cannot proceed: LDK
+                // still holds the temporary channel after `FundingGenerationReady`,
+                // and leaving it live after a fee/wallet failure means a retry
+                // races the original open while the waiter already returned.
+                let abandon_temp_channel = |this: &LampoHandler, msg: &str| {
+                    this.emit(Event::OnChain(OnChainEvent::FundingChannelFailed {
+                        temporary_channel_id: Some(temporary_channel_id.to_string()),
+                        txid: None,
+                        reason: msg.to_owned(),
+                    }));
+                    if let Err(err) = this
+                        .channel_manager
+                        .manager()
+                        .force_close_broadcasting_latest_txn(
+                            &temporary_channel_id,
+                            &counterparty_node_id,
+                            msg.to_owned(),
+                        )
+                    {
+                        log::warn!(
+                            target: "lampo",
+                            "failed to abandon channel `{temporary_channel_id}` after funding error: {err:?}"
+                        );
+                    }
+                };
                 // FIXME: estimate the fee rate with a callback
-                let fee = self
-                    .chain_manager
-                    .backend
-                    .fee_rate_estimation(6)
-                    .await
-                    .map_err(|err| {
+                let fee = match self.chain_manager.backend.fee_rate_estimation(6).await {
+                    std::result::Result::Ok(fee) => fee,
+                    Err(err) => {
                         let msg = format!("Channel Opening Error: {err}");
+                        // The `open_channel` waiter only wakes on a matching
+                        // `SendRawTransaction` or `FundingChannelFailed`; without
+                        // emitting the latter a fee-estimation failure leaves that
+                        // request task hanging forever (socket + event-bus
+                        // subscription leaked), which an unauthenticated caller
+                        // can exploit.
+                        abandon_temp_channel(self, &msg);
                         self.emit(Event::Lightning(LightningEvent::ChannelEvent {
                             state: "error".to_owned(),
                             message: msg,
                         }));
-                        err
-                    })?;
+                        return Err(err);
+                    }
+                };
                 log::info!("fee estimated {:?} sats", fee);
 
                 let best_block = self.channel_manager.manager().current_best_block().height;
@@ -303,9 +333,7 @@ impl Handler for LampoHandler {
                     Err(err) => {
                         let msg = format!("Failed to create funding transaction: {err}");
                         log::error!(target: "lampo", "{}", msg);
-                        self.emit(Event::OnChain(OnChainEvent::FundingChannelFailed(
-                            msg.clone(),
-                        )));
+                        abandon_temp_channel(self, &msg);
                         return Err(err);
                     }
                 };
@@ -317,20 +345,39 @@ impl Handler for LampoHandler {
                     "transaction hex `{}`",
                     lampo_common::bitcoin::consensus::encode::serialize_hex(&transaction)
                 );
+                // Hand the tx to LDK *before* emitting `FundingChannelEnd`,
+                // under the shared wait-state lock so a concurrent timeout
+                // cannot force-close an already-accepted funding (and so we
+                // skip handoff if the waiter already abandoned).
+                match self
+                    .channel_manager
+                    .funding_transaction_generated_if_waiting(
+                        temporary_channel_id,
+                        counterparty_node_id,
+                        transaction.clone(),
+                    ) {
+                    std::result::Result::Ok(false) => {
+                        let msg =
+                            "funding wait already abandoned; skipped funding_transaction_generated"
+                                .to_owned();
+                        log::warn!(target: "lampo", "{}", msg);
+                        abandon_temp_channel(self, &msg);
+                        return Err(error::anyhow!("{}", msg));
+                    }
+                    std::result::Result::Err(err) => {
+                        let msg = format!("funding_transaction_generated failed: {err}");
+                        log::error!(target: "lampo", "{}", msg);
+                        abandon_temp_channel(self, &msg);
+                        return Err(err);
+                    }
+                    std::result::Result::Ok(true) => {}
+                }
                 self.emit(Event::Lightning(LightningEvent::FundingChannelEnd {
                     counterparty_node_id,
                     temporary_channel_id,
                     channel_value_satoshis,
-                    funding_transaction: transaction.clone(),
+                    funding_transaction: transaction,
                 }));
-                self.channel_manager
-                    .manager()
-                    .funding_transaction_generated(
-                        temporary_channel_id,
-                        counterparty_node_id,
-                        transaction,
-                    )
-                    .map_err(|err| error::anyhow!("{:?}", err))?;
                 Ok(())
             }
             ldk::events::Event::ChannelPending {

--- a/lampod/src/actions/handler.rs
+++ b/lampod/src/actions/handler.rs
@@ -19,6 +19,7 @@ use lampo_common::handler::Handler as EventHandler;
 use lampo_common::json;
 use lampo_common::jsonrpc::Request;
 use lampo_common::ldk;
+use lampo_common::ldk::chain::chaininterface::{BroadcasterInterface, TransactionType};
 use lampo_common::ldk::sign::NodeSigner;
 use lampo_common::model::response::PaymentHop;
 use lampo_common::model::response::PaymentState;
@@ -627,6 +628,56 @@ impl Handler for LampoHandler {
                     }
                     log::error!(target: "lampo::handler", "no reachable address for `{node_id}`; an onion message to it will not be delivered");
                 });
+                Ok(())
+            }
+            ldk::events::Event::BumpTransaction(
+                ldk::events::bump_transaction::BumpTransactionEvent::ChannelClose {
+                    channel_id,
+                    counterparty_node_id,
+                    commitment_tx,
+                    pending_htlcs,
+                    ..
+                },
+            ) => {
+                // For anchor channels -- lampo's default channel type -- LDK
+                // does NOT broadcast the force-close commitment through the
+                // `BroadcasterInterface`. It hands the fully-signed holder
+                // commitment to the host inside this event and makes the host
+                // the sole broadcaster. The old catch-all `_` arm dropped it in
+                // a log line, so the channel balance stayed frozen on an
+                // unspent funding output with no recovery path. Broadcast it
+                // now so the funds can be swept once it confirms. A CPFP anchor
+                // child to fee-bump the (near zero-fee) commitment is still
+                // TODO, but the commitment must at least reach the mempool.
+                log::warn!(
+                    target: "lampo::handler",
+                    "channel `{channel_id}` with `{counterparty_node_id}` force-closed: \
+                     broadcasting local commitment tx `{}` ({} pending HTLC(s))",
+                    commitment_tx.compute_txid(),
+                    pending_htlcs.len(),
+                );
+                self.chain_manager.broadcast_transactions(&[(
+                    &commitment_tx,
+                    TransactionType::UnilateralClose {
+                        counterparty_node_id,
+                        channel_id,
+                    },
+                )]);
+                Ok(())
+            }
+            ldk::events::Event::BumpTransaction(
+                ldk::events::bump_transaction::BumpTransactionEvent::HTLCResolution { .. },
+            ) => {
+                // Zero-fee HTLC claims of anchor channels are likewise
+                // event-delivered and host-broadcast. Full anchor-fee handling
+                // is not implemented yet, so surface this loudly rather than
+                // silently dropping it: unresolved in-flight HTLCs can lose
+                // value once their CLTV deadlines pass.
+                log::error!(
+                    target: "lampo::handler",
+                    "unhandled BumpTransaction::HTLCResolution: in-flight HTLC claims need \
+                     manual broadcast to enforce CLTV deadlines"
+                );
                 Ok(())
             }
             _ => {

--- a/lampod/src/lib.rs
+++ b/lampod/src/lib.rs
@@ -293,7 +293,21 @@ impl LampoDaemon {
         let _ = self.onchain_manager().listen();
         log::info!(target: "lampo", "Starting peer manager");
         let shutdown = self.shutdown.clone();
-        let _ = self.peer_manager().run_with_shutdown(shutdown.clone());
+        // A failed p2p listener bind must stop the node, not leave it running
+        // without an inbound peer plane. Surface the error to the caller
+        // (`listen().await??` in the binary, or the returned `JoinHandle` for
+        // embedders) and flip the shutdown flag so the rest of the daemon
+        // winds down instead of serving headless.
+        if let Err(err) = self.peer_manager().run_with_shutdown(shutdown.clone()) {
+            log::error!(target: "lampod", "peer manager failed to start: {err}");
+            self.shutdown.store(true, Ordering::Release);
+            return tokio::spawn(async move {
+                // Bind failures are the common case, but `run_with_shutdown`
+                // also fails on nonblocking setup / internal state. Do not
+                // collapse every error into `AddrInUse`.
+                Err(io::Error::new(io::ErrorKind::Other, err.to_string()))
+            });
+        }
         log::info!(target: "lampo", "Starting channel manager");
         let _ = self.channel_manager().listen();
 

--- a/lampod/src/ln/channel_manager.rs
+++ b/lampod/src/ln/channel_manager.rs
@@ -1,14 +1,16 @@
 //! Channel Manager Implementation
+use std::collections::HashMap;
 use std::fs::File;
 use std::io::BufReader;
 use std::path::Path;
 use std::sync::{Arc, Mutex, OnceLock};
-use std::time::SystemTime;
+use std::time::{Duration, SystemTime};
 
 use lampo_common::backend::Backend;
 use lampo_common::bitcoin::{BlockHash, Transaction};
 use lampo_common::conf::LampoConf;
 use lampo_common::error;
+use lampo_common::event::ln::LightningEvent;
 use lampo_common::event::onchain::OnChainEvent;
 use lampo_common::event::Event;
 use lampo_common::handler::Handler;
@@ -35,13 +37,30 @@ use lampo_common::types::LampoChannel;
 use lampo_common::types::LampoGraph;
 use lampo_common::types::LampoRouter;
 use lampo_common::types::LampoScorer;
-use lampo_common::types::{LampoArcChannelManager, LampoChainMonitor};
+use lampo_common::types::{ChannelId, LampoArcChannelManager, LampoChainMonitor};
 
 use crate::actions::handler::LampoHandler;
 use crate::async_run;
 use crate::chain::{LampoChainManager, WalletManager};
 use crate::persistence::LampoPersistence;
 use crate::utils::logger::LampoLogger;
+
+/// How long `open_channel` waits for the funding transaction to be broadcast
+/// before giving up. LDK reaps a stalled unfunded channel after roughly a
+/// minute of ping ticks; this outer bound guarantees the request always
+/// returns even if the peer stalls in a state that emits no terminal event.
+const FUNDING_WAIT_TIMEOUT_SECS: u64 = 120;
+
+/// Coordinates the `open_channel` waiter with `FundingGenerationReady` so a
+/// timeout cannot force-close a channel whose funding LDK already accepted
+/// (and vice versa: the producer must not hand off after the waiter abandoned).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum FundingWaitState {
+    /// Waiter timed out; producer must not call `funding_transaction_generated`.
+    Abandoned,
+    /// Producer handed funding to LDK; waiter must not force-close.
+    Accepted,
+}
 
 pub struct LampoChannelManager {
     monitor: OnceLock<Arc<LampoChainMonitor>>,
@@ -51,6 +70,8 @@ pub struct LampoChannelManager {
     score: OnceLock<Arc<Mutex<LampoScorer>>>,
     handler: OnceLock<Arc<LampoHandler>>,
     router: OnceLock<Arc<LampoRouter>>,
+    /// Shared with the event handler; see [`FundingWaitState`].
+    funding_wait_state: Mutex<HashMap<ChannelId, FundingWaitState>>,
 
     pub(crate) onchain: Arc<LampoChainManager>,
     pub(crate) conf: LampoConf,
@@ -78,7 +99,62 @@ impl LampoChannelManager {
             graph: OnceLock::new(),
             score: OnceLock::new(),
             router: OnceLock::new(),
+            funding_wait_state: Mutex::new(HashMap::new()),
         }
+    }
+
+    /// Hand funding to LDK only if the waiter has not already abandoned.
+    /// Holds the wait-state lock across the LDK call so timeout cleanup cannot
+    /// race the handoff.
+    pub(crate) fn funding_transaction_generated_if_waiting(
+        &self,
+        temporary_channel_id: ChannelId,
+        counterparty_node_id: lampo_common::types::NodeId,
+        transaction: Transaction,
+    ) -> error::Result<bool> {
+        let mut state = self
+            .funding_wait_state
+            .lock()
+            .expect("funding wait state poisoned");
+        if matches!(
+            state.get(&temporary_channel_id),
+            Some(FundingWaitState::Abandoned)
+        ) {
+            return Ok(false);
+        }
+        self.manager()
+            .funding_transaction_generated(temporary_channel_id, counterparty_node_id, transaction)
+            .map_err(|err| error::anyhow!("{:?}", err))?;
+        state.insert(temporary_channel_id, FundingWaitState::Accepted);
+        Ok(true)
+    }
+
+    /// Returns `true` when the waiter should force-close (handoff not yet
+    /// accepted). Marks the open as abandoned so a concurrent producer skips
+    /// `funding_transaction_generated`.
+    pub(crate) fn abandon_funding_wait_if_unaccepted(
+        &self,
+        temporary_channel_id: ChannelId,
+    ) -> bool {
+        let mut state = self
+            .funding_wait_state
+            .lock()
+            .expect("funding wait state poisoned");
+        if matches!(
+            state.get(&temporary_channel_id),
+            Some(FundingWaitState::Accepted)
+        ) {
+            return false;
+        }
+        state.insert(temporary_channel_id, FundingWaitState::Abandoned);
+        true
+    }
+
+    pub(crate) fn clear_funding_wait(&self, temporary_channel_id: &ChannelId) {
+        self.funding_wait_state
+            .lock()
+            .expect("funding wait state poisoned")
+            .remove(temporary_channel_id);
     }
 
     pub fn set_handler(&self, handler: Arc<LampoHandler>) {
@@ -252,10 +328,18 @@ impl LampoChannelManager {
         // its channels existed.
         let mut config = self.conf.ldk_conf.clone();
         config.channel_handshake_config.announce_for_forwarding = open_channel.public;
+        let peer_id = open_channel.node_id()?;
         let push_msat = open_channel.push_msat.unwrap_or(0);
-        self.manager()
+        // Subscribe *before* `create_channel`: a fast peer can finish
+        // negotiation on another runtime thread and emit `FundingChannelEnd`
+        // before a post-create subscription would see it, leaving the handoff
+        // flag false and the timeout path force-closing an already-funded
+        // channel.
+        let mut events = self.handler().events();
+        let temp_channel_id = self
+            .manager()
             .create_channel(
-                open_channel.node_id()?,
+                peer_id,
                 open_channel.amount,
                 push_msat,
                 0,
@@ -264,25 +348,153 @@ impl LampoChannelManager {
             )
             .map_err(|err| error::anyhow!("{:?}", err))?;
 
-        // Wait for SendRawTransaction or FundingChannelFailed to be received
-        let mut events = self.handler().events();
-        let tx: Option<Transaction> = loop {
-            let event = events
-                .recv()
-                .await
-                .ok_or(error::anyhow!("Channel funding: no event received"))?;
+        // Wait for *this* channel's funding transaction to be broadcast, or
+        // for the open to fail. The event bus is process-wide: any
+        // `SendRawTransaction` (including unilateral-close / bump broadcasts)
+        // or any `FundingChannelFailed` would otherwise complete or abort an
+        // unrelated waiter. Close events are matched on the temporary channel
+        // id returned by `create_channel` for the same reason. Without a
+        // terminal case and an overall timeout the request task blocks on
+        // `recv().await` forever, leaking its actix task, socket and event-bus
+        // subscription; an unauthenticated flood of such requests exhausts the
+        // process fd table and takes the node down.
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(FUNDING_WAIT_TIMEOUT_SECS);
+        let mut expected_funding_txid = None;
+        let mut funding_handed_to_ldk = false;
+        let mut early_broadcast: Option<Transaction> = None;
+        let tx: Option<Transaction> = 'wait: loop {
+            // Apply one event. `None` keeps waiting; `Some` ends the loop.
+            let apply = |event: Event,
+                         expected: &mut Option<lampo_common::bitcoin::Txid>,
+                         handed: &mut bool,
+                         early: &mut Option<Transaction>|
+             -> Option<error::Result<Option<Transaction>>> {
+                match event {
+                    Event::Lightning(LightningEvent::FundingChannelEnd {
+                        temporary_channel_id,
+                        funding_transaction,
+                        ..
+                    }) if temporary_channel_id == temp_channel_id => {
+                        let txid = funding_transaction.compute_txid();
+                        *expected = Some(txid);
+                        *handed = true;
+                        // Broadcast can race ahead of this event on a fast
+                        // peer; accept a buffered matching SendRawTransaction.
+                        if early.as_ref().is_some_and(|tx| tx.compute_txid() == txid) {
+                            return Some(Ok(early.take()));
+                        }
+                        None
+                    }
+                    Event::OnChain(OnChainEvent::SendRawTransaction(tx)) => {
+                        if *expected == Some(tx.compute_txid()) {
+                            Some(Ok(Some(tx)))
+                        } else if expected.is_none() {
+                            *early = Some(tx);
+                            None
+                        } else {
+                            None
+                        }
+                    }
+                    Event::OnChain(OnChainEvent::FundingChannelFailed {
+                        temporary_channel_id: Some(channel_id),
+                        reason,
+                        ..
+                    }) if channel_id == temp_channel_id.to_string() => {
+                        Some(Err(error::anyhow!("{}", reason)))
+                    }
+                    Event::OnChain(OnChainEvent::FundingChannelFailed {
+                        txid: Some(failed_txid),
+                        reason,
+                        ..
+                    }) if *expected == Some(failed_txid) => {
+                        // Handoff already succeeded; broadcast RPC errors are
+                        // ambiguous (backend may have accepted the tx) and LDK
+                        // may still rebroadcast. Do not present this as a
+                        // safely-retryable open failure.
+                        Some(Err(error::anyhow!(
+                            "channel funding broadcast reported failure after handoff ({reason}); channel left open (broadcast may still be pending)"
+                        )))
+                    }
+                    Event::Lightning(LightningEvent::CloseChannelEvent {
+                        channel_id,
+                        message,
+                        ..
+                    }) if channel_id == temp_channel_id.to_string() => Some(Err(error::anyhow!(
+                        "channel closed before funding: {message}"
+                    ))),
+                    _ => None,
+                }
+            };
 
-            match event {
-                Event::OnChain(OnChainEvent::SendRawTransaction(tx)) => {
-                    break Some(tx);
+            if tokio::time::Instant::now() >= deadline {
+                // Drain events that arrived as the deadline fired so a queued
+                // `FundingChannelEnd` cannot be missed before force-close.
+                while let Ok(event) = events.try_recv() {
+                    if let Some(done) = apply(
+                        event,
+                        &mut expected_funding_txid,
+                        &mut funding_handed_to_ldk,
+                        &mut early_broadcast,
+                    ) {
+                        self.clear_funding_wait(&temp_channel_id);
+                        break 'wait done?;
+                    }
                 }
-                Event::OnChain(OnChainEvent::FundingChannelFailed(reason)) => {
-                    return Err(error::anyhow!("{}", reason));
+                // Producer-owned wait state serializes with handoff: if LDK
+                // already accepted funding, do not force-close; if not, mark
+                // Abandoned so a concurrent producer skips handoff.
+                if funding_handed_to_ldk
+                    || !self.abandon_funding_wait_if_unaccepted(temp_channel_id)
+                {
+                    return Err(error::anyhow!(
+                        "channel funding broadcast still pending after {FUNDING_WAIT_TIMEOUT_SECS}s for peer {peer_id}; channel left open"
+                    ));
                 }
-                _ => {}
+                if let Err(err) = self.manager().force_close_broadcasting_latest_txn(
+                    &temp_channel_id,
+                    &peer_id,
+                    format!("funding wait timed out after {FUNDING_WAIT_TIMEOUT_SECS}s"),
+                ) {
+                    log::warn!(
+                        target: "lampo",
+                        "failed to abandon timed-out channel `{temp_channel_id}` with `{peer_id}`: {err:?}"
+                    );
+                    // Keep the `Abandoned` tombstone: a late
+                    // `FundingGenerationReady` must not hand funding to LDK
+                    // after we already reported timeout to the caller.
+                    return Err(error::anyhow!(
+                        "channel funding timed out after {FUNDING_WAIT_TIMEOUT_SECS}s waiting for peer {peer_id}"
+                    ));
+                }
+                self.clear_funding_wait(&temp_channel_id);
+                return Err(error::anyhow!(
+                    "channel funding timed out after {FUNDING_WAIT_TIMEOUT_SECS}s waiting for peer {peer_id}"
+                ));
+            }
+
+            match tokio::time::timeout_at(deadline, events.recv()).await {
+                Ok(Some(event)) => {
+                    if let Some(done) = apply(
+                        event,
+                        &mut expected_funding_txid,
+                        &mut funding_handed_to_ldk,
+                        &mut early_broadcast,
+                    ) {
+                        self.clear_funding_wait(&temp_channel_id);
+                        break 'wait done?;
+                    }
+                }
+                Ok(None) => {
+                    self.clear_funding_wait(&temp_channel_id);
+                    return Err(error::anyhow!("Channel funding: no event received"));
+                }
+                Err(_) => {
+                    // Deadline elapsed while waiting; next iteration drains.
+                }
             }
         };
 
+        self.clear_funding_wait(&temp_channel_id);
         let txid = tx.as_ref().map(|tx| tx.txid());
 
         Ok(response::OpenChannel {

--- a/lampod/src/ln/peer_manager.rs
+++ b/lampod/src/ln/peer_manager.rs
@@ -16,6 +16,7 @@ use lampo_common::ldk::net;
 use lampo_common::ldk::net::SocketDescriptor;
 use lampo_common::ldk::onion_message::messenger::{DefaultMessageRouter, OnionMessenger};
 use lampo_common::ldk::routing::gossip::{NetworkGraph, P2PGossipSync};
+use lampo_common::ldk::sign::EntropySource;
 use lampo_common::types::NodeId;
 use lampo_common::types::{LampoArcChannelManager, LampoChainMonitor, LampoGraph};
 
@@ -83,13 +84,21 @@ impl LampoPeerManager {
         wallet_manager: Arc<dyn WalletManager>,
         channel_manager: Arc<LampoChannelManager>,
     ) -> error::Result<()> {
-        let ephemeral_bytes = [0; 32];
         let current_time = SystemTime::now()
             .duration_since(SystemTime::UNIX_EPOCH)
             .unwrap()
             .as_secs();
 
         let keys = wallet_manager.ldk_keys().keys_manager.clone();
+        // LDK derives every per-connection BOLT-8 noise ephemeral key from
+        // these bytes, and `PeerManager::new` documents them as
+        // "cryptographically secure random bytes". A constant seed makes
+        // `midstate = SHA256(seed)` public, so every handshake ephemeral is
+        // publicly derivable from the cleartext pubkeys in Acts One/Two --
+        // which voids Noise_XK confidentiality and authentication (an active
+        // attacker can forge Act Two toward an initiator or Act Three toward a
+        // responder under any node_id). Seed from the node's CSPRNG instead.
+        let ephemeral_bytes = keys.get_secure_random_bytes();
         let graph = channel_manager.graph();
         let onion_messenger = Arc::new(OnionMessenger::new(
             keys.clone(),

--- a/lampod/src/ln/peer_manager.rs
+++ b/lampod/src/ln/peer_manager.rs
@@ -1,7 +1,8 @@
+use std::collections::HashMap;
 use std::net::SocketAddr;
 use std::str::FromStr;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 use std::time::{Duration, SystemTime};
 
 use async_trait::async_trait;
@@ -51,12 +52,30 @@ pub type SimpleArcPeerManager<M, T, L> = PeerManager<
 type InnerLampoPeerManager =
     SimpleArcPeerManager<LampoChainMonitor, LampoChainManager, LampoLogger>;
 
+/// Upper bound on the number of outbound dials the user-facing `connect`
+/// path keeps in flight at once. Each in-flight dial pins a task, two file
+/// descriptors and an LDK peer entry until the handshake reaper frees it, so
+/// an unauthenticated flood would otherwise exhaust the process fd table.
+const MAX_CONCURRENT_DIALS: usize = 32;
+
+/// How long a single user-facing dial may run before it is abandoned. Mirrors
+/// the reconnect loop's 5 s precedent, scaled to LDK's handshake-reaper bound
+/// (two ping-timer intervals), so a silent/black-holed peer cannot pin the
+/// request forever.
+const DIAL_TIMEOUT: Duration = Duration::from_secs(20);
+
 pub struct LampoPeerManager {
     peer_manager: Option<Arc<InnerLampoPeerManager>>,
     channel_manager: Option<Arc<LampoChannelManager>>,
     conf: LampoConf,
     logger: Arc<LampoLogger>,
     onion_messenger: Option<Arc<LampoArcOnionMessenger<LampoLogger>>>,
+    /// Caps concurrent outbound dials started through `connect` (see
+    /// [`MAX_CONCURRENT_DIALS`]).
+    dial_permits: Arc<tokio::sync::Semaphore>,
+    /// Serializes outbound dials per node id so a timed-out attempt's
+    /// cleanup cannot race another dial to the same peer.
+    outbound_dial_locks: Arc<Mutex<HashMap<NodeId, Arc<tokio::sync::Mutex<()>>>>>,
 }
 
 impl LampoPeerManager {
@@ -67,7 +86,13 @@ impl LampoPeerManager {
             logger,
             channel_manager: None,
             onion_messenger: None,
+            dial_permits: Arc::new(tokio::sync::Semaphore::new(MAX_CONCURRENT_DIALS)),
+            outbound_dial_locks: Arc::new(Mutex::new(HashMap::new())),
         }
+    }
+
+    fn outbound_dial_lock(&self, node_id: NodeId) -> OutboundDialLockGuard {
+        OutboundDialLockGuard::acquire(&self.outbound_dial_locks, node_id)
     }
 
     pub fn manager(&self) -> Arc<InnerLampoPeerManager> {
@@ -192,6 +217,7 @@ impl LampoPeerManager {
             let chan_manager = chan_manager.clone();
             let shutdown = shutdown.clone();
             let store_path = peer_store_path(&self.conf);
+            let dial_locks = Arc::clone(&self.outbound_dial_locks);
             tokio::spawn(async move {
                 let mut interval = tokio::time::interval(Duration::from_secs(10));
                 interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
@@ -216,13 +242,21 @@ impl LampoPeerManager {
                             target: "lampo",
                             "reconnecting to channel peer `{peer}` at `{host}`"
                         );
-                        // Bound each attempt so one hung TCP cannot stall
-                        // the rest of the channel list.
-                        let _ = tokio::time::timeout(
+                        // Share the per-node dial lock with user `/connect` so
+                        // a reconnect timeout cannot node-wide-disconnect a
+                        // concurrent user dial.
+                        let node_lock = OutboundDialLockGuard::acquire(&dial_locks, peer);
+                        let _node_guard = node_lock.lock.lock().await;
+                        if tokio::time::timeout(
                             Duration::from_secs(5),
                             dial(peer_manager.clone(), peer, host),
                         )
-                        .await;
+                        .await
+                        .is_err()
+                            && peer_manager.peer_by_node_id(&peer).is_none()
+                        {
+                            peer_manager.disconnect_by_node_id(peer);
+                        }
                     }
                 }
             });
@@ -332,7 +366,52 @@ impl LampoPeerManager {
     }
 
     pub async fn connect(&self, node_id: NodeId, host: SocketAddr) -> error::Result<()> {
-        dial(self.manager(), node_id, host).await?;
+        // Bound the resources an unauthenticated `/connect` caller can pin.
+        // Without a cap, a request flood accumulates one task + two fds + one
+        // LDK peer entry per in-flight dial until the handshake reaper frees
+        // it, exhausting the fd table and taking down both the REST API and
+        // the LN listener. Fail fast once the budget is spent instead of
+        // queueing, and time each dial out near the reaper bound so a silent
+        // peer cannot hold the slot for the full ping interval.
+        // Take a global dial permit *before* waiting on the per-node lock so
+        // silent-peer contention cannot queue unbounded HTTP tasks outside the
+        // 32-slot cap. Serialize per node so overlapping dials cannot leave a
+        // timeout's `disconnect_by_node_id` tearing down a sibling attempt that
+        // already completed (or an inbound that landed for the same id).
+        let _permit = Arc::clone(&self.dial_permits)
+            .try_acquire_owned()
+            .map_err(|_| error::anyhow!("too many concurrent connection attempts"))?;
+        let node_lock = self.outbound_dial_lock(node_id);
+        let _node_guard = node_lock.lock.lock().await;
+        let result = match tokio::time::timeout(DIAL_TIMEOUT, dial(self.manager(), node_id, host))
+            .await
+        {
+            Ok(result) => result,
+            Err(_) => {
+                // `timeout` only drops the close-notification future from
+                // `connect_outbound`; the socket and I/O tasks stay registered
+                // with the peer manager until its handshake reaper runs. Tear
+                // them down before the semaphore permit is released so a flood
+                // of timed-out `/connect`s cannot accumulate more than
+                // `MAX_CONCURRENT_DIALS` live outbound connections.
+                // Skip cleanup when a live peer already exists for this id —
+                // an inbound (or a completed sibling dial) must not be killed
+                // with the timed-out socket. `disconnect_by_node_id` is not
+                // socket-scoped.
+                if self.manager().peer_by_node_id(&node_id).is_none() {
+                    self.manager().disconnect_by_node_id(node_id);
+                } else {
+                    log::debug!(
+                        target: "lampo",
+                        "dial to `{node_id}` timed out but peer is already connected; leaving it alone"
+                    );
+                }
+                Err(error::anyhow!("timed out connecting to peer `{node_id}`"))
+            }
+        };
+        drop(_node_guard);
+        drop(node_lock);
+        result?;
         // Remember where this peer lives. LDK does not redial anyone on
         // restart, and a peer that never announced an address -- the common
         // case for an unannounced node -- is unreachable through the network
@@ -350,6 +429,47 @@ impl LampoPeerManager {
 
         self.manager().disconnect_by_node_id(node_id);
         Ok(())
+    }
+}
+
+/// Holds a per-node dial lock entry and removes it from the map on drop when
+/// nothing else references it — including when the `/connect` future is
+/// cancelled before reaching an explicit prune call.
+struct OutboundDialLockGuard {
+    node_id: NodeId,
+    lock: Arc<tokio::sync::Mutex<()>>,
+    map: Arc<Mutex<HashMap<NodeId, Arc<tokio::sync::Mutex<()>>>>>,
+}
+
+impl OutboundDialLockGuard {
+    fn acquire(
+        map: &Arc<Mutex<HashMap<NodeId, Arc<tokio::sync::Mutex<()>>>>>,
+        node_id: NodeId,
+    ) -> Self {
+        let lock = {
+            let mut map = map.lock().expect("outbound dial lock map poisoned");
+            map.entry(node_id)
+                .or_insert_with(|| Arc::new(tokio::sync::Mutex::new(())))
+                .clone()
+        };
+        Self {
+            node_id,
+            lock,
+            map: Arc::clone(map),
+        }
+    }
+}
+
+impl Drop for OutboundDialLockGuard {
+    fn drop(&mut self) {
+        let Ok(mut map) = self.map.lock() else {
+            return;
+        };
+        if map.get(&self.node_id).is_some_and(|existing| {
+            Arc::ptr_eq(existing, &self.lock) && Arc::strong_count(&self.lock) == 2
+        }) {
+            map.remove(&self.node_id);
+        }
     }
 }
 

--- a/lampod/src/ln/peer_manager.rs
+++ b/lampod/src/ln/peer_manager.rs
@@ -202,6 +202,22 @@ impl LampoPeerManager {
             .unwrap_or_else(|| "127.0.0.1".to_string());
         let bind_addr = format!("{bind_host}:{listen_port}");
 
+        // Bind the p2p listener eagerly, *before* detaching the accept loop.
+        // The bind used to live inside the spawned task, so a failure (most
+        // commonly the port being already taken) died in a dropped
+        // `JoinHandle` -- unlogged and unobserved -- and the node came up
+        // "healthy" (REST answering, chain syncing, getinfo echoing the
+        // configured address, the log even claiming it was listening) with no
+        // inbound peer plane at all: no inbound channels, no node-announcement
+        // refresh, and no way for monitoring to notice. A Lightning node must
+        // not run headless, so surface the error to the caller and refuse to
+        // start instead.
+        let listener = std::net::TcpListener::bind(&bind_addr)
+            .map_err(|e| error::anyhow!("failed to bind LN p2p listener on `{bind_addr}`: {e}"))?;
+        listener
+            .set_nonblocking(true)
+            .map_err(|e| error::anyhow!("failed to set the LN p2p listener non-blocking: {e}"))?;
+
         // Reconnect to channel counterparties. LDK never redials anyone:
         // after a restart (or any TCP drop) a node with live, ready channels
         // sits at zero peers forever -- it stops forwarding and cannot be
@@ -262,15 +278,14 @@ impl LampoPeerManager {
             });
         }
 
+        // Adopt the std listener into tokio *before* detaching the accept
+        // loop. `from_std` only fails if the socket is still blocking; that
+        // is a startup error and must surface from this function, not panic
+        // inside a dropped JoinHandle and leave the node running headless.
+        let listener = tokio::net::TcpListener::from_std(listener)
+            .map_err(|e| error::anyhow!("failed to adopt LN p2p listener into tokio: {e}"))?;
+        log::info!(target: "lampo", "Listening for in-bound connection on {bind_addr}");
         tokio::spawn(async move {
-            log::info!(target: "lampo", "Listening for in-bound connection on {bind_addr}");
-            let listener = match tokio::net::TcpListener::bind(bind_addr.clone()).await {
-                Ok(listener) => listener,
-                Err(e) => {
-                    return Err::<(), _>(error::anyhow!("Error binding to address: {}", e));
-                }
-            };
-
             // Node announcement runs in its own task, not inside each
             // inbound connection's task -- there is one announcement to
             // refresh, not one per peer, and the old per-connection
@@ -353,7 +368,7 @@ impl LampoPeerManager {
                     .await;
                 });
             }
-            Ok(())
+            Ok::<(), error::Error>(())
         });
         Ok(())
     }


### PR DESCRIPTION
## Summary

Evaluates the OpenVuln report (10 findings) against the current tree and fixes every finding that is still present. Three findings were already fixed on `main` after the report's `e65bd89` snapshot; the remaining **7 are patched here**, one focused commit each.

> ⚠️ Opened as a **draft** because the report marks all findings `disclosure: owner_only` and some are unpatched-until-now (incl. a critical transport-auth break). Mark ready when you're comfortable with public disclosure.

## Findings status

| # | Key | Sev | Status | Commit |
|---|-----|-----|--------|--------|
| 1/5 | `BUG-R2-C2-A1-H1/H3` | critical | **fixed here** | `ln: seed BOLT-8 noise ephemerals from the CSPRNG` |
| 2 | `BUG-R2-C1-A1-H2` | high | **fixed here** | `httpd: reject cross-origin Host headers…` |
| 3 | `BUG-R2-C1-A3-H1` | high | **fixed here** | `ln: bound and time out unauthenticated /connect…` |
| 4 | `BUG-R2-C1-A3-H2` | high | **fixed here** | `lampod: bound the channel-funding wait…` |
| 6 | `BUG-R2-C2-A6-H1` | high | **fixed here** | `handler: broadcast the commitment tx on BumpTransaction` |
| 8 | `BUG-R2-C1-A1-H1` | medium | **fixed here** | `httpd: require a JSON body on bodyless POST endpoints` |
| 9 | `BUG-R2-C2-A7-H1` | medium | **fixed here** | `ln: fail fast when the p2p listener cannot bind` |
| 7 | `BUG-R2-C2-A2-H1` | high | already fixed | `8880426` (fee unit sat/vB) |
| 10 | `BUG-R2-C2-A8-H1` | medium | already fixed | `222c71e` (monitor re-registration) |
| — | `/close` body-bind part of #8 | — | already fixed | `e496d21` |

## What each fix does

- **Constant BOLT-8 seed (`peer_manager.rs:86`)** — `[0; 32]` was passed to `PeerManager::new` as `ephemeral_random_data`, making every noise ephemeral publicly derivable from the cleartext Act One/Two pubkeys → full Noise_XK confidentiality/authentication collapse. Now seeded from `keys.get_secure_random_bytes()`.
- **DNS-rebinding (`httpd`)** — no `Host`/`Origin` validation on the loopback-only control plane. Added a `from_fn` middleware that rejects requests whose `Host` doesn't match the bound address. Loopback aliases (`localhost`/`127.0.0.1`/`::1`) are allowed even when the bind is `localhost`. Wildcard binds still reject domain Host headers (the rebinding signature) and only allow IP-literal / localhost Hosts. Unit-tested.
- **`/connect` slow-loris** — unbounded, un-timed dial. Added a 32-permit fail-fast semaphore + 20 s per-dial timeout.
- **`/fundchannel` hang** — the funding wait only woke on `SendRawTransaction`/`FundingChannelFailed`; a stalled/closed channel woke it never. Added a 120 s timeout, a `CloseChannelEvent` arm matched on the temp channel id from `create_channel`, an abandon via `force_close_broadcasting_latest_txn` on timeout (so a late `FundingGenerationReady` cannot still broadcast), and a `FundingChannelFailed` emit on the fee-error path.
- **`BumpTransaction` dropped** — anchor-channel force-close commitments are delivered to the host as the sole broadcaster and were dropped in the catch-all arm, freezing funds. Now broadcast (see limitation below).
- **CSRF on bodyless endpoints** — `/stop`, `/getinfo`, `/new_addr` took no body extractor and were CORS-safelisted "simple requests". Now require a `Json` body (non-safelisted `application/json` → preflight → blocked cross-origin).
- **Silent listener bind failure** — bind lived in a detached task whose `Err` was dropped, so a port conflict left the node running headless. Now binds eagerly, adopts the listener into tokio before spawn, and propagates the error through `listen()` as `io::ErrorKind::Other` (no `process::exit`, so embedders get an `Err`).

## Verification

- `cargo fmt --all --check` clean; `cargo check --workspace --all-targets` clean.
- **Every commit compiles independently** (checked each SHA in a shared-target worktree) so the history stays bisectable.
- Unit tests pass, including new `lampo-httpd` tests that reproduce finding #2 (foreign `Host` → 403, loopback → 200, `localhost` bind accepts loopback IPs, wildcard bind rejects domain Hosts).
- Integration smoke tests pass individually against real bitcoind/regtest: `init_connection_test_between_lampo`, `fund_a_simple_channel_from`, `pay_invoice_simple_case_lampo` — covering the connect, fund and pay paths this PR touches. (The payment tests remain flaky under back-to-back sequential runs, a pre-existing condition unrelated to these changes.)

## Limitations / follow-ups

- **`BumpTransaction`**: this broadcasts the signed commitment so it reaches the mempool and stops the silent freeze, but does **not** yet build the CPFP anchor child needed to fee-bump the near-zero-fee commitment, and `HTLCResolution` claims are logged loudly rather than broadcast. Full anchor-fee handling is a larger follow-up.