### PR TITLE
chain: cache bitcoind fees for the LDK estimator

### DIFF
--- a/lampo-chain/src/lib.rs
+++ b/lampo-chain/src/lib.rs
@@ -241,20 +241,33 @@ impl Backend for LampoChainSync {
         }
     }
 
-    async fn fee_rate_estimation(&self, blocks: u64) -> lampo_common::error::Result<u32> {
+    async fn fee_rate_estimation_with_mode(
+        &self,
+        blocks: u64,
+        mode: lampo_common::backend::FeeEstimateMode,
+    ) -> lampo_common::error::Result<u32> {
         #[derive(Deserialize)]
         pub struct FeeRate {
             feerate: Option<f64>,
             errors: Option<Vec<String>>,
         }
 
+        // ldk-node falls back to 1 sat/vB (250 sat/kW) on regtest/signet
+        // when bitcoind has no estimate. Returning 256 sat/vB here made
+        // MinAllowedNonAnchor 64000 sat/kW and rejected a 253 funder (I04).
         if self.config.network == lampo_common::bitcoin::Network::Regtest {
-            return Ok(256);
+            return Ok(250);
         }
 
         let resp = self
             .rpc_client
-            .call_method::<json::Value>("estimatesmartfee", &[blocks.into()])
+            .call_method::<json::Value>(
+                "estimatesmartfee",
+                &[
+                    blocks.into(),
+                    json::Value::String(mode.as_core_str().to_owned()),
+                ],
+            )
             .await?;
         let resp: FeeRate = json::from_value(resp)?;
         if let Some(errs) = resp.errors {
@@ -263,14 +276,10 @@ impl Backend for LampoChainSync {
         let Some(feerate) = resp.feerate else {
             return Err(error::anyhow!("No fee rate estimation available").into());
         };
-        // bitcoind returns BTC/kvB. The callers expect sat/vB (see
-        // `FeeRate::from_sat_per_vb_unchecked` in the channel funding path),
-        // so convert: BTC/kvB * 1e8 sat/BTC / 1000 vB/kvB = * 1e5 sat/vB.
-        // Returning sat/kvB here (a plain * 1e8) inflated fees by 1000x and
-        // made small wallets fail every channel open with "Insufficient
-        // funds" (found on the mutinynet leg: 7 sat/vB used as 7092 sat/vB).
-        let sats_per_vb = feerate * 100_000.0;
-        Ok(sats_per_vb.ceil() as u32)
+        // bitcoind returns BTC/kvB. Convert straight to sat/kW (ldk-node:
+        // `* 25_000_000`). Rounding through integer sat/vB first would turn
+        // 1.001 sat/vB into 500 sat/kW and reject a 253-floor funder.
+        lampo_common::backend::btc_per_kvb_to_sat_per_kw(feerate)
     }
 
     async fn get_transaction(
@@ -296,22 +305,25 @@ impl Backend for LampoChainSync {
         unimplemented!()
     }
 
-    // TODO: specify what kind of format the result should be!
     async fn minimum_mempool_fee(&self) -> lampo_common::error::Result<u32> {
         #[derive(Debug, Deserialize)]
         struct MempoolInfo {
             loaded: bool,
             mempoolminfee: f64,
-        };
+        }
         let mempool_info = self
             .rpc_client
             .call_method::<json::Value>("getmempoolinfo", &[])
             .await?;
         let mempool_info: MempoolInfo = json::from_value(mempool_info)?;
-        if mempool_info.loaded {
-            log::warn!("mempool is still loading, so the fee may be not accurate!");
+        if !mempool_info.loaded {
+            log::warn!(
+                target: "lampo-chain",
+                "mempool is still loading, so the fee may be not accurate"
+            );
         }
-        Ok((mempool_info.mempoolminfee * (100_000_000 as f64)) as u32)
+        // bitcoind returns BTC/kvB. Convert straight to sat/kW.
+        lampo_common::backend::btc_per_kvb_to_sat_per_kw(mempool_info.mempoolminfee)
     }
 
     fn set_handler(&self, handler: Arc<dyn lampo_common::handler::Handler>) {

--- a/lampo-common/src/backend.rs
+++ b/lampo-common/src/backend.rs
@@ -31,6 +31,55 @@ pub enum BackendKind {
     Core,
 }
 
+/// bitcoind `estimatesmartfee` estimate mode. Matches ldk-node.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum FeeEstimateMode {
+    Conservative,
+    Economical,
+}
+
+impl FeeEstimateMode {
+    pub fn as_core_str(self) -> &'static str {
+        match self {
+            Self::Conservative => "CONSERVATIVE",
+            Self::Economical => "ECONOMICAL",
+        }
+    }
+}
+
+/// bitcoind `estimatesmartfee` / `mempoolminfee` is BTC/kvB.
+///
+/// sat/kW = BTC/kvB * 1e8 / 4 = BTC/kvB * 25_000_000. Round at sat/kW,
+/// same as ldk-node, so a 1.001 sat/vB mempool floor stays ~250 sat/kW
+/// (then LDK's 253 floor) instead of ceiling to 2 sat/vB = 500 sat/kW.
+pub fn btc_per_kvb_to_sat_per_kw(btc_per_kvb: f64) -> error::Result<u32> {
+    if !btc_per_kvb.is_finite() || btc_per_kvb < 0.0 {
+        return Err(error::anyhow!("invalid feerate {btc_per_kvb} BTC/kvB"));
+    }
+    let sat_kw = (btc_per_kvb * 25_000_000.0).round();
+    if sat_kw > u32::MAX as f64 {
+        return Err(error::anyhow!("feerate overflow: {btc_per_kvb} BTC/kvB"));
+    }
+    Ok(sat_kw as u32)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::btc_per_kvb_to_sat_per_kw;
+
+    #[test]
+    fn one_sat_per_vb_is_250_sat_per_kw() {
+        assert_eq!(btc_per_kvb_to_sat_per_kw(0.00001).unwrap(), 250);
+    }
+
+    #[test]
+    fn fractional_sat_per_vb_does_not_ceil_to_two() {
+        // 0.00001001 BTC/kvB = 1.001 sat/vB. Ceiling that to 2 sat/vB
+        // then * 250 would install 500 sat/kW and reject a 253 funder.
+        assert_eq!(btc_per_kvb_to_sat_per_kw(0.00001001).unwrap(), 250);
+    }
+}
+
 // FIXME: add the BlockSource trait for this
 /// Bakend Trait specification
 #[async_trait]
@@ -47,11 +96,27 @@ pub trait Backend: Send + Sync {
 
     /// Fetch feerate give a number of blocks
     ///
-    /// Returns the feerate in **sats/vbyte**.
+    /// Returns the feerate in **sat/kW** (LDK's `sat_per_1000_weight`).
+    /// Convert bitcoind's BTC/kvB with [`btc_per_kvb_to_sat_per_kw`] so we
+    /// do not round through integer sat/vB first.
     ///
     /// FIXME: use `FeeRate` instead of `u32`
-    async fn fee_rate_estimation(&self, blocks: u64) -> error::Result<u32>;
+    async fn fee_rate_estimation(&self, blocks: u64) -> error::Result<u32> {
+        self.fee_rate_estimation_with_mode(blocks, FeeEstimateMode::Conservative)
+            .await
+    }
 
+    /// Like [`Self::fee_rate_estimation`], with bitcoind's `estimate_mode`.
+    ///
+    /// ldk-node uses `CONSERVATIVE` for MaximumFeeEstimate and UrgentOnChainSweep,
+    /// `ECONOMICAL` otherwise.
+    async fn fee_rate_estimation_with_mode(
+        &self,
+        blocks: u64,
+        mode: FeeEstimateMode,
+    ) -> error::Result<u32>;
+
+    /// Current mempool minimum feerate in **sat/kW**.
     async fn minimum_mempool_fee(&self) -> error::Result<u32>;
 
     async fn brodcast_tx(&self, tx: &Transaction);

--- a/lampod/src/actions/handler.rs
+++ b/lampod/src/actions/handler.rs
@@ -7,7 +7,6 @@ use tokio::sync::RwLock;
 
 use lampo_common::async_trait;
 use lampo_common::bitcoin::Amount;
-use lampo_common::bitcoin::FeeRate;
 use lampo_common::chan;
 use lampo_common::error;
 use lampo_common::error::Ok;
@@ -24,7 +23,7 @@ use lampo_common::ldk::sign::NodeSigner;
 use lampo_common::model::response::PaymentHop;
 use lampo_common::model::response::PaymentState;
 
-use crate::chain::{LampoChainManager, WalletManager};
+use crate::chain::{FeeTarget, LampoChainManager, WalletManager};
 use crate::command::Command;
 use crate::ln::payer_proof::{self, PayerProofRecord};
 use crate::ln::{LampoChannelManager, LampoInventoryManager, LampoPeerManager};
@@ -297,26 +296,16 @@ impl Handler for LampoHandler {
                         );
                     }
                 };
-                // FIXME: estimate the fee rate with a callback
-                let fee = match self.chain_manager.backend.fee_rate_estimation(6).await {
-                    std::result::Result::Ok(fee) => fee,
-                    Err(err) => {
-                        let msg = format!("Channel Opening Error: {err}");
-                        // The `open_channel` waiter only wakes on a matching
-                        // `SendRawTransaction` or `FundingChannelFailed`; without
-                        // emitting the latter a fee-estimation failure leaves that
-                        // request task hanging forever (socket + event-bus
-                        // subscription leaked), which an unauthenticated caller
-                        // can exploit.
-                        abandon_temp_channel(self, &msg);
-                        self.emit(Event::Lightning(LightningEvent::ChannelEvent {
-                            state: "error".to_owned(),
-                            message: msg,
-                        }));
-                        return Err(err);
-                    }
-                };
-                log::info!("fee estimated {:?} sats", fee);
+                // Same as ldk-node: ChannelFunding is 12-block economical,
+                // read from the cache (never block the event loop on RPC).
+                let fee_rate = self
+                    .chain_manager
+                    .estimate_fee_rate(FeeTarget::ChannelFunding);
+                log::info!(
+                    target: "lampo",
+                    "funding fee rate {} sat/kW",
+                    fee_rate.to_sat_per_kwu()
+                );
 
                 let best_block = self.channel_manager.manager().current_best_block().height;
                 let transaction = match self
@@ -324,7 +313,7 @@ impl Handler for LampoHandler {
                     .create_transaction(
                         output_script,
                         Amount::from_sat(channel_value_satoshis),
-                        FeeRate::from_sat_per_vb_unchecked(fee as u64),
+                        fee_rate,
                         // FIXME: remove unwrap
                         Height::from_consensus(best_block).unwrap(),
                     )

--- a/lampod/src/chain/blockchain.rs
+++ b/lampod/src/chain/blockchain.rs
@@ -1,11 +1,14 @@
 use std::collections::HashMap;
-use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Weak};
+use std::time::{Duration, Instant};
 
 use lampo_common::async_trait;
-use lampo_common::backend::Backend;
+use lampo_common::backend::{Backend, FeeEstimateMode};
 use lampo_common::bitcoin;
 use lampo_common::bitcoin::blockdata::constants::ChainHash;
-use lampo_common::bitcoin::Transaction;
+use lampo_common::bitcoin::{FeeRate, Transaction};
+use lampo_common::conf::Network;
 use lampo_common::error;
 use lampo_common::ldk::chain::chaininterface::{
     BroadcasterInterface, ConfirmationTarget, FeeEstimator, TransactionType,
@@ -14,62 +17,238 @@ use lampo_common::ldk::routing::utxo::UtxoLookup;
 use lampo_common::ldk::util::wakers::Notifier;
 use lampo_common::wallet::WalletManager;
 
+use super::fee::{
+    all_targets, apply_post_estimation_adjustments, source_for_target, FeeCache, FeeSource,
+    FeeTarget, FEE_CACHE_REFRESH_SECS, FEE_CACHE_UPDATE_TIMEOUT_SECS, RELAY_FALLBACK_SAT_PER_KW,
+};
+
 #[derive(Clone)]
 pub struct LampoChainManager {
     pub backend: Arc<dyn Backend>,
     pub wallet_manager: Arc<dyn WalletManager>,
+    network: Network,
+    fee_cache: Arc<FeeCache>,
+    fee_refresh_started: Arc<AtomicBool>,
+    /// Same flag as [`crate::LampoDaemon::shutdown`]. The refresh task
+    /// holds only a `Weak` so dropping the daemon also stops the loop.
+    shutdown: Arc<AtomicBool>,
 }
 
 /// Personal Lampo implementation
 impl LampoChainManager {
     /// Create a new instance of LampoFeeEstimator with the specified
     /// Backend.
-    pub fn new(client: Arc<dyn Backend>, wallet_manager: Arc<dyn WalletManager>) -> Self {
+    pub fn new(
+        client: Arc<dyn Backend>,
+        wallet_manager: Arc<dyn WalletManager>,
+        network: Network,
+        shutdown: Arc<AtomicBool>,
+    ) -> Self {
         LampoChainManager {
             backend: client,
             wallet_manager,
-        }
-    }
-
-    fn print_ldk_target_to_string(&self, target: ConfirmationTarget) -> String {
-        match target {
-            ConfirmationTarget::MaximumFeeEstimate => String::from("maximum"),
-            ConfirmationTarget::UrgentOnChainSweep => String::from("urgent"),
-            ConfirmationTarget::AnchorChannelFee => String::from("anchor_channel"),
-            ConfirmationTarget::NonAnchorChannelFee => String::from("non_anchor_channel"),
-            ConfirmationTarget::ChannelCloseMinimum => String::from("channel_close_minimum"),
-            ConfirmationTarget::MinAllowedAnchorChannelRemoteFee => {
-                String::from("min_allowed_anchor_channel_remote")
-            }
-            ConfirmationTarget::MinAllowedNonAnchorChannelRemoteFee => {
-                String::from("min_allowed_non_anchor_channel_remote")
-            }
-            ConfirmationTarget::OutputSpendingFee => String::from("output_spending"),
+            network,
+            fee_cache: Arc::new(FeeCache::new()),
+            fee_refresh_started: Arc::new(AtomicBool::new(false)),
+            shutdown,
         }
     }
 
     pub fn estimated_fees(&self) -> HashMap<String, Option<u32>> {
-        let fees_targets = vec![
-            ConfirmationTarget::UrgentOnChainSweep,
-            ConfirmationTarget::MinAllowedNonAnchorChannelRemoteFee,
-            ConfirmationTarget::NonAnchorChannelFee,
-            ConfirmationTarget::MinAllowedAnchorChannelRemoteFee,
-            ConfirmationTarget::AnchorChannelFee,
-            ConfirmationTarget::ChannelCloseMinimum,
-            ConfirmationTarget::OutputSpendingFee,
-        ];
         let mut map: HashMap<String, Option<u32>> = HashMap::new();
-        for target in fees_targets {
-            let fee = self.get_est_sat_per_1000_weight(target);
+        for target in all_targets() {
+            let fee = self.fee_cache.get(target);
             let value = if fee == 0 { None } else { Some(fee) };
-            map.insert(self.print_ldk_target_to_string(target), value);
+            map.insert(print_fee_target(target), value);
         }
         map
     }
 
+    /// Sync feerate for wallet constructions. ldk-node's
+    /// `OnchainFeeEstimator::estimate_fee_rate`.
+    pub fn estimate_fee_rate(&self, target: FeeTarget) -> FeeRate {
+        FeeRate::from_sat_per_kwu(self.fee_cache.get(target) as u64)
+    }
+
     pub fn listen(self: Arc<Self>) -> error::Result<()> {
-        tokio::spawn(async move { self.backend.clone().listen().await });
+        let backend = self.backend.clone();
+        tokio::spawn(async move { backend.listen().await });
+        self.spawn_fee_refresh();
         Ok(())
+    }
+
+    /// Start the background refresh if it is not already running. Safe to call
+    /// from `init_onchaind` so the cache warms during the rest of startup,
+    /// and again from `listen`.
+    pub fn spawn_fee_refresh(self: Arc<Self>) {
+        if self.fee_refresh_started.swap(true, Ordering::SeqCst) {
+            return;
+        }
+        let weak = Arc::downgrade(&self);
+        tokio::spawn(async move { run_fee_refresh(weak).await });
+    }
+
+    fn should_stop(&self) -> bool {
+        self.shutdown.load(Ordering::Acquire)
+    }
+
+    async fn refresh_fee_cache(&self) -> bool {
+        if self.should_stop() {
+            return false;
+        }
+        let now = Instant::now();
+        let mut by_key: HashMap<(u64, FeeEstimateMode), u32> = HashMap::new();
+        let mut updates = HashMap::with_capacity(10);
+        for target in all_targets() {
+            if self.should_stop() {
+                return false;
+            }
+            let sat_kw = match self.estimate_sat_kw(target, &mut by_key).await {
+                Ok(sat_kw) => sat_kw,
+                Err(err) => match self.on_estimate_error(target, &err) {
+                    Some(sat_kw) => sat_kw,
+                    None => return true,
+                },
+            };
+            let sat_kw = apply_post_estimation_adjustments(target, sat_kw);
+            log::debug!(
+                target: "lampo-chain",
+                "fee cache {target:?}: {sat_kw} sat/kW"
+            );
+            updates.insert(target, sat_kw);
+        }
+        if self.fee_cache.set(updates) {
+            log::info!(
+                target: "lampo-chain",
+                "fee rate cache update finished in {}ms",
+                now.elapsed().as_millis()
+            );
+        }
+        true
+    }
+
+    async fn estimate_sat_kw(
+        &self,
+        target: FeeTarget,
+        by_key: &mut HashMap<(u64, FeeEstimateMode), u32>,
+    ) -> error::Result<u32> {
+        match source_for_target(target) {
+            FeeSource::MempoolMin => timeout_rpc(self.backend.minimum_mempool_fee()).await,
+            FeeSource::Blocks { blocks, mode } => {
+                if let Some(sat_kw) = by_key.get(&(blocks, mode)) {
+                    return Ok(*sat_kw);
+                }
+                let sat_kw =
+                    timeout_rpc(self.backend.fee_rate_estimation_with_mode(blocks, mode)).await?;
+                by_key.insert((blocks, mode), sat_kw);
+                Ok(sat_kw)
+            }
+        }
+    }
+
+    /// ldk-node: Bitcoin fails the whole update; regtest/signet fall back to
+    /// 1 sat/vB; testnet skips the update and keeps the previous cache.
+    fn on_estimate_error(&self, target: FeeTarget, err: &error::Error) -> Option<u32> {
+        match self.network {
+            Network::Bitcoin => {
+                log::error!(
+                    target: "lampo-chain",
+                    "fee estimate for {target:?} failed on bitcoin: {err}"
+                );
+                None
+            }
+            Network::Regtest | Network::Signet => {
+                log::warn!(
+                    target: "lampo-chain",
+                    "fee estimate for {target:?} failed: {err}. Falling back to 1 sat/vB"
+                );
+                Some(RELAY_FALLBACK_SAT_PER_KW)
+            }
+            _ => {
+                log::warn!(
+                    target: "lampo-chain",
+                    "fee estimate for {target:?} failed: {err}. Keeping previous cache"
+                );
+                None
+            }
+        }
+    }
+}
+
+fn print_fee_target(target: FeeTarget) -> String {
+    match target {
+        FeeTarget::OnchainPayment => String::from("onchain_payment"),
+        FeeTarget::ChannelFunding => String::from("channel_funding"),
+        FeeTarget::Lightning(ConfirmationTarget::MaximumFeeEstimate) => String::from("maximum"),
+        FeeTarget::Lightning(ConfirmationTarget::UrgentOnChainSweep) => String::from("urgent"),
+        FeeTarget::Lightning(ConfirmationTarget::AnchorChannelFee) => {
+            String::from("anchor_channel")
+        }
+        FeeTarget::Lightning(ConfirmationTarget::NonAnchorChannelFee) => {
+            String::from("non_anchor_channel")
+        }
+        FeeTarget::Lightning(ConfirmationTarget::ChannelCloseMinimum) => {
+            String::from("channel_close_minimum")
+        }
+        FeeTarget::Lightning(ConfirmationTarget::MinAllowedAnchorChannelRemoteFee) => {
+            String::from("min_allowed_anchor_channel_remote")
+        }
+        FeeTarget::Lightning(ConfirmationTarget::MinAllowedNonAnchorChannelRemoteFee) => {
+            String::from("min_allowed_non_anchor_channel_remote")
+        }
+        FeeTarget::Lightning(ConfirmationTarget::OutputSpendingFee) => {
+            String::from("output_spending")
+        }
+    }
+}
+
+async fn timeout_rpc<F, T>(fut: F) -> error::Result<T>
+where
+    F: std::future::Future<Output = error::Result<T>>,
+{
+    tokio::time::timeout(Duration::from_secs(FEE_CACHE_UPDATE_TIMEOUT_SECS), fut)
+        .await
+        .map_err(|_| error::anyhow!("fee estimate timed out"))?
+}
+
+/// Background loop for [`LampoChainManager::spawn_fee_refresh`].
+///
+/// Holds a `Weak` so the task does not keep the chain manager (and therefore
+/// the wallet / backend) alive after the daemon is dropped. Observes the
+/// daemon shutdown flag with the same 100ms poll as the LDK event processor,
+/// so a stop does not wait out the 10-minute interval.
+async fn run_fee_refresh(weak: Weak<LampoChainManager>) {
+    loop {
+        let Some(this) = weak.upgrade() else {
+            return;
+        };
+        if this.should_stop() {
+            log::info!(target: "lampo-chain", "fee cache refresh stopped");
+            return;
+        }
+        let keep_going = this.refresh_fee_cache().await;
+        drop(this);
+        if !keep_going {
+            log::info!(target: "lampo-chain", "fee cache refresh stopped");
+            return;
+        }
+        tokio::select! {
+            _ = tokio::time::sleep(Duration::from_secs(FEE_CACHE_REFRESH_SECS)) => {}
+            _ = wait_until_fee_refresh_stopped(&weak) => {
+                log::info!(target: "lampo-chain", "fee cache refresh stopped");
+                return;
+            }
+        }
+    }
+}
+
+async fn wait_until_fee_refresh_stopped(weak: &Weak<LampoChainManager>) {
+    loop {
+        match weak.upgrade() {
+            None => return,
+            Some(this) if this.should_stop() => return,
+            Some(_) => tokio::time::sleep(Duration::from_millis(100)).await,
+        }
     }
 }
 
@@ -77,9 +256,7 @@ impl LampoChainManager {
 #[async_trait]
 impl FeeEstimator for LampoChainManager {
     fn get_est_sat_per_1000_weight(&self, confirmation_target: ConfirmationTarget) -> u32 {
-        // FIXME: have the result in the cache to make easy the query of it.
-        // TODO: fix this
-        256
+        self.fee_cache.get(confirmation_target.into())
     }
 }
 
@@ -117,8 +294,14 @@ impl Backend for LampoChainManager {
         self.backend.brodcast_tx(tx).await;
     }
 
-    async fn fee_rate_estimation(&self, blocks: u64) -> lampo_common::error::Result<u32> {
-        self.backend.fee_rate_estimation(blocks).await
+    async fn fee_rate_estimation_with_mode(
+        &self,
+        blocks: u64,
+        mode: lampo_common::backend::FeeEstimateMode,
+    ) -> lampo_common::error::Result<u32> {
+        self.backend
+            .fee_rate_estimation_with_mode(blocks, mode)
+            .await
     }
 
     async fn get_transaction(

--- a/lampod/src/chain/fee.rs
+++ b/lampod/src/chain/fee.rs
@@ -1,0 +1,286 @@
+//! Cached backing store for LDK's [`FeeEstimator`].
+//!
+//! Mirrors ldk-node's `OnchainFeeEstimator`: async refresh into an `RwLock`,
+//! sync reads on the HTLC path, same block targets / fallbacks / post-adjustments.
+
+use std::collections::HashMap;
+use std::sync::RwLock;
+
+use lampo_common::backend::FeeEstimateMode;
+use lampo_common::ldk::chain::chaininterface::{ConfirmationTarget, FEERATE_FLOOR_SATS_PER_KW};
+
+/// How often we poll bitcoind. ldk-node default: 10 minutes.
+pub const FEE_CACHE_REFRESH_SECS: u64 = 600;
+
+/// Per-RPC timeout. ldk-node: `FEE_RATE_CACHE_UPDATE_TIMEOUT_SECS`.
+pub const FEE_CACHE_UPDATE_TIMEOUT_SECS: u64 = 5;
+
+/// ldk-node's regtest/signet fallback: 1 sat/vB == 250 sat/kW.
+/// [`FeeCache::get`] still clamps to [`FEERATE_FLOOR_SATS_PER_KW`].
+pub const RELAY_FALLBACK_SAT_PER_KW: u32 = 250;
+
+/// Wallet + LDK fee targets. Same split as ldk-node: `ChannelFunding` /
+/// `OnchainPayment` are not LDK `ConfirmationTarget`s.
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
+pub enum FeeTarget {
+    OnchainPayment,
+    ChannelFunding,
+    Lightning(ConfirmationTarget),
+}
+
+impl From<ConfirmationTarget> for FeeTarget {
+    fn from(value: ConfirmationTarget) -> Self {
+        Self::Lightning(value)
+    }
+}
+
+/// sat/vB → sat/kW. LDK documents this as `satoshis-per-byte * 250`.
+#[cfg(test)]
+pub fn sat_per_vb_to_kw(sat_vb: u32) -> u32 {
+    sat_vb.saturating_mul(250)
+}
+
+/// Last-resort sat/kW when the cache is cold. Same numbers as ldk-node.
+pub fn fallback_sat_per_kw(target: FeeTarget) -> u32 {
+    match target {
+        FeeTarget::OnchainPayment => 5000,
+        FeeTarget::ChannelFunding => 1000,
+        FeeTarget::Lightning(ldk_target) => match ldk_target {
+            ConfirmationTarget::MaximumFeeEstimate => 8000,
+            ConfirmationTarget::UrgentOnChainSweep => 5000,
+            ConfirmationTarget::MinAllowedAnchorChannelRemoteFee
+            | ConfirmationTarget::MinAllowedNonAnchorChannelRemoteFee => FEERATE_FLOOR_SATS_PER_KW,
+            ConfirmationTarget::AnchorChannelFee => 500,
+            ConfirmationTarget::NonAnchorChannelFee => 1000,
+            ConfirmationTarget::ChannelCloseMinimum => 500,
+            ConfirmationTarget::OutputSpendingFee => 1000,
+        },
+    }
+}
+
+/// Where the sat/kW for this target comes from. Matches ldk-node's bitcoind
+/// `update_fee_rate_estimates` match.
+pub enum FeeSource {
+    MempoolMin,
+    Blocks { blocks: u64, mode: FeeEstimateMode },
+}
+
+pub fn source_for_target(target: FeeTarget) -> FeeSource {
+    match target {
+        FeeTarget::OnchainPayment => FeeSource::Blocks {
+            blocks: 6,
+            mode: FeeEstimateMode::Economical,
+        },
+        FeeTarget::ChannelFunding => FeeSource::Blocks {
+            blocks: 12,
+            mode: FeeEstimateMode::Economical,
+        },
+        FeeTarget::Lightning(ConfirmationTarget::MinAllowedAnchorChannelRemoteFee) => {
+            FeeSource::MempoolMin
+        }
+        FeeTarget::Lightning(ConfirmationTarget::MaximumFeeEstimate) => FeeSource::Blocks {
+            blocks: 1,
+            mode: FeeEstimateMode::Conservative,
+        },
+        FeeTarget::Lightning(ConfirmationTarget::UrgentOnChainSweep) => FeeSource::Blocks {
+            blocks: 6,
+            mode: FeeEstimateMode::Conservative,
+        },
+        FeeTarget::Lightning(ConfirmationTarget::MinAllowedNonAnchorChannelRemoteFee) => {
+            FeeSource::Blocks {
+                blocks: 144,
+                mode: FeeEstimateMode::Economical,
+            }
+        }
+        FeeTarget::Lightning(ConfirmationTarget::AnchorChannelFee) => FeeSource::Blocks {
+            blocks: 1008,
+            mode: FeeEstimateMode::Economical,
+        },
+        FeeTarget::Lightning(ConfirmationTarget::NonAnchorChannelFee) => FeeSource::Blocks {
+            blocks: 12,
+            mode: FeeEstimateMode::Economical,
+        },
+        FeeTarget::Lightning(ConfirmationTarget::ChannelCloseMinimum) => FeeSource::Blocks {
+            blocks: 144,
+            mode: FeeEstimateMode::Economical,
+        },
+        FeeTarget::Lightning(ConfirmationTarget::OutputSpendingFee) => FeeSource::Blocks {
+            blocks: 12,
+            mode: FeeEstimateMode::Economical,
+        },
+    }
+}
+
+pub fn all_targets() -> [FeeTarget; 10] {
+    [
+        FeeTarget::OnchainPayment,
+        FeeTarget::ChannelFunding,
+        ConfirmationTarget::MaximumFeeEstimate.into(),
+        ConfirmationTarget::UrgentOnChainSweep.into(),
+        ConfirmationTarget::MinAllowedAnchorChannelRemoteFee.into(),
+        ConfirmationTarget::MinAllowedNonAnchorChannelRemoteFee.into(),
+        ConfirmationTarget::AnchorChannelFee.into(),
+        ConfirmationTarget::NonAnchorChannelFee.into(),
+        ConfirmationTarget::ChannelCloseMinimum.into(),
+        ConfirmationTarget::OutputSpendingFee.into(),
+    ]
+}
+
+/// ldk-node `apply_post_estimation_adjustments`.
+///
+/// `MinAllowedNonAnchorChannelRemoteFee` is nudged down by 1 sat/vB so a
+/// funder whose estimator rounded up is still accepted.
+/// `MaximumFeeEstimate` is bumped (`* 11/10 + 2500` sat/kW) so the LDK
+/// fee-inflation ceiling is not so tight that a peer a bit above the
+/// one-block conservative estimate gets force-closed.
+pub fn apply_post_estimation_adjustments(target: FeeTarget, sat_kw: u32) -> u32 {
+    match target {
+        FeeTarget::Lightning(ConfirmationTarget::MinAllowedNonAnchorChannelRemoteFee) => {
+            sat_kw.saturating_sub(250).max(FEERATE_FLOOR_SATS_PER_KW)
+        }
+        FeeTarget::Lightning(ConfirmationTarget::MaximumFeeEstimate) => sat_kw
+            .saturating_mul(11)
+            .saturating_div(10)
+            .saturating_add(2500),
+        _ => sat_kw,
+    }
+}
+
+pub struct FeeCache {
+    rates: RwLock<HashMap<FeeTarget, u32>>,
+}
+
+impl FeeCache {
+    pub fn new() -> Self {
+        Self {
+            rates: RwLock::new(HashMap::new()),
+        }
+    }
+
+    pub fn get(&self, target: FeeTarget) -> u32 {
+        let rates = self.rates.read().unwrap_or_else(|e| e.into_inner());
+        let fallback = fallback_sat_per_kw(target);
+        rates
+            .get(&target)
+            .copied()
+            .unwrap_or(fallback)
+            .max(FEERATE_FLOOR_SATS_PER_KW)
+    }
+
+    /// Replace the cache. Returns whether the map actually changed.
+    pub fn set(&self, rates: HashMap<FeeTarget, u32>) -> bool {
+        let mut locked = self.rates.write().unwrap_or_else(|e| e.into_inner());
+        if *locked != rates {
+            *locked = rates;
+            true
+        } else {
+            false
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sat_per_vb_to_kw_is_times_250() {
+        assert_eq!(sat_per_vb_to_kw(1), 250);
+        assert_eq!(sat_per_vb_to_kw(12), 3000);
+    }
+
+    #[test]
+    fn channel_funding_is_12_economical_with_1000_fallback() {
+        assert_eq!(fallback_sat_per_kw(FeeTarget::ChannelFunding), 1000);
+        let FeeSource::Blocks { blocks, mode } = source_for_target(FeeTarget::ChannelFunding)
+        else {
+            panic!("channel funding must be a block target");
+        };
+        assert_eq!(blocks, 12);
+        assert_eq!(mode, FeeEstimateMode::Economical);
+    }
+
+    #[test]
+    fn onchain_payment_is_6_economical() {
+        let FeeSource::Blocks { blocks, mode } = source_for_target(FeeTarget::OnchainPayment)
+        else {
+            panic!("onchain payment must be a block target");
+        };
+        assert_eq!(blocks, 6);
+        assert_eq!(mode, FeeEstimateMode::Economical);
+    }
+
+    #[test]
+    fn cold_cache_accepts_a_253_funder() {
+        let cache = FeeCache::new();
+        assert_eq!(
+            cache.get(ConfirmationTarget::MinAllowedAnchorChannelRemoteFee.into()),
+            FEERATE_FLOOR_SATS_PER_KW
+        );
+        assert_eq!(
+            cache.get(ConfirmationTarget::MinAllowedNonAnchorChannelRemoteFee.into()),
+            FEERATE_FLOOR_SATS_PER_KW
+        );
+    }
+
+    #[test]
+    fn cold_cache_channel_funding_uses_ldk_node_fallback() {
+        let cache = FeeCache::new();
+        assert_eq!(cache.get(FeeTarget::ChannelFunding), 1000);
+    }
+
+    #[test]
+    fn non_anchor_min_allowed_subtracts_one_sat_per_vb() {
+        let target = ConfirmationTarget::MinAllowedNonAnchorChannelRemoteFee.into();
+        assert_eq!(
+            apply_post_estimation_adjustments(target, sat_per_vb_to_kw(2)),
+            FEERATE_FLOOR_SATS_PER_KW
+        );
+        assert_eq!(
+            apply_post_estimation_adjustments(target, sat_per_vb_to_kw(1)),
+            FEERATE_FLOOR_SATS_PER_KW
+        );
+    }
+
+    #[test]
+    fn maximum_fee_estimate_gets_ldk_node_leeway() {
+        // 8 sat/vB = 2000 sat/kW → 2000 * 11/10 + 2500 = 4700
+        assert_eq!(
+            apply_post_estimation_adjustments(
+                ConfirmationTarget::MaximumFeeEstimate.into(),
+                sat_per_vb_to_kw(8),
+            ),
+            4700
+        );
+    }
+
+    #[test]
+    fn other_targets_are_not_adjusted() {
+        assert_eq!(
+            apply_post_estimation_adjustments(
+                ConfirmationTarget::UrgentOnChainSweep.into(),
+                sat_per_vb_to_kw(12),
+            ),
+            3000
+        );
+        assert_eq!(
+            apply_post_estimation_adjustments(FeeTarget::ChannelFunding, sat_per_vb_to_kw(4)),
+            1000
+        );
+    }
+
+    #[test]
+    fn min_allowed_anchor_reads_mempool_min() {
+        assert!(matches!(
+            source_for_target(ConfirmationTarget::MinAllowedAnchorChannelRemoteFee.into()),
+            FeeSource::MempoolMin
+        ));
+        let FeeSource::Blocks { blocks, mode } =
+            source_for_target(ConfirmationTarget::UrgentOnChainSweep.into())
+        else {
+            panic!("urgent must be a block target");
+        };
+        assert_eq!(blocks, 6);
+        assert_eq!(mode, FeeEstimateMode::Conservative);
+    }
+}

--- a/lampod/src/chain/mod.rs
+++ b/lampod/src/chain/mod.rs
@@ -1,7 +1,9 @@
 //! Chain module implementation that contains all the code related to the blockchain communication.
 mod blockchain;
+mod fee;
 
 pub use lampo_common::bitcoin::Network;
 pub use lampo_common::wallet::WalletManager;
 
 pub use blockchain::LampoChainManager;
+pub use fee::FeeTarget;

--- a/lampod/src/lib.rs
+++ b/lampod/src/lib.rs
@@ -154,8 +154,15 @@ impl LampoDaemon {
 
     pub fn init_onchaind(&mut self, client: Arc<dyn Backend>) -> error::Result<()> {
         log::debug!(target: "lampod", "init onchaind ..");
-        let onchain_manager = LampoChainManager::new(client, self.wallet_manager.clone());
-        self.onchain_manager = Some(Arc::new(onchain_manager));
+        let onchain_manager = Arc::new(LampoChainManager::new(
+            client,
+            self.wallet_manager.clone(),
+            self.conf.network,
+            self.shutdown.clone(),
+        ));
+        // Warm the fee cache during the rest of init; do not wait for listen().
+        onchain_manager.clone().spawn_fee_refresh();
+        self.onchain_manager = Some(onchain_manager);
         Ok(())
     }
 


### PR DESCRIPTION
## Summary
- Wire a cached LDK `FeeEstimator` from bitcoind, matching ldk-node: mempool min for `MinAllowedAnchor*`, conservative 1/6-block for max/urgent, economical otherwise, minus 250 sat/kW on `MinAllowedNonAnchor*`, and `* 11/10 + 2500` on `MaximumFeeEstimate`.
- Fund channels from `FeeTarget::ChannelFunding` (12-block economical) instead of a live `estimatesmartfee(6)` RPC, so the event loop never blocks on fee estimation.
- Keep the 253 sat/kW relay floor for inbound opens (I04). Convert bitcoind BTC/kvB straight to sat/kW (no integer sat/vB rounding). Stop the fee refresher on daemon shutdown.

## Test plan
- [ ] `cargo test -p lampod --lib -- fee`
- [ ] `cargo test -p lampo-common --lib -- backend::tests`
- [ ] Re-run interop I04 (ldk-server opens to lampo at 253 sat/kW)
- [ ] On a node with bitcoind, check `estimate_fees` shows distinct targets after ~startup, not all 256
- [ ] Open a channel from lampo and confirm the funding tx uses ~12-block economical, not the old 6-block conservative sat/vB path