### PR TITLE
Add LND-compatible REST API for Zeus

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,6 +28,7 @@ dependencies = [
  "actix-codec",
  "actix-rt",
  "actix-service",
+ "actix-tls",
  "actix-utils",
  "base64 0.22.1",
  "bitflags 2.9.0",
@@ -40,7 +41,7 @@ dependencies = [
  "foldhash",
  "futures-core",
  "h2",
- "http",
+ "http 0.2.12",
  "httparse",
  "httpdate",
  "itoa",
@@ -76,7 +77,7 @@ checksum = "14f8c75c51892f18d9c46150c5ac7beb81c95f78c8b83a634d49f4ca32551fe7"
 dependencies = [
  "bytestring",
  "cfg-if",
- "http",
+ "http 0.2.12",
  "regex",
  "regex-lite",
  "serde",
@@ -89,6 +90,7 @@ version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24eda4e2a6e042aa4e55ac438a2ae052d3b5da0ecf83d7411e1a368946925208"
 dependencies = [
+ "actix-macros",
  "futures-core",
  "tokio",
 ]
@@ -121,6 +123,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "actix-tls"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6176099de3f58fbddac916a7f8c6db297e021d706e7a6b99947785fee14abe9f"
+dependencies = [
+ "actix-rt",
+ "actix-service",
+ "actix-utils",
+ "futures-core",
+ "impl-more 0.1.9",
+ "pin-project-lite",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "actix-utils"
 version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -143,6 +164,7 @@ dependencies = [
  "actix-rt",
  "actix-server",
  "actix-service",
+ "actix-tls",
  "actix-utils",
  "actix-web-codegen",
  "bytes",
@@ -154,7 +176,7 @@ dependencies = [
  "foldhash",
  "futures-core",
  "futures-util",
- "impl-more",
+ "impl-more 0.3.5",
  "itoa",
  "language-tags",
  "log",
@@ -316,10 +338,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
 name = "autocfg"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
+
+[[package]]
+name = "aws-lc-rs"
+version = "1.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce2b2dcc879c3bae0d371e77c99f2238400ef24ec001394befa67b6e543add9e"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.44.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f09fae7be8bb3174e05c6afdb34199e6dc0c7c04ba9fa237b1967adfbde27483"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+ "pkg-config",
+]
 
 [[package]]
 name = "base58ck"
@@ -541,6 +592,15 @@ checksum = "b65c2e1ab98050c93cc9ada070d5070e014329c65196d03f6f8f1f75c2666f37"
 
 [[package]]
 name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "block-buffer"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
@@ -598,13 +658,14 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.20"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04da6a0d40b948dfc4fa8f5bbf402b0fc1a64a28dbf7d12ffd683550f2c1b63a"
+checksum = "509591b7bcd67f4ef775afad7662703b4935daaa6ec0e5605cfb1090b32a2b6d"
 dependencies = [
+ "find-msvc-tools",
  "jobserver",
  "libc",
- "shlex",
+ "shlex 2.0.1",
 ]
 
 [[package]]
@@ -626,7 +687,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.3.0",
  "rand_core 0.10.1",
 ]
 
@@ -743,6 +804,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -830,6 +900,15 @@ dependencies = [
 
 [[package]]
 name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
@@ -913,6 +992,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
 ]
 
 [[package]]
@@ -1063,13 +1152,24 @@ dependencies = [
 
 [[package]]
 name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer 0.10.4",
+ "crypto-common 0.1.7",
+ "subtle",
+]
+
+[[package]]
+name = "digest"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
- "block-buffer",
+ "block-buffer 0.12.1",
  "const-oid",
- "crypto-common",
+ "crypto-common 0.2.2",
 ]
 
 [[package]]
@@ -1097,6 +1197,12 @@ checksum = "95249b50c6c185bee49034bcb378a49dc2b5dff0be90ff6616d31d64febab05d"
 dependencies = [
  "litrs",
 ]
+
+[[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "dyn-clone"
@@ -1176,6 +1282,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "find-msvc-tools"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d45db016d36b838f563236e9193d0ee6ce38f3f68b6c94e914b4929c96bbb890"
+
+[[package]]
+name = "fixedbitset"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
+
+[[package]]
 name = "flate2"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1205,6 +1323,12 @@ checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "futures"
@@ -1305,14 +1429,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1334,9 +1470,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 6.0.0",
  "rand_core 0.10.1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1363,7 +1501,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "futures-util",
- "http",
+ "http 0.2.12",
  "indexmap 2.9.0",
  "slab",
  "tokio",
@@ -1448,6 +1586,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3011d1213f159867b13cfd6ac92d2cd5f1345762c63be3554e84092d85a50bbd"
 
 [[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest 0.10.7",
+]
+
+[[package]]
 name = "http"
 version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1456,6 +1603,39 @@ dependencies = [
  "bytes",
  "fnv",
  "itoa",
+]
+
+[[package]]
+name = "http"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "918d3568bebf352712bc2ef3d46a8bcf1a75b373be6539de198e9105cbbf9ce0"
+dependencies = [
+ "bytes",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca2a8f2913ee65f60facd6a5905613afaa448497a0230cc41ce022d93290bc2c"
+dependencies = [
+ "bytes",
+ "http 1.5.0",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23169fe34a5fbcdd3f3862e78fb9b6fccd5f02a6dc6f732547005d45631ce71c"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http 1.5.0",
+ "http-body",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -1477,6 +1657,65 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "707114b52a152fa7bdb290cd7cd5912d9467273b6d74e21b8d81aca1f8533f6b"
 dependencies = [
  "typenum",
+]
+
+[[package]]
+name = "hyper"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d22053281f852e11534f5198498373cbb59295120a20771d90f7ed1897490a72"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "http 1.5.0",
+ "http-body",
+ "httparse",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http 1.5.0",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+ "webpki-roots",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http 1.5.0",
+ "http-body",
+ "hyper",
+ "ipnet",
+ "libc",
+ "percent-encoding",
+ "pin-project-lite",
+ "socket2 0.6.0",
+ "tokio",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -1650,6 +1889,12 @@ dependencies = [
 
 [[package]]
 name = "impl-more"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8a5a9a0ff0086c7a148acb942baaabeadf9504d10400b5a05645853729b9cd2"
+
+[[package]]
+name = "impl-more"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "277ff51754a3f68f12f58446c5d006aa8baa4914ea273cce24a599cfaff33d4f"
@@ -1692,6 +1937,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ipnet"
+version = "2.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a756c3fac73139e83f14c2d742155dd2b78d3ee56597b419a0579b7bdd6dd78"
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1702,6 +1953,15 @@ name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
 dependencies = [
  "either",
 ]
@@ -1822,18 +2082,54 @@ dependencies = [
 ]
 
 [[package]]
+name = "lampo-lnd"
+version = "0.1.0"
+dependencies = [
+ "actix-rt",
+ "actix-web",
+ "base64 0.22.1",
+ "bytes",
+ "futures-util",
+ "hex",
+ "hmac",
+ "lampo-common",
+ "lampod",
+ "log",
+ "pbjson",
+ "pbjson-build",
+ "pbjson-types",
+ "prost",
+ "prost-build",
+ "protoc-bin-vendored",
+ "rand 0.8.5",
+ "rcgen",
+ "rustls",
+ "rustls-pemfile",
+ "serde",
+ "serde_json",
+ "sha2",
+ "tempfile",
+ "thiserror 2.0.20",
+ "tokio",
+ "tokio-rustls",
+]
+
+[[package]]
 name = "lampo-testing"
 version = "0.1.0"
 dependencies = [
  "anyhow",
  "clightning-testing",
+ "hex",
  "lampo-bdk-wallet",
  "lampo-chain",
  "lampo-common",
  "lampo-httpd",
+ "lampo-lnd",
  "lampod",
  "log",
  "port-selector",
+ "reqwest",
  "tempfile",
  "tokio",
 ]
@@ -1862,6 +2158,7 @@ dependencies = [
  "lampo-chain",
  "lampo-common",
  "lampo-httpd",
+ "lampo-lnd",
  "lampod",
  "log",
  "radicle-term",
@@ -2109,6 +2406,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
 name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2184,6 +2487,12 @@ dependencies = [
  "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.52.0",
 ]
+
+[[package]]
+name = "multimap"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
 name = "newline-converter"
@@ -2302,7 +2611,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa5b33308ca3f5902ccef8aa51f72dd71d6ee9f1c3cd04ac2e77eec33fe1da4f"
 dependencies = [
  "anyhow",
- "itertools",
+ "itertools 0.10.5",
  "once_cell",
  "paperclip-actix",
  "paperclip-core",
@@ -2312,7 +2621,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "serde_yaml",
- "thiserror",
+ "thiserror 1.0.69",
  "url",
 ]
 
@@ -2347,7 +2656,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -2357,7 +2666,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "827a0067440b62e798bc3e8cfb7036a0f63c3adbb21fe6a56fb3d6f6d8fa53f8"
 dependencies = [
  "heck 0.4.1",
- "http",
+ "http 0.2.12",
  "lazy_static",
  "mime",
  "proc-macro-error2",
@@ -2398,10 +2707,67 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
+name = "pbjson"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7e6349fa080353f4a597daffd05cb81572a9c031a6d4fff7e504947496fcc68"
+dependencies = [
+ "base64 0.21.7",
+ "serde",
+]
+
+[[package]]
+name = "pbjson-build"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6eea3058763d6e656105d1403cb04e0a41b7bbac6362d413e7c33be0c32279c9"
+dependencies = [
+ "heck 0.5.0",
+ "itertools 0.13.0",
+ "prost",
+ "prost-types",
+]
+
+[[package]]
+name = "pbjson-types"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e54e5e7bfb1652f95bc361d76f3c780d8e526b134b85417e774166ee941f0887"
+dependencies = [
+ "bytes",
+ "chrono",
+ "pbjson",
+ "pbjson-build",
+ "prost",
+ "prost-build",
+ "serde",
+]
+
+[[package]]
+name = "pem"
+version = "3.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
+dependencies = [
+ "base64 0.22.1",
+ "serde_core",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
+
+[[package]]
+name = "petgraph"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3672b37090dbd86368a4145bc067582552b29c27377cad4e0a306c97f9bd7772"
+dependencies = [
+ "fixedbitset",
+ "indexmap 2.9.0",
+]
 
 [[package]]
 name = "phf"
@@ -2473,6 +2839,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "prettyplease"
+version = "0.2.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6837b9e10d61f45f987d50808f83d1ee3d206c66acf650c3e4ae2e1f6ddedf55"
+dependencies = [
+ "proc-macro2",
+ "syn 2.0.100",
+]
+
+[[package]]
 name = "proc-macro-crate"
 version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2510,6 +2886,178 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "prost"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-build"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
+dependencies = [
+ "heck 0.5.0",
+ "itertools 0.13.0",
+ "log",
+ "multimap",
+ "once_cell",
+ "petgraph",
+ "prettyplease",
+ "prost",
+ "prost-types",
+ "regex",
+ "syn 2.0.100",
+ "tempfile",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
+dependencies = [
+ "anyhow",
+ "itertools 0.13.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52c2c1bf36ddb1a1c396b3601a3cec27c2462e45f07c386894ec3ccf5332bd16"
+dependencies = [
+ "prost",
+]
+
+[[package]]
+name = "protoc-bin-vendored"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1c381df33c98266b5f08186583660090a4ffa0889e76c7e9a5e175f645a67fa"
+dependencies = [
+ "protoc-bin-vendored-linux-aarch_64",
+ "protoc-bin-vendored-linux-ppcle_64",
+ "protoc-bin-vendored-linux-s390_64",
+ "protoc-bin-vendored-linux-x86_32",
+ "protoc-bin-vendored-linux-x86_64",
+ "protoc-bin-vendored-macos-aarch_64",
+ "protoc-bin-vendored-macos-x86_64",
+ "protoc-bin-vendored-win32",
+]
+
+[[package]]
+name = "protoc-bin-vendored-linux-aarch_64"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c350df4d49b5b9e3ca79f7e646fde2377b199e13cfa87320308397e1f37e1a4c"
+
+[[package]]
+name = "protoc-bin-vendored-linux-ppcle_64"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a55a63e6c7244f19b5c6393f025017eb5d793fd5467823a099740a7a4222440c"
+
+[[package]]
+name = "protoc-bin-vendored-linux-s390_64"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1dba5565db4288e935d5330a07c264a4ee8e4a5b4a4e6f4e83fad824cc32f3b0"
+
+[[package]]
+name = "protoc-bin-vendored-linux-x86_32"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8854774b24ee28b7868cd71dccaae8e02a2365e67a4a87a6cd11ee6cdbdf9cf5"
+
+[[package]]
+name = "protoc-bin-vendored-linux-x86_64"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b38b07546580df720fa464ce124c4b03630a6fb83e05c336fea2a241df7e5d78"
+
+[[package]]
+name = "protoc-bin-vendored-macos-aarch_64"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89278a9926ce312e51f1d999fee8825d324d603213344a9a706daa009f1d8092"
+
+[[package]]
+name = "protoc-bin-vendored-macos-x86_64"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81745feda7ccfb9471d7a4de888f0652e806d5795b61480605d4943176299756"
+
+[[package]]
+name = "protoc-bin-vendored-win32"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95067976aca6421a523e491fce939a3e65249bac4b977adee0ee9771568e8aa3"
+
+[[package]]
+name = "quinn"
+version = "0.11.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2 0.6.0",
+ "thiserror 2.0.20",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
+dependencies = [
+ "bytes",
+ "getrandom 0.4.3",
+ "lru-slab",
+ "rand 0.10.2",
+ "rand_pcg",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.20",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35a133f956daabe89a61a685c2649f13d82d5aa4bd5d12d1277e1072a21c0694"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2 0.6.0",
+ "tracing",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2558,8 +3106,8 @@ dependencies = [
  "inquire",
  "libc",
  "radicle-signals",
- "shlex",
- "thiserror",
+ "shlex 1.3.0",
+ "thiserror 1.0.69",
  "unicode-display-width",
  "unicode-segmentation",
  "zeroize",
@@ -2613,6 +3161,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
+name = "rand_pcg"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
+dependencies = [
+ "rand_core 0.10.1",
+]
+
+[[package]]
+name = "rcgen"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75e669e5202259b5314d1ea5397316ad400819437857b90861765f24c4cf80a2"
+dependencies = [
+ "pem",
+ "ring",
+ "rustls-pki-types",
+ "time",
+ "yasna",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2657,6 +3227,58 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
+name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-core",
+ "http 1.5.0",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.16",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "rusqlite"
 version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2671,6 +3293,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc-hash"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
+
+[[package]]
 name = "rustix"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2681,6 +3309,53 @@ dependencies = [
  "libc",
  "linux-raw-sys",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06"
+dependencies = [
+ "aws-lc-rs",
+ "log",
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f4925028c7eb5d1fcdaf196971378ed9d2c1c4efc7dc5d011256f76c99c0a96"
+dependencies = [
+ "web-time",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0527518605e68109d875e248ea259b6758801cf165e4b2c2733ae3b51f12535a"
+dependencies = [
+ "aws-lc-rs",
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -2823,8 +3498,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -2832,6 +3518,12 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "shlex"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "signal-hook"
@@ -2970,6 +3662,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
 name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2989,6 +3687,26 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
 ]
 
 [[package]]
@@ -3023,6 +3741,7 @@ dependencies = [
  "lampo-testing",
  "log",
  "ntest",
+ "reqwest",
  "serde_json",
  "tokio",
  "tokio-test-shutdown-timeout",
@@ -3034,7 +3753,16 @@ version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec86235f5fcc2a73650310756d2ac5b138a5780bbbdfae3eeccec992c435ba4f"
+dependencies = [
+ "thiserror-impl 2.0.20",
 ]
 
 [[package]]
@@ -3046,6 +3774,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.100",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -3148,6 +3887,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-test-shutdown-timeout"
 version = "0.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3189,6 +3938,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "tower"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
+dependencies = [
+ "bitflags 2.9.0",
+ "bytes",
+ "futures-util",
+ "http 1.5.0",
+ "http-body",
+ "pin-project-lite",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "url",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
+
+[[package]]
 name = "tracing"
 version = "0.1.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3219,6 +4013,12 @@ checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
 dependencies = [
  "once_cell",
 ]
+
+[[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "typenum"
@@ -3281,6 +4081,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
 name = "url"
 version = "2.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3331,6 +4137,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3372,6 +4187,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "555d470ec0bc3bb57890405e5d4322cc9ea83cebb085523ced7be4144dac1e61"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "once_cell",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
 name = "wasm-bindgen-macro"
 version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3401,6 +4229,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.77"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dcd9d09a39985f5344844e66b0c530a33843579125f23e21e9f0f220850f22a"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -3685,6 +4542,15 @@ name = "writeable"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
+
+[[package]]
+name = "yasna"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e17bb3549cc1321ae1296b9cdc2698e2b6cb1992adfa19a8c72e5b7a738f44cd"
+dependencies = [
+ "time",
+]
 
 [[package]]
 name = "yoke"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
         "lampod-cli",
         "lampo-cli",
         "lampo-httpd",
+        "lampo-lnd",
         "lampo-testing",
         "tests/tests",
         "lampo-chain",
@@ -17,6 +18,7 @@ default-members = [
         "lampod-cli",
         "lampo-cli",
         "lampo-httpd",
+        "lampo-lnd",
         "lampo-chain",
         "lampo-bdk-wallet"
 ]

--- a/docs/brainstorms/2026-08-16-lnd-rest-api-zeus.md
+++ b/docs/brainstorms/2026-08-16-lnd-rest-api-zeus.md
@@ -1,0 +1,161 @@
+# LND-compatible REST API for lampo, validated with Zeus
+
+Date: 2026-08-16
+Status: brainstorm (decisions locked with maintainer, see below)
+
+## Context
+
+- Zeus (https://github.com/ZeusLN/zeus) remote backends: **LND REST**
+  (macaroon auth, hex, sent as `Grpc-Metadata-macaroon` header), CLN
+  clnrest (rune auth), LNC, LNDHub, and Nostr Wallet Connect. Zeus does
+  **not** speak LND gRPC to remote nodes.
+- PR #474 (https://github.com/vincenzopalazzo/lampo.rs/pull/474) adds a
+  `lampo-grpc` tonic crate with the full LND proto dump but only
+  `GetInfo` and `ConnectPeer` implemented. Stale since Sept 2025;
+  predates the async migration. Decision: **do not take it over** —
+  start fresh, reference it for ideas only.
+- Roadmap issue #392 already lists "Implementing an LND-compatible API
+  like rld and making it the primary one" plus "dropping the generic
+  `call` in favour of strongly typed calls like `node.info()`".
+- Current `lampo-httpd` (actix-web, paperclip, no auth) exposes:
+  getinfo, funds, networkchannels, decode, invoice, keysend, pay,
+  offer, newaddr, channels, close, connect, fundchannel, stop. Most
+  core operations exist; the work is wire-format compatibility plus
+  authentication.
+
+## Decisions (from maintainer, 2026-08-16)
+
+1. **Goal**: LND API compatibility is the strategic deliverable; Zeus
+   is the first real client used to validate it.
+2. **PR #474**: start a fresh crate; reference the PR only.
+3. **Surface**: LND REST first; gRPC later, sharing a typed layer.
+4. **Auth**: full LND-style macaroon bakery (permissions/caveats) plus
+   TLS from day one.
+
+## Clarified Problem Statement
+
+**Goal:** Ship a new crate exposing an LND-compatible REST API (with
+macaroon + TLS auth) sufficient for Zeus to connect to lampo as a
+remote "LND" node.
+
+**Constraints:**
+- Wire fidelity with LND's REST conventions (grpc-gateway style JSON:
+  camelCase/snake_case exactly as lnd emits, bytes as base64, uint64
+  as string) — Zeus parses these shapes strictly.
+- Macaroon auth compatible with what Zeus sends (`Grpc-Metadata-
+  macaroon` header, hex-encoded), backed by a real bakery with
+  permission caveats; TLS with self-signed cert generated at startup
+  (lnd-style `tls.cert`/`tls.key`, `admin.macaroon` on disk).
+- Must not regress the existing JSON-RPC / lampo-httpd surfaces.
+- New dependencies need maintainer sign-off (repo rule). Expected:
+  `prost`/`pbjson` or hand-rolled serde types, `macaroon` crate,
+  `rcgen` for cert generation.
+- Each commit self-contained, passes `make fmt` + `make check`.
+
+**Non-goals:**
+- gRPC server itself (later phase; design must not block it).
+- LNC, LNDHub, NWC, or clnrest backends.
+- Streaming/subscription endpoints (`SubscribeInvoices`, channel event
+  streams) beyond what Zeus strictly needs for the first milestone.
+- Full lnrpc coverage — only the Zeus-critical subset (below).
+- Taking over or rebasing PR #474.
+
+**Success criteria:**
+- Zeus (Android/iOS build or desktop) connects to lampo on regtest/
+  signet using the "LND (REST)" node interface with host, port, and
+  hex macaroon, over TLS.
+- Zeus can: view balances and channels, generate an invoice, receive
+  a payment, pay an invoice, decode a payreq, get a new on-chain
+  address, connect a peer, open and close a channel.
+- Rejected/absent/wrong-permission macaroons are refused with
+  LND-shaped errors.
+- Integration test in `tests/` exercising the REST surface (curl-level
+  fidelity, e.g. against fixtures captured from a real lnd).
+
+**Zeus-critical endpoint subset (first milestone):**
+`GET /v1/getinfo`, `GET /v1/balance/blockchain`,
+`GET /v1/balance/channels`, `GET /v1/channels` (+ pending, closed),
+`GET/POST /v1/invoices`, `GET /v1/payreq/{payreq}`,
+`POST /v2/router/send` (or `/v1/channels/transactions`),
+`GET /v1/payments`, `GET /v1/transactions`, `POST /v1/newaddress`,
+`GET /v1/peers`, `POST /v1/peers` (connect), `POST /v1/channels`
+(open), `DELETE /v1/channels/{funding_txid}/{output_index}` (close).
+
+## Approaches Considered
+
+### Approach A: Hand-written REST crate (mirror lampo-httpd pattern)
+- Sketch: new `lampo-lnd` crate with actix-web routes; hand-written
+  serde structs for each LND request/response; each handler calls the
+  existing `LampoDaemon` handler like `lampo-httpd` does today.
+- Affected files: new `lampo-lnd/`, `lampod-cli/src/main.rs` +
+  `args.rs` (spawn the server), `Cargo.toml` workspace.
+- Tradeoffs: fastest to first Zeus connection; no proto toolchain.
+  But every type is transcribed by hand (drift risk vs. lnd), and a
+  future gRPC server shares nothing — the typed layer would be
+  rebuilt.
+- Effort: M
+
+### Approach B: Typed-core-first (roadmap-pure)
+- Sketch: first land the strongly-typed internal API from #392
+  (`node.info()`, `node.pay()`, ... on `LampoDaemon`), refactor
+  lampo-httpd/jsonrpc onto it, then add the LND REST crate as a thin
+  adapter over the typed core.
+- Affected files: `lampod/src/` broadly (handler, jsonrpc), then new
+  `lampo-lnd/`.
+- Tradeoffs: best long-term architecture and directly executes the
+  roadmap experiment; gRPC later is trivial. But the refactor is a
+  large, churny prerequisite that delays Zeus validation by weeks and
+  touches everything.
+- Effort: L (XL including the refactor)
+
+### Approach C: Proto-derived types, REST-first (recommended)
+- Sketch: new `lampo-lnd` crate vendoring `lightning.proto` (+
+  `router.proto`), compiled with `prost` + `pbjson` so the generated
+  Rust types serialize to exactly the JSON grpc-gateway emits.
+  Hand-write the REST routes (actix-web, matching lnd's URL mapping),
+  each converting proto types <-> lampo model and calling the daemon.
+  A later gRPC phase reuses the identical generated types and
+  conversion layer, adding only a tonic transport.
+- Affected files: new `lampo-lnd/` (build.rs, protos, `routes/`,
+  `convert/`, `auth/`), `lampod-cli` wiring, workspace `Cargo.toml`,
+  `deny.toml` for new deps.
+- Tradeoffs: guaranteed wire fidelity and a shared typed layer for
+  free (the proto types *are* the contract), directly reusable for
+  gRPC. Costs: proto toolchain in the build (protoc via
+  `protoc-bin-vendored` or committed generated code), and pbjson's
+  proto3-JSON mapping must be spot-checked against grpc-gateway
+  output for a few endpoints.
+- Effort: L
+
+## Recommendation
+
+Approach C. It satisfies both stated goals with one artifact: the
+prost/pbjson-generated types give LND wire fidelity for Zeus today and
+become the shared typed layer the future gRPC server needs, without
+first paying for the Approach B core refactor. I'd sequence it as:
+(1) crate skeleton + TLS + macaroon bakery + `/v1/getinfo`;
+(2) read-only endpoints (balances, channels, invoices, payments,
+decode); (3) mutating endpoints (invoice create, pay, newaddress,
+connect, open/close); (4) Zeus end-to-end validation on signet.
+One honest uncertainty: pbjson matches canonical proto3 JSON, while
+grpc-gateway (lnd) has a couple of quirks (e.g. some snake_case
+fields, enums as strings) — verify with captured lnd responses early,
+in step (1), before mass-producing endpoints.
+
+## Open questions
+
+- Macaroon crate choice: `macaroon` (rust-macaroon) is barely
+  maintained — vendor, fork, or accept it? Needs maintainer sign-off
+  per dependency rule.
+- Does Zeus require any streaming endpoint for its core screens (e.g.
+  invoice subscription for the receive screen), or does it poll on
+  REST? Verify against the Zeus LND backend source before scoping
+  milestone 1.
+- Where does the LND listener config live — new `[lnd]` section in
+  `lampo.conf` (port, tls dir, macaroon dir)?
+- Should `lampo-httpd` eventually be deprecated in favour of this
+  surface ("making it the primary one" per #392)? Out of scope now,
+  worth a roadmap note.
+- Version string in `getinfo`: Zeus gates features on lnd versions
+  (e.g. `v0.20.0` checks). Decide what lampo reports (mimic an lnd
+  version vs. honest lampo version — affects Zeus feature gating).

--- a/docs/plans/2026-08-16-lnd-rest-api-zeus.md
+++ b/docs/plans/2026-08-16-lnd-rest-api-zeus.md
@@ -8,8 +8,8 @@
 
 - `lampo-lnd/` (new) — crate: protos, auth, tls, routes, convert, server
 - `Cargo.toml` — workspace member
-- `lampo-common/src/conf.rs` — `lnd-rest-*` config knobs
-- `lampod-cli/src/{args,main}.rs` — spawn LND REST listener
+- `lampo-common/src/conf.rs` — `lnd` API-mode switch
+- `lampod-cli/src/{args,main}.rs` — select and spawn the LND REST listener
 - `lampo.example.conf` — document new keys
 - `tests/tests/src/` — auth + REST smoke integration
 - `tools/lnd-rest-smoke.sh` — curl-based LND REST smoke (not `lncli`)
@@ -51,7 +51,8 @@
 
 ## Edge cases / security (from review)
 
-- Legacy `lampo-httpd` stays loopback-only by default; LND REST is the remote surface.
+- `lnd=true` selects LND REST instead of legacy `lampo-httpd`; both use
+  `api-host`/`api-port`, so the unauthenticated API is never exposed alongside it.
 - Never log macaroons, full bodies, invoices, or preimages.
 - Fail startup if LND REST bind/TLS/macaroon init fails (do not detach-and-ignore).
 - Bound body/header sizes; auth before large body work.

--- a/docs/plans/2026-08-16-lnd-rest-api-zeus.md
+++ b/docs/plans/2026-08-16-lnd-rest-api-zeus.md
@@ -1,0 +1,92 @@
+# Plan: lnd-rest-api-zeus
+
+**Goal:** Ship a new `lampo-lnd` crate exposing an LND-compatible REST API (TLS + real macaroon bakery) so Zeus can connect to lampo as a remote "LND" node, without taking over PR #474.
+
+**Approach:** C from `docs/brainstorms/2026-08-16-lnd-rest-api-zeus.md` — proto-derived types (`prost`/`pbjson`), handwritten Actix REST routes, shared conversion layer reusable by a later gRPC transport.
+
+## Affected files
+
+- `lampo-lnd/` (new) — crate: protos, auth, tls, routes, convert, server
+- `Cargo.toml` — workspace member
+- `lampo-common/src/conf.rs` — `lnd-rest-*` config knobs
+- `lampod-cli/src/{args,main}.rs` — spawn LND REST listener
+- `lampo.example.conf` — document new keys
+- `tests/tests/src/` — auth + REST smoke integration
+- `tools/lnd-rest-smoke.sh` — curl-based LND REST smoke (not `lncli`)
+- `deny.toml` — allow new deps if needed
+
+## Approach
+
+1. Add `lampo-lnd` with pinned LND `v0.20.0-beta` `lightning.proto` + `routerrpc/router.proto`, compiled via `prost-build` + `pbjson-build` (vendored `protoc` when system protoc is missing).
+2. Keep a transport-independent adapter that talks to `lampod::jsonrpc::*` / managers directly — **do not** route through `LampoDaemon::call` (that loops into the HTTP external handler).
+3. Hand-write Actix routes matching LND grpc-gateway paths; serialize with pbjson so `uint64` is string and bytes are base64.
+4. Persist stable `tls.cert`/`tls.key` and macaroon root key under the network data dir (`0700`/`0600`, no silent rotation).
+5. Verify macaroons with HMAC + first-party permission caveats; authorize deny-by-default per LND entity/action table; accept `Grpc-Metadata-macaroon` hex only.
+6. Milestone-1 endpoint set = Zeus P0 connect + money path (see below). History endpoints that lampo cannot back yet return empty LND-shaped lists rather than inventing data.
+7. Smoke with curl against the official LND REST contract. **Official `lncli` is gRPC-only** and cannot validate a REST-only server; a later gRPC phase unlocks `lncli`.
+
+## Milestone-1 endpoints
+
+| Method | Path | Backing |
+|--------|------|---------|
+| GET | `/v1/getinfo` | inventory + managers (omit `lampo_dir`) |
+| GET | `/v1/balance/blockchain` | wallet balance |
+| GET | `/v1/balance/channels` | derive from channel list |
+| GET | `/v1/channels` | channel manager |
+| GET | `/v1/channels/pending` | pending channels (empty/partial OK) |
+| GET | `/v1/channels/closed` | empty list until persisted |
+| GET | `/v1/peers` | peer manager |
+| POST | `/v1/peers` | connect |
+| POST | `/v1/newaddress` | newaddr |
+| POST | `/v1/invoices` | invoice + in-memory index |
+| GET | `/v1/invoice/{r_hash}` | in-memory index + settle via events |
+| GET | `/v1/invoices` | in-memory index |
+| GET | `/v1/payreq/{payreq}` | decode |
+| POST | `/v1/channels/transactions` | pay (unary Sync) |
+| POST | `/v2/router/send` | pay as NDJSON stream (Zeus path) |
+| POST | `/v1/channels` | fundchannel |
+| DELETE | `/v1/channels/{txid}/{idx}` | close by funding outpoint |
+| GET | `/v1/payments` | empty or recent in-memory |
+| GET | `/v1/transactions` | empty or best-effort UTXO mapping |
+
+## Edge cases / security (from review)
+
+- Legacy `lampo-httpd` stays loopback-only by default; LND REST is the remote surface.
+- Never log macaroons, full bodies, invoices, or preimages.
+- Fail startup if LND REST bind/TLS/macaroon init fails (do not detach-and-ignore).
+- Bound body/header sizes; auth before large body work.
+- Stable TLS identity across restarts; no silent root-key rewrite.
+- Close-by-outpoint: resolve funding txid/index against LDK channel details (Lampo close currently wants peer/channel id).
+- `getinfo.version`: report `0.18.5-beta` so Zeus unlocks modern UI without claiming unsupported RPCs.
+
+## Test plan
+
+- Unit: macaroon verify/deny matrix; TLS restart stability; pbjson golden fixtures for GetInfo/Invoice/Channel.
+- Integration (regtest via `lampo-testing`): TLS+macaroon getinfo; wrong macaroon 401; readonly cannot pay; create invoice + pay path if feasible.
+- Smoke script: `tools/lnd-rest-smoke.sh` curls getinfo/balance/channels with hex macaroon (`-k`).
+- Document why `lncli` is deferred (gRPC).
+
+## Conventions
+
+- Imperative commits, `make fmt` + targeted tests before push.
+- Maintainer sign-off already implied by Approach C deps: `prost`, `pbjson*`, `rcgen`, `rustls`, `macaroon` (or minimal LND-compatible bakery if crate is unfit).
+- Logs always carry `target: "lampo-lnd"`.
+- No unwrap in production paths.
+
+## Open questions / risks
+
+- `macaroon` crate maintenance — implement thin LND bakery if crate cannot express entity/action caveats.
+- pbjson vs grpc-gateway quirks — pin golden fixtures from LND v0.20 early.
+- Invoice settle visibility needs event subscription; without it Zeus receive polling never sees SETTLED.
+- Full Zeus E2E on a phone is manual; CI covers curl smoke + unit/integration.
+
+## Estimated size
+
+L (>200 LOC)
+
+## PR sequencing inside this delivery
+
+1. Crate + TLS + bakery + GetInfo + smoke.
+2. Read endpoints (balances, channels, peers).
+3. Mutating endpoints (invoice, pay, connect, open/close, newaddress).
+4. Reviews (Bugbot + security) then open PR.

--- a/lampo-common/src/conf.rs
+++ b/lampo-common/src/conf.rs
@@ -26,6 +26,10 @@ pub struct LampoConf {
     pub announce_addr: Option<String>,
     pub api_host: String,
     pub api_port: u64,
+    /// Enable the LND-compatible REST listener (Zeus remote node).
+    pub lnd_rest: Option<bool>,
+    pub lnd_rest_host: Option<String>,
+    pub lnd_rest_port: Option<u64>,
     pub reindex: Option<Height>,
     pub dev_sync: Option<bool>,
     /// Allow the on-chain wallet to scan in parallel with the LDK chain
@@ -70,6 +74,9 @@ impl Default for LampoConf {
             announce_addr: None,
             api_host: "127.0.0.1".to_owned(),
             api_port: 7878,
+            lnd_rest: None,
+            lnd_rest_host: None,
+            lnd_rest_port: None,
             reindex: None,
             dev_sync: None,
             wallet_sync_parallel: None,
@@ -259,6 +266,17 @@ impl TryFrom<String> for LampoConf {
         let api_host = api_host.unwrap_or("http://127.0.0.1".to_owned());
         let api_port: u64 = api_port.unwrap_or("7979".to_owned()).parse()?;
 
+        let lnd_rest = conf
+            .get_conf("lnd-rest")
+            .unwrap_or(None)
+            .map(|s| s.to_lowercase() == "true" || s == "1");
+        let lnd_rest_host = conf.get_conf("lnd-rest-host").unwrap_or(None);
+        let lnd_rest_port = conf
+            .get_conf("lnd-rest-port")
+            .unwrap_or(None)
+            .map(|s| s.parse::<u64>())
+            .transpose()?;
+
         // Parse dev_sync field - defaults to None (false)
         let dev_sync = conf
             .get_conf("dev-sync")
@@ -294,6 +312,9 @@ impl TryFrom<String> for LampoConf {
             announce_addr,
             api_host,
             api_port,
+            lnd_rest,
+            lnd_rest_host,
+            lnd_rest_port,
             reindex,
             dev_sync,
             wallet_sync_parallel,

--- a/lampo-common/src/conf.rs
+++ b/lampo-common/src/conf.rs
@@ -26,10 +26,8 @@ pub struct LampoConf {
     pub announce_addr: Option<String>,
     pub api_host: String,
     pub api_port: u64,
-    /// Enable the LND-compatible REST listener (Zeus remote node).
-    pub lnd_rest: Option<bool>,
-    pub lnd_rest_host: Option<String>,
-    pub lnd_rest_port: Option<u64>,
+    /// Serve the LND-compatible API instead of lampo-httpd.
+    pub lnd: Option<bool>,
     pub reindex: Option<Height>,
     pub dev_sync: Option<bool>,
     /// Allow the on-chain wallet to scan in parallel with the LDK chain
@@ -74,9 +72,7 @@ impl Default for LampoConf {
             announce_addr: None,
             api_host: "127.0.0.1".to_owned(),
             api_port: 7878,
-            lnd_rest: None,
-            lnd_rest_host: None,
-            lnd_rest_port: None,
+            lnd: None,
             reindex: None,
             dev_sync: None,
             wallet_sync_parallel: None,
@@ -266,16 +262,10 @@ impl TryFrom<String> for LampoConf {
         let api_host = api_host.unwrap_or("http://127.0.0.1".to_owned());
         let api_port: u64 = api_port.unwrap_or("7979".to_owned()).parse()?;
 
-        let lnd_rest = conf
-            .get_conf("lnd-rest")
+        let lnd = conf
+            .get_conf("lnd")
             .unwrap_or(None)
             .map(|s| s.to_lowercase() == "true" || s == "1");
-        let lnd_rest_host = conf.get_conf("lnd-rest-host").unwrap_or(None);
-        let lnd_rest_port = conf
-            .get_conf("lnd-rest-port")
-            .unwrap_or(None)
-            .map(|s| s.parse::<u64>())
-            .transpose()?;
 
         // Parse dev_sync field - defaults to None (false)
         let dev_sync = conf
@@ -312,9 +302,7 @@ impl TryFrom<String> for LampoConf {
             announce_addr,
             api_host,
             api_port,
-            lnd_rest,
-            lnd_rest_host,
-            lnd_rest_port,
+            lnd,
             reindex,
             dev_sync,
             wallet_sync_parallel,

--- a/lampo-common/src/conf.rs
+++ b/lampo-common/src/conf.rs
@@ -28,6 +28,8 @@ pub struct LampoConf {
     pub api_port: u64,
     /// Serve the LND-compatible API instead of lampo-httpd.
     pub lnd: Option<bool>,
+    /// Additional DNS names or IP addresses for the LND REST TLS certificate.
+    pub lnd_tls_sans: Vec<String>,
     pub reindex: Option<Height>,
     pub dev_sync: Option<bool>,
     /// Allow the on-chain wallet to scan in parallel with the LDK chain
@@ -73,6 +75,7 @@ impl Default for LampoConf {
             api_host: "127.0.0.1".to_owned(),
             api_port: 7878,
             lnd: None,
+            lnd_tls_sans: Vec::new(),
             reindex: None,
             dev_sync: None,
             wallet_sync_parallel: None,
@@ -266,6 +269,7 @@ impl TryFrom<String> for LampoConf {
             .get_conf("lnd")
             .unwrap_or(None)
             .map(|s| s.to_lowercase() == "true" || s == "1");
+        let lnd_tls_sans = conf.get_confs("lnd-tls-san");
 
         // Parse dev_sync field - defaults to None (false)
         let dev_sync = conf
@@ -303,6 +307,7 @@ impl TryFrom<String> for LampoConf {
             api_host,
             api_port,
             lnd,
+            lnd_tls_sans,
             reindex,
             dev_sync,
             wallet_sync_parallel,

--- a/lampo-common/src/model/close_channel.rs
+++ b/lampo-common/src/model/close_channel.rs
@@ -14,6 +14,8 @@ pub mod request {
         pub node_id: String,
         // Hex of the channel
         pub channel_id: Option<String>,
+        #[serde(default)]
+        pub force: bool,
     }
 
     impl CloseChannel {
@@ -74,6 +76,7 @@ pub mod tests {
         let req = crate::model::request::CloseChannel {
             node_id: node_id.clone(),
             channel_id: channel_hex,
+            force: false,
         };
         let channel_bytes = [
             10, 68, 103, 117, 38, 172, 140, 96, 118, 22, 189, 145, 37, 141, 126, 93, 241, 216, 111,

--- a/lampo-common/src/model/connect.rs
+++ b/lampo-common/src/model/connect.rs
@@ -1,5 +1,6 @@
 //! Connect Model
-use std::{net::SocketAddr, str::FromStr};
+use std::net::{SocketAddr, ToSocketAddrs};
+use std::str::FromStr;
 
 use paperclip::actix::Apiv2Schema;
 use serde::{Deserialize, Serialize};
@@ -21,12 +22,37 @@ impl Connect {
     }
 
     pub fn addr(&self) -> error::Result<SocketAddr> {
-        let addr = format!("{}:{}", self.addr, self.port);
-        let result = SocketAddr::from_str(&addr);
-        match result {
-            Ok(res) => Ok(res),
-            Err(e) => Err(e.into()),
+        let port = u16::try_from(self.port)
+            .map_err(|_| error::anyhow!("peer port must be between 1 and 65535"))?;
+        if port == 0 {
+            error::bail!("peer port must be between 1 and 65535");
         }
+        (self.addr.as_str(), port)
+            .to_socket_addrs()?
+            .next()
+            .ok_or_else(|| error::anyhow!("peer address did not resolve"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Connect;
+
+    #[test]
+    fn resolves_hostname_and_unbracketed_ipv6() {
+        let hostname = Connect {
+            node_id: String::new(),
+            addr: "localhost".into(),
+            port: 9735,
+        };
+        assert_eq!(hostname.addr().unwrap().port(), 9735);
+
+        let ipv6 = Connect {
+            node_id: String::new(),
+            addr: "::1".into(),
+            port: 9735,
+        };
+        assert!(ipv6.addr().unwrap().is_ipv6());
     }
 }
 

--- a/lampo-common/src/model/invoice.rs
+++ b/lampo-common/src/model/invoice.rs
@@ -35,6 +35,9 @@ pub mod request {
         /// How long the RPC waits for the terminal `PaymentEvent` (`fast` / `medium` / `large`).
         #[serde(default)]
         pub timeout: PayTimeout,
+        /// Exact payment wait timeout in seconds, when requested by a compatible API.
+        #[serde(default)]
+        pub timeout_secs: Option<u64>,
     }
 
     #[derive(Serialize, Deserialize, Apiv2Schema)]
@@ -82,6 +85,7 @@ pub mod response {
     pub struct Bolt11InvoiceInfo {
         pub issuer_id: Option<String>,
         pub payment_hash: String,
+        pub timestamp: u64,
         pub expiry_time: Option<u64>,
         pub description: Option<String>,
         pub routes: Vec<String>,

--- a/lampo-common/src/model/invoice.rs
+++ b/lampo-common/src/model/invoice.rs
@@ -28,6 +28,9 @@ pub mod request {
     pub struct Pay {
         pub invoice_str: String,
         pub amount: Option<u64>,
+        /// Maximum routing fees allowed for this payment, in millisatoshis.
+        #[serde(default)]
+        pub max_fee_msat: Option<u64>,
         pub bolt12: Option<Bolt12Pay>,
         /// How long the RPC waits for the terminal `PaymentEvent` (`fast` / `medium` / `large`).
         #[serde(default)]
@@ -78,6 +81,7 @@ pub mod response {
     #[derive(Debug, Serialize, Deserialize, Apiv2Schema)]
     pub struct Bolt11InvoiceInfo {
         pub issuer_id: Option<String>,
+        pub payment_hash: String,
         pub expiry_time: Option<u64>,
         pub description: Option<String>,
         pub routes: Vec<String>,

--- a/lampo-common/src/model/invoice.rs
+++ b/lampo-common/src/model/invoice.rs
@@ -181,6 +181,12 @@ pub mod response {
         pub path: Vec<PaymentHop>,
         pub payment_hash: Option<String>,
         pub state: PaymentState,
+        /// Total value delivered across all successful MPP paths.
+        pub value_msat: u64,
+        /// Total routing fees paid across all successful MPP paths.
+        pub fee_msat: u64,
+        /// Terminal failure detail, when the payment failed.
+        pub reason: Option<String>,
         /// Hex encoded preimage, the receipt of the payment.
         pub payment_preimage: Option<String>,
         /// Bech32 encoded BOLT 12 payer proof, proving to a third party that

--- a/lampo-common/src/model/invoice.rs
+++ b/lampo-common/src/model/invoice.rs
@@ -35,7 +35,7 @@ pub mod request {
         /// How long the RPC waits for the terminal `PaymentEvent` (`fast` / `medium` / `large`).
         #[serde(default)]
         pub timeout: PayTimeout,
-        /// Exact payment wait timeout in seconds, when requested by a compatible API.
+        /// Retry deadline before an HTLC is launched, for compatible payment APIs.
         #[serde(default)]
         pub timeout_secs: Option<u64>,
     }

--- a/lampo-common/src/model/open_channel.rs
+++ b/lampo-common/src/model/open_channel.rs
@@ -16,6 +16,8 @@ pub mod request {
         pub amount: u64,
         #[serde(default)]
         pub push_msat: Option<u64>,
+        #[serde(default)]
+        pub sat_per_vbyte: Option<u64>,
         pub public: bool,
     }
 

--- a/lampo-lnd/Cargo.toml
+++ b/lampo-lnd/Cargo.toml
@@ -1,0 +1,39 @@
+[package]
+name = "lampo-lnd"
+version = "0.1.0"
+edition = "2021"
+description = "LND-compatible REST API surface for lampo (Zeus remote node)"
+publish = false
+
+[dependencies]
+actix-web = { version = "4", features = ["rustls-0_23"] }
+base64 = "0.22"
+bytes = "1"
+futures-util = "0.3"
+hex = "0.4"
+hmac = "0.12"
+lampo-common = { path = "../lampo-common" }
+lampod = { path = "../lampod" }
+log = "0.4"
+pbjson = "0.7"
+pbjson-types = "0.7"
+prost = "0.13"
+rand = "0.8"
+rcgen = "0.13"
+rustls = { version = "0.23", features = ["ring"] }
+rustls-pemfile = "2"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+sha2 = "0.10"
+thiserror = "2"
+tokio = { version = "1", features = ["fs", "macros", "rt", "sync", "time"] }
+tokio-rustls = "0.26"
+
+[build-dependencies]
+pbjson-build = "0.7"
+prost-build = "0.13"
+protoc-bin-vendored = "3"
+
+[dev-dependencies]
+actix-rt = "2"
+tempfile = "3"

--- a/lampo-lnd/build.rs
+++ b/lampo-lnd/build.rs
@@ -1,0 +1,33 @@
+use std::env;
+use std::io::Result;
+use std::path::PathBuf;
+
+fn main() -> Result<()> {
+    // Prefer a system protoc when present; fall back to the vendored binary so
+    // CI machines without protobuf-compiler still build.
+    if env::var_os("PROTOC").is_none() {
+        if let Ok(protoc) = protoc_bin_vendored::protoc_bin_path() {
+            // SAFETY: build-script exclusive; no concurrent readers of PROTOC.
+            unsafe { env::set_var("PROTOC", protoc) };
+        }
+    }
+
+    let out_dir = PathBuf::from(env::var("OUT_DIR").expect("OUT_DIR"));
+    let descriptor_path = out_dir.join("proto_descriptor.bin");
+
+    let mut config = prost_build::Config::new();
+    config
+        .file_descriptor_set_path(&descriptor_path)
+        .compile_well_known_types()
+        .extern_path(".google.protobuf", "::pbjson_types")
+        .bytes(["."]);
+
+    config.compile_protos(&["proto/lightning.proto"], &["proto/"])?;
+
+    let descriptor_set = std::fs::read(&descriptor_path)?;
+    pbjson_build::Builder::new()
+        .register_descriptors(&descriptor_set)?
+        .build(&[".lnrpc"])?;
+
+    Ok(())
+}

--- a/lampo-lnd/proto/lightning.proto
+++ b/lampo-lnd/proto/lightning.proto
@@ -1,0 +1,5411 @@
+syntax = "proto3";
+
+package lnrpc;
+
+option go_package = "github.com/lightningnetwork/lnd/lnrpc";
+
+/*
+ * Comments in this file will be directly parsed into the API
+ * Documentation as descriptions of the associated method, message, or field.
+ * These descriptions should go right above the definition of the object, and
+ * can be in either block or // comment format.
+ *
+ * An RPC method can be matched to an lncli command by placing a line in the
+ * beginning of the description in exactly the following format:
+ * lncli: `methodname`
+ *
+ * Failure to specify the exact name of the command will cause documentation
+ * generation to fail.
+ *
+ * More information on how exactly the gRPC documentation is generated from
+ * this proto file can be found here:
+ * https://github.com/lightninglabs/lightning-api
+ */
+
+// Lightning is the main RPC server of the daemon.
+service Lightning {
+    /* lncli: `walletbalance`
+    WalletBalance returns total unspent outputs(confirmed and unconfirmed), all
+    confirmed unspent outputs and all unconfirmed unspent outputs under control
+    of the wallet.
+    */
+    rpc WalletBalance (WalletBalanceRequest) returns (WalletBalanceResponse);
+
+    /* lncli: `channelbalance`
+    ChannelBalance returns a report on the total funds across all open channels,
+    categorized in local/remote, pending local/remote and unsettled local/remote
+    balances.
+    */
+    rpc ChannelBalance (ChannelBalanceRequest) returns (ChannelBalanceResponse);
+
+    /* lncli: `listchaintxns`
+    GetTransactions returns a list describing all the known transactions
+    relevant to the wallet.
+    */
+    rpc GetTransactions (GetTransactionsRequest) returns (TransactionDetails);
+
+    /* lncli: `estimatefee`
+    EstimateFee asks the chain backend to estimate the fee rate and total fees
+    for a transaction that pays to multiple specified outputs.
+
+    When using REST, the `AddrToAmount` map type can be set by appending
+    `&AddrToAmount[<address>]=<amount_to_send>` to the URL. Unfortunately this
+    map type doesn't appear in the REST API documentation because of a bug in
+    the grpc-gateway library.
+    */
+    rpc EstimateFee (EstimateFeeRequest) returns (EstimateFeeResponse);
+
+    /* lncli: `sendcoins`
+    SendCoins executes a request to send coins to a particular address. Unlike
+    SendMany, this RPC call only allows creating a single output at a time. If
+    neither target_conf, or sat_per_vbyte are set, then the internal wallet will
+    consult its fee model to determine a fee for the default confirmation
+    target.
+    */
+    rpc SendCoins (SendCoinsRequest) returns (SendCoinsResponse);
+
+    /* lncli: `listunspent`
+    Deprecated, use walletrpc.ListUnspent instead.
+
+    ListUnspent returns a list of all utxos spendable by the wallet with a
+    number of confirmations between the specified minimum and maximum.
+    */
+    rpc ListUnspent (ListUnspentRequest) returns (ListUnspentResponse);
+
+    /*
+    SubscribeTransactions creates a uni-directional stream from the server to
+    the client in which any newly discovered transactions relevant to the
+    wallet are sent over.
+    */
+    rpc SubscribeTransactions (GetTransactionsRequest)
+        returns (stream Transaction);
+
+    /* lncli: `sendmany`
+    SendMany handles a request for a transaction that creates multiple specified
+    outputs in parallel. If neither target_conf, or sat_per_vbyte are set, then
+    the internal wallet will consult its fee model to determine a fee for the
+    default confirmation target.
+    */
+    rpc SendMany (SendManyRequest) returns (SendManyResponse);
+
+    /* lncli: `newaddress`
+    NewAddress creates a new address under control of the local wallet.
+    */
+    rpc NewAddress (NewAddressRequest) returns (NewAddressResponse);
+
+    /* lncli: `signmessage`
+    SignMessage signs a message with this node's private key. The returned
+    signature string is `zbase32` encoded and pubkey recoverable, meaning that
+    only the message digest and signature are needed for verification.
+    */
+    rpc SignMessage (SignMessageRequest) returns (SignMessageResponse);
+
+    /* lncli: `verifymessage`
+    VerifyMessage verifies a signature over a message and recovers the signer's
+    public key. The signature is only deemed valid if the recovered public key
+    corresponds to a node key in the public Lightning network. The signature
+    must be zbase32 encoded and signed by an active node in the resident node's
+    channel database. In addition to returning the validity of the signature,
+    VerifyMessage also returns the recovered pubkey from the signature.
+    */
+    rpc VerifyMessage (VerifyMessageRequest) returns (VerifyMessageResponse);
+
+    /* lncli: `connect`
+    ConnectPeer attempts to establish a connection to a remote peer. This is at
+    the networking level, and is used for communication between nodes. This is
+    distinct from establishing a channel with a peer.
+    */
+    rpc ConnectPeer (ConnectPeerRequest) returns (ConnectPeerResponse);
+
+    /* lncli: `disconnect`
+    DisconnectPeer attempts to disconnect one peer from another identified by a
+    given pubKey. In the case that we currently have a pending or active channel
+    with the target peer, then this action will be not be allowed.
+    */
+    rpc DisconnectPeer (DisconnectPeerRequest) returns (DisconnectPeerResponse);
+
+    /* lncli: `listpeers`
+    ListPeers returns a verbose listing of all currently active peers.
+    */
+    rpc ListPeers (ListPeersRequest) returns (ListPeersResponse);
+
+    /*
+    SubscribePeerEvents creates a uni-directional stream from the server to
+    the client in which any events relevant to the state of peers are sent
+    over. Events include peers going online and offline.
+    */
+    rpc SubscribePeerEvents (PeerEventSubscription) returns (stream PeerEvent);
+
+    /* lncli: `getinfo`
+    GetInfo returns general information concerning the lightning node including
+    it's identity pubkey, alias, the chains it is connected to, and information
+    concerning the number of open+pending channels.
+    */
+    rpc GetInfo (GetInfoRequest) returns (GetInfoResponse);
+
+    /* lncli: 'getdebuginfo'
+    GetDebugInfo returns debug information concerning the state of the daemon
+    and its subsystems. This includes the full configuration and the latest log
+    entries from the log file.
+    */
+    rpc GetDebugInfo (GetDebugInfoRequest) returns (GetDebugInfoResponse);
+
+    /** lncli: `getrecoveryinfo`
+    GetRecoveryInfo returns information concerning the recovery mode including
+    whether it's in a recovery mode, whether the recovery is finished, and the
+    progress made so far.
+    */
+    rpc GetRecoveryInfo (GetRecoveryInfoRequest)
+        returns (GetRecoveryInfoResponse);
+
+    // TODO(roasbeef): merge with below with bool?
+    /* lncli: `pendingchannels`
+    PendingChannels returns a list of all the channels that are currently
+    considered "pending". A channel is pending if it has finished the funding
+    workflow and is waiting for confirmations for the funding txn, or is in the
+    process of closure, either initiated cooperatively or non-cooperatively.
+    */
+    rpc PendingChannels (PendingChannelsRequest)
+        returns (PendingChannelsResponse);
+
+    /* lncli: `listchannels`
+    ListChannels returns a description of all the open channels that this node
+    is a participant in.
+    */
+    rpc ListChannels (ListChannelsRequest) returns (ListChannelsResponse);
+
+    /*
+    SubscribeChannelEvents creates a uni-directional stream from the server to
+    the client in which any updates relevant to the state of the channels are
+    sent over. Events include new active channels, inactive channels, and closed
+    channels.
+    */
+    rpc SubscribeChannelEvents (ChannelEventSubscription)
+        returns (stream ChannelEventUpdate);
+
+    /* lncli: `closedchannels`
+    ClosedChannels returns a description of all the closed channels that
+    this node was a participant in.
+    */
+    rpc ClosedChannels (ClosedChannelsRequest) returns (ClosedChannelsResponse);
+
+    /*
+    OpenChannelSync is a synchronous version of the OpenChannel RPC call. This
+    call is meant to be consumed by clients to the REST proxy. As with all
+    other sync calls, all byte slices are intended to be populated as hex
+    encoded strings.
+    */
+    rpc OpenChannelSync (OpenChannelRequest) returns (ChannelPoint);
+
+    /* lncli: `openchannel`
+    OpenChannel attempts to open a singly funded channel specified in the
+    request to a remote peer. Users are able to specify a target number of
+    blocks that the funding transaction should be confirmed in, or a manual fee
+    rate to us for the funding transaction. If neither are specified, then a
+    lax block confirmation target is used. Each OpenStatusUpdate will return
+    the pending channel ID of the in-progress channel. Depending on the
+    arguments specified in the OpenChannelRequest, this pending channel ID can
+    then be used to manually progress the channel funding flow.
+    */
+    rpc OpenChannel (OpenChannelRequest) returns (stream OpenStatusUpdate);
+
+    /* lncli: `batchopenchannel`
+    BatchOpenChannel attempts to open multiple single-funded channels in a
+    single transaction in an atomic way. This means either all channel open
+    requests succeed at once or all attempts are aborted if any of them fail.
+    This is the safer variant of using PSBTs to manually fund a batch of
+    channels through the OpenChannel RPC.
+    */
+    rpc BatchOpenChannel (BatchOpenChannelRequest)
+        returns (BatchOpenChannelResponse);
+
+    /*
+    FundingStateStep is an advanced funding related call that allows the caller
+    to either execute some preparatory steps for a funding workflow, or
+    manually progress a funding workflow. The primary way a funding flow is
+    identified is via its pending channel ID. As an example, this method can be
+    used to specify that we're expecting a funding flow for a particular
+    pending channel ID, for which we need to use specific parameters.
+    Alternatively, this can be used to interactively drive PSBT signing for
+    funding for partially complete funding transactions.
+    */
+    rpc FundingStateStep (FundingTransitionMsg) returns (FundingStateStepResp);
+
+    /*
+    ChannelAcceptor dispatches a bi-directional streaming RPC in which
+    OpenChannel requests are sent to the client and the client responds with
+    a boolean that tells LND whether or not to accept the channel. This allows
+    node operators to specify their own criteria for accepting inbound channels
+    through a single persistent connection.
+    */
+    rpc ChannelAcceptor (stream ChannelAcceptResponse)
+        returns (stream ChannelAcceptRequest);
+
+    /* lncli: `closechannel`
+    CloseChannel attempts to close an active channel identified by its channel
+    outpoint (ChannelPoint). The actions of this method can additionally be
+    augmented to attempt a force close after a timeout period in the case of an
+    inactive peer. If a non-force close (cooperative closure) is requested,
+    then the user can specify either a target number of blocks until the
+    closure transaction is confirmed, or a manual fee rate. If neither are
+    specified, then a default lax, block confirmation target is used.
+    */
+    rpc CloseChannel (CloseChannelRequest) returns (stream CloseStatusUpdate);
+
+    /* lncli: `abandonchannel`
+    AbandonChannel removes all channel state from the database except for a
+    close summary. This method can be used to get rid of permanently unusable
+    channels due to bugs fixed in newer versions of lnd. This method can also be
+    used to remove externally funded channels where the funding transaction was
+    never broadcast. Only available for non-externally funded channels in dev
+    build.
+    */
+    rpc AbandonChannel (AbandonChannelRequest) returns (AbandonChannelResponse);
+
+    /* lncli: `sendpayment`
+    Deprecated, use routerrpc.SendPaymentV2. SendPayment dispatches a
+    bi-directional streaming RPC for sending payments through the Lightning
+    Network. A single RPC invocation creates a persistent bi-directional
+    stream allowing clients to rapidly send payments through the Lightning
+    Network with a single persistent connection.
+    */
+    rpc SendPayment (stream SendRequest) returns (stream SendResponse) {
+        option deprecated = true;
+    }
+
+    /*
+    Deprecated, use routerrpc.SendPaymentV2. SendPaymentSync is the synchronous
+    non-streaming version of SendPayment. This RPC is intended to be consumed by
+    clients of the REST proxy. Additionally, this RPC expects the destination's
+    public key and the payment hash (if any) to be encoded as hex strings.
+    */
+    rpc SendPaymentSync (SendRequest) returns (SendResponse) {
+        option deprecated = true;
+    }
+
+    /* lncli: `sendtoroute`
+    Deprecated, use routerrpc.SendToRouteV2. SendToRoute is a bi-directional
+    streaming RPC for sending payment through the Lightning Network. This
+    method differs from SendPayment in that it allows users to specify a full
+    route manually. This can be used for things like rebalancing, and atomic
+    swaps.
+    */
+    rpc SendToRoute (stream SendToRouteRequest) returns (stream SendResponse) {
+        option deprecated = true;
+    }
+
+    /*
+    Deprecated, use routerrpc.SendToRouteV2. SendToRouteSync is a synchronous
+    version of SendToRoute. It Will block until the payment either fails or
+    succeeds.
+    */
+    rpc SendToRouteSync (SendToRouteRequest) returns (SendResponse) {
+        option deprecated = true;
+    }
+
+    /* lncli: `addinvoice`
+    AddInvoice attempts to add a new invoice to the invoice database. Any
+    duplicated invoices are rejected, therefore all invoices *must* have a
+    unique payment preimage.
+    */
+    rpc AddInvoice (Invoice) returns (AddInvoiceResponse);
+
+    /* lncli: `listinvoices`
+    ListInvoices returns a list of all the invoices currently stored within the
+    database. Any active debug invoices are ignored. It has full support for
+    paginated responses, allowing users to query for specific invoices through
+    their add_index. This can be done by using either the first_index_offset or
+    last_index_offset fields included in the response as the index_offset of the
+    next request. By default, the first 100 invoices created will be returned.
+    Backwards pagination is also supported through the Reversed flag.
+    */
+    rpc ListInvoices (ListInvoiceRequest) returns (ListInvoiceResponse);
+
+    /* lncli: `lookupinvoice`
+    LookupInvoice attempts to look up an invoice according to its payment hash.
+    The passed payment hash *must* be exactly 32 bytes, if not, an error is
+    returned.
+    */
+    rpc LookupInvoice (PaymentHash) returns (Invoice);
+
+    /*
+    SubscribeInvoices returns a uni-directional stream (server -> client) for
+    notifying the client of newly added/settled invoices. The caller can
+    optionally specify the add_index and/or the settle_index. If the add_index
+    is specified, then we'll first start by sending add invoice events for all
+    invoices with an add_index greater than the specified value. If the
+    settle_index is specified, then next, we'll send out all settle events for
+    invoices with a settle_index greater than the specified value. One or both
+    of these fields can be set. If no fields are set, then we'll only send out
+    the latest add/settle events.
+    */
+    rpc SubscribeInvoices (InvoiceSubscription) returns (stream Invoice);
+
+    /* lncli: `deletecanceledinvoice`
+    DeleteCanceledInvoice removes a canceled invoice from the database. If the
+    invoice is not in the canceled state, an error will be returned.
+    */
+    rpc DeleteCanceledInvoice (DelCanceledInvoiceReq)
+        returns (DelCanceledInvoiceResp);
+
+    /* lncli: `decodepayreq`
+    DecodePayReq takes an encoded payment request string and attempts to decode
+    it, returning a full description of the conditions encoded within the
+    payment request.
+    */
+    rpc DecodePayReq (PayReqString) returns (PayReq);
+
+    /* lncli: `listpayments`
+    ListPayments returns a list of all outgoing payments.
+    */
+    rpc ListPayments (ListPaymentsRequest) returns (ListPaymentsResponse);
+
+    /* lncli: `deletepayments`
+    DeletePayment deletes an outgoing payment from DB. Note that it will not
+    attempt to delete an In-Flight payment, since that would be unsafe.
+    */
+    rpc DeletePayment (DeletePaymentRequest) returns (DeletePaymentResponse);
+
+    /* lncli: `deletepayments --all`
+    DeleteAllPayments deletes all outgoing payments from DB. Note that it will
+    not attempt to delete In-Flight payments, since that would be unsafe.
+    */
+    rpc DeleteAllPayments (DeleteAllPaymentsRequest)
+        returns (DeleteAllPaymentsResponse);
+
+    /* lncli: `describegraph`
+    DescribeGraph returns a description of the latest graph state from the
+    point of view of the node. The graph information is partitioned into two
+    components: all the nodes/vertexes, and all the edges that connect the
+    vertexes themselves. As this is a directed graph, the edges also contain
+    the node directional specific routing policy which includes: the time lock
+    delta, fee information, etc.
+    */
+    rpc DescribeGraph (ChannelGraphRequest) returns (ChannelGraph);
+
+    /* lncli: `getnodemetrics`
+    GetNodeMetrics returns node metrics calculated from the graph. Currently
+    the only supported metric is betweenness centrality of individual nodes.
+    */
+    rpc GetNodeMetrics (NodeMetricsRequest) returns (NodeMetricsResponse);
+
+    /* lncli: `getchaninfo`
+    GetChanInfo returns the latest authenticated network announcement for the
+    given channel identified by its channel ID: an 8-byte integer which
+    uniquely identifies the location of transaction's funding output within the
+    blockchain.
+    */
+    rpc GetChanInfo (ChanInfoRequest) returns (ChannelEdge);
+
+    /* lncli: `getnodeinfo`
+    GetNodeInfo returns the latest advertised, aggregated, and authenticated
+    channel information for the specified node identified by its public key.
+    */
+    rpc GetNodeInfo (NodeInfoRequest) returns (NodeInfo);
+
+    /* lncli: `queryroutes`
+    QueryRoutes attempts to query the daemon's Channel Router for a possible
+    route to a target destination capable of carrying a specific amount of
+    satoshis. The returned route contains the full details required to craft and
+    send an HTLC, also including the necessary information that should be
+    present within the Sphinx packet encapsulated within the HTLC.
+
+    When using REST, the `dest_custom_records` map type can be set by appending
+    `&dest_custom_records[<record_number>]=<record_data_base64_url_encoded>`
+    to the URL. Unfortunately this map type doesn't appear in the REST API
+    documentation because of a bug in the grpc-gateway library.
+    */
+    rpc QueryRoutes (QueryRoutesRequest) returns (QueryRoutesResponse);
+
+    /* lncli: `getnetworkinfo`
+    GetNetworkInfo returns some basic stats about the known channel graph from
+    the point of view of the node.
+    */
+    rpc GetNetworkInfo (NetworkInfoRequest) returns (NetworkInfo);
+
+    /* lncli: `stop`
+    StopDaemon will send a shutdown request to the interrupt handler, triggering
+    a graceful shutdown of the daemon.
+    */
+    rpc StopDaemon (StopRequest) returns (StopResponse);
+
+    /*
+    SubscribeChannelGraph launches a streaming RPC that allows the caller to
+    receive notifications upon any changes to the channel graph topology from
+    the point of view of the responding node. Events notified include: new
+    nodes coming online, nodes updating their authenticated attributes, new
+    channels being advertised, updates in the routing policy for a directional
+    channel edge, and when channels are closed on-chain.
+    */
+    rpc SubscribeChannelGraph (GraphTopologySubscription)
+        returns (stream GraphTopologyUpdate);
+
+    /* lncli: `debuglevel`
+    DebugLevel allows a caller to programmatically set the logging verbosity of
+    lnd. The logging can be targeted according to a coarse daemon-wide logging
+    level, or in a granular fashion to specify the logging for a target
+    sub-system.
+    */
+    rpc DebugLevel (DebugLevelRequest) returns (DebugLevelResponse);
+
+    /* lncli: `feereport`
+    FeeReport allows the caller to obtain a report detailing the current fee
+    schedule enforced by the node globally for each channel.
+    */
+    rpc FeeReport (FeeReportRequest) returns (FeeReportResponse);
+
+    /* lncli: `updatechanpolicy`
+    UpdateChannelPolicy allows the caller to update the fee schedule and
+    channel policies for all channels globally, or a particular channel.
+    */
+    rpc UpdateChannelPolicy (PolicyUpdateRequest)
+        returns (PolicyUpdateResponse);
+
+    /* lncli: `fwdinghistory`
+    ForwardingHistory allows the caller to query the htlcswitch for a record of
+    all HTLCs forwarded within the target time range, and integer offset
+    within that time range, for a maximum number of events. If no maximum number
+    of events is specified, up to 100 events will be returned. If no time-range
+    is specified, then events will be returned in the order that they occured.
+
+    A list of forwarding events are returned. The size of each forwarding event
+    is 40 bytes, and the max message size able to be returned in gRPC is 4 MiB.
+    As a result each message can only contain 50k entries. Each response has
+    the index offset of the last entry. The index offset can be provided to the
+    request to allow the caller to skip a series of records.
+    */
+    rpc ForwardingHistory (ForwardingHistoryRequest)
+        returns (ForwardingHistoryResponse);
+
+    /* lncli: `exportchanbackup`
+    ExportChannelBackup attempts to return an encrypted static channel backup
+    for the target channel identified by it channel point. The backup is
+    encrypted with a key generated from the aezeed seed of the user. The
+    returned backup can either be restored using the RestoreChannelBackup
+    method once lnd is running, or via the InitWallet and UnlockWallet methods
+    from the WalletUnlocker service.
+    */
+    rpc ExportChannelBackup (ExportChannelBackupRequest)
+        returns (ChannelBackup);
+
+    /*
+    ExportAllChannelBackups returns static channel backups for all existing
+    channels known to lnd. A set of regular singular static channel backups for
+    each channel are returned. Additionally, a multi-channel backup is returned
+    as well, which contains a single encrypted blob containing the backups of
+    each channel.
+    */
+    rpc ExportAllChannelBackups (ChanBackupExportRequest)
+        returns (ChanBackupSnapshot);
+
+    /* lncli: `verifychanbackup`
+    VerifyChanBackup allows a caller to verify the integrity of a channel backup
+    snapshot. This method will accept either a packed Single or a packed Multi.
+    Specifying both will result in an error.
+    */
+    rpc VerifyChanBackup (ChanBackupSnapshot)
+        returns (VerifyChanBackupResponse);
+
+    /* lncli: `restorechanbackup`
+    RestoreChannelBackups accepts a set of singular channel backups, or a
+    single encrypted multi-chan backup and attempts to recover any funds
+    remaining within the channel. If we are able to unpack the backup, then the
+    new channel will be shown under listchannels, as well as pending channels.
+    */
+    rpc RestoreChannelBackups (RestoreChanBackupRequest)
+        returns (RestoreBackupResponse);
+
+    /*
+    SubscribeChannelBackups allows a client to sub-subscribe to the most up to
+    date information concerning the state of all channel backups. Each time a
+    new channel is added, we return the new set of channels, along with a
+    multi-chan backup containing the backup info for all channels. Each time a
+    channel is closed, we send a new update, which contains new new chan back
+    ups, but the updated set of encrypted multi-chan backups with the closed
+    channel(s) removed.
+    */
+    rpc SubscribeChannelBackups (ChannelBackupSubscription)
+        returns (stream ChanBackupSnapshot);
+
+    /* lncli: `bakemacaroon`
+    BakeMacaroon allows the creation of a new macaroon with custom read and
+    write permissions. No first-party caveats are added since this can be done
+    offline.
+    */
+    rpc BakeMacaroon (BakeMacaroonRequest) returns (BakeMacaroonResponse);
+
+    /* lncli: `listmacaroonids`
+    ListMacaroonIDs returns all root key IDs that are in use.
+    */
+    rpc ListMacaroonIDs (ListMacaroonIDsRequest)
+        returns (ListMacaroonIDsResponse);
+
+    /* lncli: `deletemacaroonid`
+    DeleteMacaroonID deletes the specified macaroon ID and invalidates all
+    macaroons derived from that ID.
+    */
+    rpc DeleteMacaroonID (DeleteMacaroonIDRequest)
+        returns (DeleteMacaroonIDResponse);
+
+    /* lncli: `listpermissions`
+    ListPermissions lists all RPC method URIs and their required macaroon
+    permissions to access them.
+    */
+    rpc ListPermissions (ListPermissionsRequest)
+        returns (ListPermissionsResponse);
+
+    /*
+    CheckMacaroonPermissions checks whether the provided macaroon contains all
+    the provided permissions. If the macaroon is valid (e.g. all caveats are
+    satisfied), and all permissions provided in the request are met, then
+    this RPC returns true.
+    */
+    rpc CheckMacaroonPermissions (CheckMacPermRequest)
+        returns (CheckMacPermResponse);
+
+    /*
+    RegisterRPCMiddleware adds a new gRPC middleware to the interceptor chain. A
+    gRPC middleware is software component external to lnd that aims to add
+    additional business logic to lnd by observing/intercepting/validating
+    incoming gRPC client requests and (if needed) replacing/overwriting outgoing
+    messages before they're sent to the client. When registering the middleware
+    must identify itself and indicate what custom macaroon caveats it wants to
+    be responsible for. Only requests that contain a macaroon with that specific
+    custom caveat are then sent to the middleware for inspection. The other
+    option is to register for the read-only mode in which all requests/responses
+    are forwarded for interception to the middleware but the middleware is not
+    allowed to modify any responses. As a security measure, _no_ middleware can
+    modify responses for requests made with _unencumbered_ macaroons!
+    */
+    rpc RegisterRPCMiddleware (stream RPCMiddlewareResponse)
+        returns (stream RPCMiddlewareRequest);
+
+    /* lncli: `sendcustom`
+    SendCustomMessage sends a custom peer message.
+    */
+    rpc SendCustomMessage (SendCustomMessageRequest)
+        returns (SendCustomMessageResponse);
+
+    /* lncli: `subscribecustom`
+    SubscribeCustomMessages subscribes to a stream of incoming custom peer
+    messages.
+
+    To include messages with type outside of the custom range (>= 32768) lnd
+    needs to be compiled with  the `dev` build tag, and the message type to
+    override should be specified in lnd's experimental protocol configuration.
+    */
+    rpc SubscribeCustomMessages (SubscribeCustomMessagesRequest)
+        returns (stream CustomMessage);
+
+    /* lncli: `listaliases`
+    ListAliases returns the set of all aliases that have ever existed with
+    their confirmed SCID (if it exists) and/or the base SCID (in the case of
+    zero conf).
+    */
+    rpc ListAliases (ListAliasesRequest) returns (ListAliasesResponse);
+
+    /*
+    LookupHtlcResolution retrieves a final htlc resolution from the database.
+    If the htlc has no final resolution yet, a NotFound grpc status code is
+    returned.
+    */
+    rpc LookupHtlcResolution (LookupHtlcResolutionRequest)
+        returns (LookupHtlcResolutionResponse);
+}
+
+message LookupHtlcResolutionRequest {
+    uint64 chan_id = 1;
+
+    uint64 htlc_index = 2;
+}
+
+message LookupHtlcResolutionResponse {
+    // Settled is true is the htlc was settled. If false, the htlc was failed.
+    bool settled = 1;
+
+    // Offchain indicates whether the htlc was resolved off-chain or on-chain.
+    bool offchain = 2;
+}
+
+message SubscribeCustomMessagesRequest {
+}
+
+message CustomMessage {
+    // Peer from which the message originates
+    bytes peer = 1;
+
+    // Message type. This value will be in the custom range (>= 32768).
+    uint32 type = 2;
+
+    // Raw message data
+    bytes data = 3;
+}
+
+message SendCustomMessageRequest {
+    // Peer to send the message to
+    bytes peer = 1;
+
+    // Message type. This value needs to be in the custom range (>= 32768).
+    // To send a type < custom range, lnd needs to be compiled with the `dev`
+    // build tag, and the message type to override should be specified in lnd's
+    // experimental protocol configuration.
+    uint32 type = 2;
+
+    // Raw message data.
+    bytes data = 3;
+}
+
+message SendCustomMessageResponse {
+    // The status of the send operation.
+    string status = 1;
+}
+
+message Utxo {
+    // The type of address
+    AddressType address_type = 1;
+
+    // The address
+    string address = 2;
+
+    // The value of the unspent coin in satoshis
+    int64 amount_sat = 3;
+
+    // The pkscript in hex
+    string pk_script = 4;
+
+    // The outpoint in format txid:n
+    OutPoint outpoint = 5;
+
+    // The number of confirmations for the Utxo
+    int64 confirmations = 6;
+}
+
+enum OutputScriptType {
+    SCRIPT_TYPE_PUBKEY_HASH = 0;
+    SCRIPT_TYPE_SCRIPT_HASH = 1;
+    SCRIPT_TYPE_WITNESS_V0_PUBKEY_HASH = 2;
+    SCRIPT_TYPE_WITNESS_V0_SCRIPT_HASH = 3;
+    SCRIPT_TYPE_PUBKEY = 4;
+    SCRIPT_TYPE_MULTISIG = 5;
+    SCRIPT_TYPE_NULLDATA = 6;
+    SCRIPT_TYPE_NON_STANDARD = 7;
+    SCRIPT_TYPE_WITNESS_UNKNOWN = 8;
+    SCRIPT_TYPE_WITNESS_V1_TAPROOT = 9;
+}
+
+message OutputDetail {
+    // The type of the output
+    OutputScriptType output_type = 1;
+
+    // The address
+    string address = 2;
+
+    // The pkscript in hex
+    string pk_script = 3;
+
+    // The output index used in the raw transaction
+    int64 output_index = 4;
+
+    // The value of the output coin in satoshis
+    int64 amount = 5;
+
+    // Denotes if the output is controlled by the internal wallet
+    bool is_our_address = 6;
+}
+
+message Transaction {
+    // The transaction hash
+    string tx_hash = 1;
+
+    // The transaction amount, denominated in satoshis
+    int64 amount = 2;
+
+    // The number of confirmations
+    int32 num_confirmations = 3;
+
+    // The hash of the block this transaction was included in
+    string block_hash = 4;
+
+    // The height of the block this transaction was included in
+    int32 block_height = 5;
+
+    // Timestamp of this transaction
+    int64 time_stamp = 6;
+
+    // Fees paid for this transaction
+    int64 total_fees = 7;
+
+    // Addresses that received funds for this transaction. Deprecated as it is
+    // now incorporated in the output_details field.
+    repeated string dest_addresses = 8 [deprecated = true];
+
+    // Outputs that received funds for this transaction
+    repeated OutputDetail output_details = 11;
+
+    // The raw transaction hex.
+    string raw_tx_hex = 9;
+
+    // A label that was optionally set on transaction broadcast.
+    string label = 10;
+
+    // PreviousOutpoints/Inputs of this transaction.
+    repeated PreviousOutPoint previous_outpoints = 12;
+}
+
+message GetTransactionsRequest {
+    /*
+    The height from which to list transactions, inclusive. If this value is
+    greater than end_height, transactions will be read in reverse.
+    */
+    int32 start_height = 1;
+
+    /*
+    The height until which to list transactions, inclusive. To include
+    unconfirmed transactions, this value should be set to -1, which will
+    return transactions from start_height until the current chain tip and
+    unconfirmed transactions. If no end_height is provided, the call will
+    default to this option.
+    */
+    int32 end_height = 2;
+
+    // An optional filter to only include transactions relevant to an account.
+    string account = 3;
+
+    /*
+    The index of a transaction that will be used in a query to determine which
+    transaction should be returned in the response.
+    */
+    uint32 index_offset = 4;
+
+    /*
+    The maximal number of transactions returned in the response to this query.
+    This value should be set to 0 to return all transactions.
+    */
+    uint32 max_transactions = 5;
+}
+
+message TransactionDetails {
+    // The list of transactions relevant to the wallet.
+    repeated Transaction transactions = 1;
+
+    /*
+    The index of the last item in the set of returned transactions. This can be
+    used to seek further, pagination style.
+    */
+    uint64 last_index = 2;
+
+    /*
+    The index of the last item in the set of returned transactions. This can be
+    used to seek backwards, pagination style.
+    */
+    uint64 first_index = 3;
+}
+
+message FeeLimit {
+    oneof limit {
+        /*
+        The fee limit expressed as a fixed amount of satoshis.
+
+        The fields fixed and fixed_msat are mutually exclusive.
+        */
+        int64 fixed = 1;
+
+        /*
+        The fee limit expressed as a fixed amount of millisatoshis.
+
+        The fields fixed and fixed_msat are mutually exclusive.
+        */
+        int64 fixed_msat = 3;
+
+        // The fee limit expressed as a percentage of the payment amount.
+        int64 percent = 2;
+    }
+}
+
+message SendRequest {
+    /*
+    The identity pubkey of the payment recipient. When using REST, this field
+    must be encoded as base64.
+    */
+    bytes dest = 1;
+
+    /*
+    The hex-encoded identity pubkey of the payment recipient. Deprecated now
+    that the REST gateway supports base64 encoding of bytes fields.
+    */
+    string dest_string = 2 [deprecated = true];
+
+    /*
+    The amount to send expressed in satoshis.
+
+    The fields amt and amt_msat are mutually exclusive.
+    */
+    int64 amt = 3;
+
+    /*
+    The amount to send expressed in millisatoshis.
+
+    The fields amt and amt_msat are mutually exclusive.
+    */
+    int64 amt_msat = 12;
+
+    /*
+    The hash to use within the payment's HTLC. When using REST, this field
+    must be encoded as base64.
+    */
+    bytes payment_hash = 4;
+
+    /*
+    The hex-encoded hash to use within the payment's HTLC. Deprecated now
+    that the REST gateway supports base64 encoding of bytes fields.
+    */
+    string payment_hash_string = 5 [deprecated = true];
+
+    /*
+    A bare-bones invoice for a payment within the Lightning Network. With the
+    details of the invoice, the sender has all the data necessary to send a
+    payment to the recipient.
+    */
+    string payment_request = 6;
+
+    /*
+    The CLTV delta from the current height that should be used to set the
+    timelock for the final hop.
+    */
+    int32 final_cltv_delta = 7;
+
+    /*
+    The maximum number of satoshis that will be paid as a fee of the payment.
+    This value can be represented either as a percentage of the amount being
+    sent, or as a fixed amount of the maximum fee the user is willing the pay to
+    send the payment. If not specified, lnd will use a default value of 100%
+    fees for small amounts (<=1k sat) or 5% fees for larger amounts.
+    */
+    FeeLimit fee_limit = 8;
+
+    /*
+    The channel id of the channel that must be taken to the first hop. If zero,
+    any channel may be used.
+    */
+    uint64 outgoing_chan_id = 9 [jstype = JS_STRING];
+
+    /*
+    The pubkey of the last hop of the route. If empty, any hop may be used.
+    */
+    bytes last_hop_pubkey = 13;
+
+    /*
+    An optional maximum total time lock for the route. This should not exceed
+    lnd's `--max-cltv-expiry` setting. If zero, then the value of
+    `--max-cltv-expiry` is enforced.
+    */
+    uint32 cltv_limit = 10;
+
+    /*
+    An optional field that can be used to pass an arbitrary set of TLV records
+    to a peer which understands the new records. This can be used to pass
+    application specific data during the payment attempt. Record types are
+    required to be in the custom range >= 65536. When using REST, the values
+    must be encoded as base64.
+    */
+    map<uint64, bytes> dest_custom_records = 11;
+
+    // If set, circular payments to self are permitted.
+    bool allow_self_payment = 14;
+
+    /*
+    Features assumed to be supported by the final node. All transitive feature
+    dependencies must also be set properly. For a given feature bit pair, either
+    optional or remote may be set, but not both. If this field is nil or empty,
+    the router will try to load destination features from the graph as a
+    fallback.
+    */
+    repeated FeatureBit dest_features = 15;
+
+    /*
+    The payment address of the generated invoice.  This is also called
+    payment secret in specifications (e.g. BOLT 11).
+    */
+    bytes payment_addr = 16;
+}
+
+message SendResponse {
+    string payment_error = 1;
+    bytes payment_preimage = 2;
+    Route payment_route = 3;
+    bytes payment_hash = 4;
+}
+
+message SendToRouteRequest {
+    /*
+    The payment hash to use for the HTLC. When using REST, this field must be
+    encoded as base64.
+    */
+    bytes payment_hash = 1;
+
+    /*
+    An optional hex-encoded payment hash to be used for the HTLC. Deprecated now
+    that the REST gateway supports base64 encoding of bytes fields.
+    */
+    string payment_hash_string = 2 [deprecated = true];
+
+    reserved 3;
+
+    // Route that should be used to attempt to complete the payment.
+    Route route = 4;
+}
+
+message ChannelAcceptRequest {
+    // The pubkey of the node that wishes to open an inbound channel.
+    bytes node_pubkey = 1;
+
+    // The hash of the genesis block that the proposed channel resides in.
+    bytes chain_hash = 2;
+
+    // The pending channel id.
+    bytes pending_chan_id = 3;
+
+    // The funding amount in satoshis that initiator wishes to use in the
+    // channel.
+    uint64 funding_amt = 4;
+
+    // The push amount of the proposed channel in millisatoshis.
+    uint64 push_amt = 5;
+
+    // The dust limit of the initiator's commitment tx.
+    uint64 dust_limit = 6;
+
+    // The maximum amount of coins in millisatoshis that can be pending in this
+    // channel.
+    uint64 max_value_in_flight = 7;
+
+    // The minimum amount of satoshis the initiator requires us to have at all
+    // times.
+    uint64 channel_reserve = 8;
+
+    // The smallest HTLC in millisatoshis that the initiator will accept.
+    uint64 min_htlc = 9;
+
+    // The initial fee rate that the initiator suggests for both commitment
+    // transactions.
+    uint64 fee_per_kw = 10;
+
+    /*
+    The number of blocks to use for the relative time lock in the pay-to-self
+    output of both commitment transactions.
+    */
+    uint32 csv_delay = 11;
+
+    // The total number of incoming HTLC's that the initiator will accept.
+    uint32 max_accepted_htlcs = 12;
+
+    // A bit-field which the initiator uses to specify proposed channel
+    // behavior.
+    uint32 channel_flags = 13;
+
+    // The commitment type the initiator wishes to use for the proposed channel.
+    CommitmentType commitment_type = 14;
+
+    // Whether the initiator wants to open a zero-conf channel via the channel
+    // type.
+    bool wants_zero_conf = 15;
+
+    // Whether the initiator wants to use the scid-alias channel type. This is
+    // separate from the feature bit.
+    bool wants_scid_alias = 16;
+}
+
+message ChannelAcceptResponse {
+    // Whether or not the client accepts the channel.
+    bool accept = 1;
+
+    // The pending channel id to which this response applies.
+    bytes pending_chan_id = 2;
+
+    /*
+    An optional error to send the initiating party to indicate why the channel
+    was rejected. This field *should not* contain sensitive information, it will
+    be sent to the initiating party. This field should only be set if accept is
+    false, the channel will be rejected if an error is set with accept=true
+    because the meaning of this response is ambiguous. Limited to 500
+    characters.
+    */
+    string error = 3;
+
+    /*
+    The upfront shutdown address to use if the initiating peer supports option
+    upfront shutdown script (see ListPeers for the features supported). Note
+    that the channel open will fail if this value is set for a peer that does
+    not support this feature bit.
+    */
+    string upfront_shutdown = 4;
+
+    /*
+    The csv delay (in blocks) that we require for the remote party.
+    */
+    uint32 csv_delay = 5;
+
+    /*
+    The reserve amount in satoshis that we require the remote peer to adhere to.
+    We require that the remote peer always have some reserve amount allocated to
+    them so that there is always a disincentive to broadcast old state (if they
+    hold 0 sats on their side of the channel, there is nothing to lose).
+    */
+    uint64 reserve_sat = 6;
+
+    /*
+    The maximum amount of funds in millisatoshis that we allow the remote peer
+    to have in outstanding htlcs.
+    */
+    uint64 in_flight_max_msat = 7;
+
+    /*
+    The maximum number of htlcs that the remote peer can offer us.
+    */
+    uint32 max_htlc_count = 8;
+
+    /*
+    The minimum value in millisatoshis for incoming htlcs on the channel.
+    */
+    uint64 min_htlc_in = 9;
+
+    /*
+    The number of confirmations we require before we consider the channel open.
+    */
+    uint32 min_accept_depth = 10;
+
+    /*
+    Whether the responder wants this to be a zero-conf channel. This will fail
+    if either side does not have the scid-alias feature bit set. The minimum
+    depth field must be zero if this is true.
+    */
+    bool zero_conf = 11;
+}
+
+message ChannelPoint {
+    oneof funding_txid {
+        /*
+        Txid of the funding transaction. When using REST, this field must be
+        encoded as base64.
+        */
+        bytes funding_txid_bytes = 1;
+
+        /*
+        Hex-encoded string representing the byte-reversed hash of the funding
+        transaction.
+        */
+        string funding_txid_str = 2;
+    }
+
+    // The index of the output of the funding transaction
+    uint32 output_index = 3;
+}
+
+message OutPoint {
+    // Raw bytes representing the transaction id.
+    bytes txid_bytes = 1;
+
+    // Reversed, hex-encoded string representing the transaction id.
+    string txid_str = 2;
+
+    // The index of the output on the transaction.
+    uint32 output_index = 3;
+}
+
+message PreviousOutPoint {
+    // The outpoint in format txid:n.
+    string outpoint = 1;
+
+    // Denotes if the outpoint is controlled by the internal wallet.
+    // The flag will only detect p2wkh, np2wkh and p2tr inputs as its own.
+    bool is_our_output = 2;
+}
+
+message LightningAddress {
+    // The identity pubkey of the Lightning node.
+    string pubkey = 1;
+
+    // The network location of the lightning node, e.g. `69.69.69.69:1337` or
+    // `localhost:10011`.
+    string host = 2;
+}
+
+enum CoinSelectionStrategy {
+    // Use the coin selection strategy defined in the global configuration
+    // (lnd.conf).
+    STRATEGY_USE_GLOBAL_CONFIG = 0;
+
+    // Select the largest available coins first during coin selection.
+    STRATEGY_LARGEST = 1;
+
+    // Randomly select the available coins during coin selection.
+    STRATEGY_RANDOM = 2;
+}
+
+message EstimateFeeRequest {
+    // The map from addresses to amounts for the transaction.
+    map<string, int64> AddrToAmount = 1;
+
+    // The target number of blocks that this transaction should be confirmed
+    // by.
+    int32 target_conf = 2;
+
+    // The minimum number of confirmations each one of your outputs used for
+    // the transaction must satisfy.
+    int32 min_confs = 3;
+
+    // Whether unconfirmed outputs should be used as inputs for the transaction.
+    bool spend_unconfirmed = 4;
+
+    // The strategy to use for selecting coins during fees estimation.
+    CoinSelectionStrategy coin_selection_strategy = 5;
+}
+
+message EstimateFeeResponse {
+    // The total fee in satoshis.
+    int64 fee_sat = 1;
+
+    // Deprecated, use sat_per_vbyte.
+    // The fee rate in satoshi/vbyte.
+    int64 feerate_sat_per_byte = 2 [deprecated = true];
+
+    // The fee rate in satoshi/vbyte.
+    uint64 sat_per_vbyte = 3;
+}
+
+message SendManyRequest {
+    // The map from addresses to amounts
+    map<string, int64> AddrToAmount = 1;
+
+    // The target number of blocks that this transaction should be confirmed
+    // by.
+    int32 target_conf = 3;
+
+    // A manual fee rate set in sat/vbyte that should be used when crafting the
+    // transaction.
+    uint64 sat_per_vbyte = 4;
+
+    // Deprecated, use sat_per_vbyte.
+    // A manual fee rate set in sat/vbyte that should be used when crafting the
+    // transaction.
+    int64 sat_per_byte = 5 [deprecated = true];
+
+    // An optional label for the transaction, limited to 500 characters.
+    string label = 6;
+
+    // The minimum number of confirmations each one of your outputs used for
+    // the transaction must satisfy.
+    int32 min_confs = 7;
+
+    // Whether unconfirmed outputs should be used as inputs for the transaction.
+    bool spend_unconfirmed = 8;
+
+    // The strategy to use for selecting coins during sending many requests.
+    CoinSelectionStrategy coin_selection_strategy = 9;
+}
+message SendManyResponse {
+    // The id of the transaction
+    string txid = 1;
+}
+
+message SendCoinsRequest {
+    // The address to send coins to
+    string addr = 1;
+
+    // The amount in satoshis to send
+    int64 amount = 2;
+
+    // The target number of blocks that this transaction should be confirmed
+    // by.
+    int32 target_conf = 3;
+
+    // A manual fee rate set in sat/vbyte that should be used when crafting the
+    // transaction.
+    uint64 sat_per_vbyte = 4;
+
+    // Deprecated, use sat_per_vbyte.
+    // A manual fee rate set in sat/vbyte that should be used when crafting the
+    // transaction.
+    int64 sat_per_byte = 5 [deprecated = true];
+
+    /*
+    If set, the amount field should be unset. It indicates lnd will send all
+    wallet coins or all selected coins to the specified address.
+    */
+    bool send_all = 6;
+
+    // An optional label for the transaction, limited to 500 characters.
+    string label = 7;
+
+    // The minimum number of confirmations each one of your outputs used for
+    // the transaction must satisfy.
+    int32 min_confs = 8;
+
+    // Whether unconfirmed outputs should be used as inputs for the transaction.
+    bool spend_unconfirmed = 9;
+
+    // The strategy to use for selecting coins.
+    CoinSelectionStrategy coin_selection_strategy = 10;
+
+    // A list of selected outpoints as inputs for the transaction.
+    repeated OutPoint outpoints = 11;
+}
+message SendCoinsResponse {
+    // The transaction ID of the transaction
+    string txid = 1;
+}
+
+message ListUnspentRequest {
+    // The minimum number of confirmations to be included.
+    int32 min_confs = 1;
+
+    // The maximum number of confirmations to be included.
+    int32 max_confs = 2;
+
+    // An optional filter to only include outputs belonging to an account.
+    string account = 3;
+}
+message ListUnspentResponse {
+    // A list of utxos
+    repeated Utxo utxos = 1;
+}
+
+/*
+`AddressType` has to be one of:
+
+- `p2wkh`: Pay to witness key hash (`WITNESS_PUBKEY_HASH` = 0)
+- `np2wkh`: Pay to nested witness key hash (`NESTED_PUBKEY_HASH` = 1)
+- `p2tr`: Pay to taproot pubkey (`TAPROOT_PUBKEY` = 4)
+*/
+enum AddressType {
+    WITNESS_PUBKEY_HASH = 0;
+    NESTED_PUBKEY_HASH = 1;
+    UNUSED_WITNESS_PUBKEY_HASH = 2;
+    UNUSED_NESTED_PUBKEY_HASH = 3;
+    TAPROOT_PUBKEY = 4;
+    UNUSED_TAPROOT_PUBKEY = 5;
+}
+
+message NewAddressRequest {
+    // The type of address to generate.
+    AddressType type = 1;
+
+    /*
+    The name of the account to generate a new address for. If empty, the
+    default wallet account is used.
+    */
+    string account = 2;
+}
+message NewAddressResponse {
+    // The newly generated wallet address
+    string address = 1;
+}
+
+message SignMessageRequest {
+    /*
+    The message to be signed. When using REST, this field must be encoded as
+    base64.
+    */
+    bytes msg = 1;
+
+    /*
+    Instead of the default double-SHA256 hashing of the message before signing,
+    only use one round of hashing instead.
+    */
+    bool single_hash = 2;
+}
+message SignMessageResponse {
+    // The signature for the given message
+    string signature = 1;
+}
+
+message VerifyMessageRequest {
+    /*
+    The message over which the signature is to be verified. When using REST,
+    this field must be encoded as base64.
+    */
+    bytes msg = 1;
+
+    // The signature to be verified over the given message
+    string signature = 2;
+}
+message VerifyMessageResponse {
+    // Whether the signature was valid over the given message
+    bool valid = 1;
+
+    // The pubkey recovered from the signature
+    string pubkey = 2;
+}
+
+message ConnectPeerRequest {
+    /*
+    Lightning address of the peer to connect to.
+    */
+    LightningAddress addr = 1;
+
+    /*
+    If set, the daemon will attempt to persistently connect to the target
+    peer. Otherwise, the call will be synchronous.
+    */
+    bool perm = 2;
+
+    /*
+    The connection timeout value (in seconds) for this request. It won't affect
+    other requests.
+    */
+    uint64 timeout = 3;
+}
+message ConnectPeerResponse {
+    // The status of the connect operation.
+    string status = 1;
+}
+
+message DisconnectPeerRequest {
+    // The pubkey of the node to disconnect from
+    string pub_key = 1;
+}
+message DisconnectPeerResponse {
+    // The status of the disconnect operation.
+    string status = 1;
+}
+
+message HTLC {
+    bool incoming = 1;
+    int64 amount = 2;
+    bytes hash_lock = 3;
+    uint32 expiration_height = 4;
+
+    // Index identifying the htlc on the channel.
+    uint64 htlc_index = 5;
+
+    // If this HTLC is involved in a forwarding operation, this field indicates
+    // the forwarding channel. For an outgoing htlc, it is the incoming channel.
+    // For an incoming htlc, it is the outgoing channel. When the htlc
+    // originates from this node or this node is the final destination,
+    // forwarding_channel will be zero. The forwarding channel will also be zero
+    // for htlcs that need to be forwarded but don't have a forwarding decision
+    // persisted yet.
+    uint64 forwarding_channel = 6;
+
+    // Index identifying the htlc on the forwarding channel.
+    uint64 forwarding_htlc_index = 7;
+
+    /*
+    Whether the HTLC is locked in. An HTLC is considered locked in when the
+    remote party has sent us the `revoke_and_ack` to irrevocably commit this
+    HTLC.
+    */
+    bool locked_in = 8;
+}
+
+enum CommitmentType {
+    /*
+    Returned when the commitment type isn't known or unavailable.
+    */
+    UNKNOWN_COMMITMENT_TYPE = 0;
+
+    /*
+    A channel using the legacy commitment format having tweaked to_remote
+    keys.
+    */
+    LEGACY = 1;
+
+    /*
+    A channel that uses the modern commitment format where the key in the
+    output of the remote party does not change each state. This makes back
+    up and recovery easier as when the channel is closed, the funds go
+    directly to that key.
+    */
+    STATIC_REMOTE_KEY = 2;
+
+    /*
+    A channel that uses a commitment format that has anchor outputs on the
+    commitments, allowing fee bumping after a force close transaction has
+    been broadcast.
+    */
+    ANCHORS = 3;
+
+    /*
+    A channel that uses a commitment type that builds upon the anchors
+    commitment format, but in addition requires a CLTV clause to spend outputs
+    paying to the channel initiator. This is intended for use on leased channels
+    to guarantee that the channel initiator has no incentives to close a leased
+    channel before its maturity date.
+    */
+    SCRIPT_ENFORCED_LEASE = 4;
+
+    /*
+    A channel that uses musig2 for the funding output, and the new tapscript
+    features where relevant.
+    */
+    SIMPLE_TAPROOT = 5;
+
+    /*
+    Identical to the SIMPLE_TAPROOT channel type, but with extra functionality.
+    This channel type also commits to additional meta data in the tapscript
+    leaves for the scripts in a channel.
+    */
+    SIMPLE_TAPROOT_OVERLAY = 6;
+}
+
+message ChannelConstraints {
+    /*
+    The CSV delay expressed in relative blocks. If the channel is force closed,
+    we will need to wait for this many blocks before we can regain our funds.
+    */
+    uint32 csv_delay = 1;
+
+    // The minimum satoshis this node is required to reserve in its balance.
+    uint64 chan_reserve_sat = 2;
+
+    // The dust limit (in satoshis) of the initiator's commitment tx.
+    uint64 dust_limit_sat = 3;
+
+    // The maximum amount of coins in millisatoshis that can be pending in this
+    // channel.
+    uint64 max_pending_amt_msat = 4;
+
+    // The smallest HTLC in millisatoshis that the initiator will accept.
+    uint64 min_htlc_msat = 5;
+
+    // The total number of incoming HTLC's that the initiator will accept.
+    uint32 max_accepted_htlcs = 6;
+}
+
+message Channel {
+    // Whether this channel is active or not
+    bool active = 1;
+
+    // The identity pubkey of the remote node
+    string remote_pubkey = 2;
+
+    /*
+    The outpoint (txid:index) of the funding transaction. With this value, Bob
+    will be able to generate a signature for Alice's version of the commitment
+    transaction.
+    */
+    string channel_point = 3;
+
+    /*
+    The unique channel ID for the channel. The first 3 bytes are the block
+    height, the next 3 the index within the block, and the last 2 bytes are the
+    output index for the channel.
+    */
+    uint64 chan_id = 4 [jstype = JS_STRING];
+
+    // The total amount of funds held in this channel
+    int64 capacity = 5;
+
+    // This node's current balance in this channel
+    int64 local_balance = 6;
+
+    // The counterparty's current balance in this channel
+    int64 remote_balance = 7;
+
+    /*
+    The amount calculated to be paid in fees for the current set of commitment
+    transactions. The fee amount is persisted with the channel in order to
+    allow the fee amount to be removed and recalculated with each channel state
+    update, including updates that happen after a system restart.
+    */
+    int64 commit_fee = 8;
+
+    // The weight of the commitment transaction
+    int64 commit_weight = 9;
+
+    /*
+    The required number of satoshis per kilo-weight that the requester will pay
+    at all times, for both the funding transaction and commitment transaction.
+    This value can later be updated once the channel is open.
+    */
+    int64 fee_per_kw = 10;
+
+    // The unsettled balance in this channel
+    int64 unsettled_balance = 11;
+
+    /*
+    The total number of satoshis we've sent within this channel.
+    */
+    int64 total_satoshis_sent = 12;
+
+    /*
+    The total number of satoshis we've received within this channel.
+    */
+    int64 total_satoshis_received = 13;
+
+    /*
+    The total number of updates conducted within this channel.
+    */
+    uint64 num_updates = 14;
+
+    /*
+    The list of active, uncleared HTLCs currently pending within the channel.
+    */
+    repeated HTLC pending_htlcs = 15;
+
+    /*
+    Deprecated. The CSV delay expressed in relative blocks. If the channel is
+    force closed, we will need to wait for this many blocks before we can regain
+    our funds.
+    */
+    uint32 csv_delay = 16 [deprecated = true];
+
+    // Whether this channel is advertised to the network or not.
+    bool private = 17;
+
+    // True if we were the ones that created the channel.
+    bool initiator = 18;
+
+    // A set of flags showing the current state of the channel.
+    string chan_status_flags = 19;
+
+    // Deprecated. The minimum satoshis this node is required to reserve in its
+    // balance.
+    int64 local_chan_reserve_sat = 20 [deprecated = true];
+
+    /*
+    Deprecated. The minimum satoshis the other node is required to reserve in
+    its balance.
+    */
+    int64 remote_chan_reserve_sat = 21 [deprecated = true];
+
+    // Deprecated. Use commitment_type.
+    bool static_remote_key = 22 [deprecated = true];
+
+    // The commitment type used by this channel.
+    CommitmentType commitment_type = 26;
+
+    /*
+    The number of seconds that the channel has been monitored by the channel
+    scoring system. Scores are currently not persisted, so this value may be
+    less than the lifetime of the channel [EXPERIMENTAL].
+    */
+    int64 lifetime = 23;
+
+    /*
+    The number of seconds that the remote peer has been observed as being online
+    by the channel scoring system over the lifetime of the channel
+    [EXPERIMENTAL].
+    */
+    int64 uptime = 24;
+
+    /*
+    Close address is the address that we will enforce payout to on cooperative
+    close if the channel was opened utilizing option upfront shutdown. This
+    value can be set on channel open by setting close_address in an open channel
+    request. If this value is not set, you can still choose a payout address by
+    cooperatively closing with the delivery_address field set.
+    */
+    string close_address = 25;
+
+    /*
+    The amount that the initiator of the channel optionally pushed to the remote
+    party on channel open. This amount will be zero if the channel initiator did
+    not push any funds to the remote peer. If the initiator field is true, we
+    pushed this amount to our peer, if it is false, the remote peer pushed this
+    amount to us.
+    */
+    uint64 push_amount_sat = 27;
+
+    /*
+    This uint32 indicates if this channel is to be considered 'frozen'. A
+    frozen channel doest not allow a cooperative channel close by the
+    initiator. The thaw_height is the height that this restriction stops
+    applying to the channel. This field is optional, not setting it or using a
+    value of zero will mean the channel has no additional restrictions. The
+    height can be interpreted in two ways: as a relative height if the value is
+    less than 500,000, or as an absolute height otherwise.
+    */
+    uint32 thaw_height = 28;
+
+    // List constraints for the local node.
+    ChannelConstraints local_constraints = 29;
+
+    // List constraints for the remote node.
+    ChannelConstraints remote_constraints = 30;
+
+    /*
+    This lists out the set of alias short channel ids that exist for a channel.
+    This may be empty.
+    */
+    repeated uint64 alias_scids = 31;
+
+    // Whether or not this is a zero-conf channel.
+    bool zero_conf = 32;
+
+    // This is the confirmed / on-chain zero-conf SCID.
+    uint64 zero_conf_confirmed_scid = 33;
+
+    // The configured alias name of our peer.
+    string peer_alias = 34;
+
+    // This is the peer SCID alias.
+    uint64 peer_scid_alias = 35 [jstype = JS_STRING];
+
+    /*
+    An optional note-to-self to go along with the channel containing some
+    useful information. This is only ever stored locally and in no way impacts
+    the channel's operation.
+    */
+    string memo = 36;
+
+    /*
+    Custom channel data that might be populated in custom channels.
+    */
+    bytes custom_channel_data = 37;
+}
+
+message ListChannelsRequest {
+    bool active_only = 1;
+    bool inactive_only = 2;
+    bool public_only = 3;
+    bool private_only = 4;
+
+    /*
+    Filters the response for channels with a target peer's pubkey. If peer is
+    empty, all channels will be returned.
+    */
+    bytes peer = 5;
+
+    // Informs the server if the peer alias lookup per channel should be
+    // enabled. It is turned off by default in order to avoid degradation of
+    // performance for existing clients.
+    bool peer_alias_lookup = 6;
+}
+message ListChannelsResponse {
+    // The list of active channels
+    repeated Channel channels = 11;
+}
+
+message AliasMap {
+    /*
+    For non-zero-conf channels, this is the confirmed SCID. Otherwise, this is
+    the first assigned "base" alias.
+    */
+    uint64 base_scid = 1;
+
+    // The set of all aliases stored for the base SCID.
+    repeated uint64 aliases = 2;
+}
+message ListAliasesRequest {
+}
+message ListAliasesResponse {
+    repeated AliasMap alias_maps = 1;
+}
+
+enum Initiator {
+    INITIATOR_UNKNOWN = 0;
+    INITIATOR_LOCAL = 1;
+    INITIATOR_REMOTE = 2;
+    INITIATOR_BOTH = 3;
+}
+
+message ChannelCloseSummary {
+    // The outpoint (txid:index) of the funding transaction.
+    string channel_point = 1;
+
+    //  The unique channel ID for the channel.
+    uint64 chan_id = 2 [jstype = JS_STRING];
+
+    // The hash of the genesis block that this channel resides within.
+    string chain_hash = 3;
+
+    // The txid of the transaction which ultimately closed this channel.
+    string closing_tx_hash = 4;
+
+    // Public key of the remote peer that we formerly had a channel with.
+    string remote_pubkey = 5;
+
+    // Total capacity of the channel.
+    int64 capacity = 6;
+
+    // Height at which the funding transaction was spent.
+    uint32 close_height = 7;
+
+    // Settled balance at the time of channel closure
+    int64 settled_balance = 8;
+
+    // The sum of all the time-locked outputs at the time of channel closure
+    int64 time_locked_balance = 9;
+
+    enum ClosureType {
+        COOPERATIVE_CLOSE = 0;
+        LOCAL_FORCE_CLOSE = 1;
+        REMOTE_FORCE_CLOSE = 2;
+        BREACH_CLOSE = 3;
+        FUNDING_CANCELED = 4;
+        ABANDONED = 5;
+    }
+
+    // Details on how the channel was closed.
+    ClosureType close_type = 10;
+
+    /*
+    Open initiator is the party that initiated opening the channel. Note that
+    this value may be unknown if the channel was closed before we migrated to
+    store open channel information after close.
+    */
+    Initiator open_initiator = 11;
+
+    /*
+    Close initiator indicates which party initiated the close. This value will
+    be unknown for channels that were cooperatively closed before we started
+    tracking cooperative close initiators. Note that this indicates which party
+    initiated a close, and it is possible for both to initiate cooperative or
+    force closes, although only one party's close will be confirmed on chain.
+    */
+    Initiator close_initiator = 12;
+
+    repeated Resolution resolutions = 13;
+
+    /*
+    This lists out the set of alias short channel ids that existed for the
+    closed channel. This may be empty.
+    */
+    repeated uint64 alias_scids = 14;
+
+    //  The confirmed SCID for a zero-conf channel.
+    uint64 zero_conf_confirmed_scid = 15 [jstype = JS_STRING];
+
+    // The TLV encoded custom channel data records for this output, which might
+    // be set for custom channels.
+    bytes custom_channel_data = 16;
+}
+
+enum ResolutionType {
+    TYPE_UNKNOWN = 0;
+
+    // We resolved an anchor output.
+    ANCHOR = 1;
+
+    /*
+    We are resolving an incoming htlc on chain. This if this htlc is
+    claimed, we swept the incoming htlc with the preimage. If it is timed
+    out, our peer swept the timeout path.
+    */
+    INCOMING_HTLC = 2;
+
+    /*
+    We are resolving an outgoing htlc on chain. If this htlc is claimed,
+    the remote party swept the htlc with the preimage. If it is timed out,
+    we swept it with the timeout path.
+    */
+    OUTGOING_HTLC = 3;
+
+    // We force closed and need to sweep our time locked commitment output.
+    COMMIT = 4;
+}
+
+enum ResolutionOutcome {
+    // Outcome unknown.
+    OUTCOME_UNKNOWN = 0;
+
+    // An output was claimed on chain.
+    CLAIMED = 1;
+
+    // An output was left unclaimed on chain.
+    UNCLAIMED = 2;
+
+    /*
+    ResolverOutcomeAbandoned indicates that an output that we did not
+    claim on chain, for example an anchor that we did not sweep and a
+    third party claimed on chain, or a htlc that we could not decode
+    so left unclaimed.
+    */
+    ABANDONED = 3;
+
+    /*
+    If we force closed our channel, our htlcs need to be claimed in two
+    stages. This outcome represents the broadcast of a timeout or success
+    transaction for this two stage htlc claim.
+    */
+    FIRST_STAGE = 4;
+
+    // A htlc was timed out on chain.
+    TIMEOUT = 5;
+}
+
+message Resolution {
+    // The type of output we are resolving.
+    ResolutionType resolution_type = 1;
+
+    // The outcome of our on chain action that resolved the outpoint.
+    ResolutionOutcome outcome = 2;
+
+    // The outpoint that was spent by the resolution.
+    OutPoint outpoint = 3;
+
+    // The amount that was claimed by the resolution.
+    uint64 amount_sat = 4;
+
+    // The hex-encoded transaction ID of the sweep transaction that spent the
+    // output.
+    string sweep_txid = 5;
+}
+
+message ClosedChannelsRequest {
+    bool cooperative = 1;
+    bool local_force = 2;
+    bool remote_force = 3;
+    bool breach = 4;
+    bool funding_canceled = 5;
+    bool abandoned = 6;
+}
+
+message ClosedChannelsResponse {
+    repeated ChannelCloseSummary channels = 1;
+}
+
+message Peer {
+    // The identity pubkey of the peer
+    string pub_key = 1;
+
+    // Network address of the peer; eg `127.0.0.1:10011`
+    string address = 3;
+
+    // Bytes of data transmitted to this peer
+    uint64 bytes_sent = 4;
+
+    // Bytes of data transmitted from this peer
+    uint64 bytes_recv = 5;
+
+    // Satoshis sent to this peer
+    int64 sat_sent = 6;
+
+    // Satoshis received from this peer
+    int64 sat_recv = 7;
+
+    // A channel is inbound if the counterparty initiated the channel
+    bool inbound = 8;
+
+    // Ping time to this peer
+    int64 ping_time = 9;
+
+    enum SyncType {
+        /*
+        Denotes that we cannot determine the peer's current sync type.
+        */
+        UNKNOWN_SYNC = 0;
+
+        /*
+        Denotes that we are actively receiving new graph updates from the peer.
+        */
+        ACTIVE_SYNC = 1;
+
+        /*
+        Denotes that we are not receiving new graph updates from the peer.
+        */
+        PASSIVE_SYNC = 2;
+
+        /*
+        Denotes that this peer is pinned into an active sync.
+        */
+        PINNED_SYNC = 3;
+    }
+
+    // The type of sync we are currently performing with this peer.
+    SyncType sync_type = 10;
+
+    // Features advertised by the remote peer in their init message.
+    map<uint32, Feature> features = 11;
+
+    /*
+    The latest errors received from our peer with timestamps, limited to the 10
+    most recent errors. These errors are tracked across peer connections, but
+    are not persisted across lnd restarts. Note that these errors are only
+    stored for peers that we have channels open with, to prevent peers from
+    spamming us with errors at no cost.
+    */
+    repeated TimestampedError errors = 12;
+
+    /*
+    This field is populated when the peer has at least one channel with us.
+    The number of times we have recorded this peer going offline or coming
+    online, recorded across restarts. Note that this value is decreased over
+    time if the peer has not recently flapped, so that we can forgive peers
+    with historically high flap counts.
+    */
+    int32 flap_count = 13;
+
+    /*
+    This field is populated when the peer has at least one channel with us.
+    The timestamp of the last flap we observed for this peer. If this value is
+    zero, we have not observed any flaps for this peer.
+    */
+    int64 last_flap_ns = 14;
+
+    /*
+    The last ping payload the peer has sent to us.
+    */
+    bytes last_ping_payload = 15;
+}
+
+message TimestampedError {
+    // The unix timestamp in seconds when the error occurred.
+    uint64 timestamp = 1;
+
+    // The string representation of the error sent by our peer.
+    string error = 2;
+}
+
+message ListPeersRequest {
+    /*
+    If true, only the last error that our peer sent us will be returned with
+    the peer's information, rather than the full set of historic errors we have
+    stored.
+    */
+    bool latest_error = 1;
+}
+message ListPeersResponse {
+    // The list of currently connected peers
+    repeated Peer peers = 1;
+}
+
+message PeerEventSubscription {
+}
+
+message PeerEvent {
+    // The identity pubkey of the peer.
+    string pub_key = 1;
+
+    enum EventType {
+        PEER_ONLINE = 0;
+        PEER_OFFLINE = 1;
+    }
+
+    EventType type = 2;
+}
+
+message GetInfoRequest {
+}
+message GetInfoResponse {
+    // The version of the LND software that the node is running.
+    string version = 14;
+
+    // The SHA1 commit hash that the daemon is compiled with.
+    string commit_hash = 20;
+
+    // The identity pubkey of the current node.
+    string identity_pubkey = 1;
+
+    // If applicable, the alias of the current node, e.g. "bob"
+    string alias = 2;
+
+    // The color of the current node in hex code format
+    string color = 17;
+
+    // Number of pending channels
+    uint32 num_pending_channels = 3;
+
+    // Number of active channels
+    uint32 num_active_channels = 4;
+
+    // Number of inactive channels
+    uint32 num_inactive_channels = 15;
+
+    // Number of peers
+    uint32 num_peers = 5;
+
+    // The node's current view of the height of the best block
+    uint32 block_height = 6;
+
+    // The node's current view of the hash of the best block
+    string block_hash = 8;
+
+    // Timestamp of the block best known to the wallet
+    int64 best_header_timestamp = 13;
+
+    // Whether the wallet's view is synced to the main chain
+    bool synced_to_chain = 9;
+
+    // Whether we consider ourselves synced with the public channel graph.
+    bool synced_to_graph = 18;
+
+    /*
+    Whether the current node is connected to testnet or testnet4. This field is
+    deprecated and the network field should be used instead.
+    */
+    bool testnet = 10 [deprecated = true];
+
+    reserved 11;
+
+    /*
+    A list of active chains the node is connected to. This will only
+    ever contain a single entry since LND will only ever have a single
+    chain backend during its lifetime.
+    */
+    repeated Chain chains = 16;
+
+    // The URIs of the current node.
+    repeated string uris = 12;
+
+    /*
+    Features that our node has advertised in our init message, node
+    announcements and invoices.
+    */
+    map<uint32, Feature> features = 19;
+
+    /*
+    Indicates whether the HTLC interceptor API is in always-on mode.
+    */
+    bool require_htlc_interceptor = 21;
+
+    // Indicates whether final htlc resolutions are stored on disk.
+    bool store_final_htlc_resolutions = 22;
+}
+
+message GetDebugInfoRequest {
+}
+
+message GetDebugInfoResponse {
+    map<string, string> config = 1;
+    repeated string log = 2;
+}
+
+message GetRecoveryInfoRequest {
+}
+message GetRecoveryInfoResponse {
+    // Whether the wallet is in recovery mode
+    bool recovery_mode = 1;
+
+    // Whether the wallet recovery progress is finished
+    bool recovery_finished = 2;
+
+    // The recovery progress, ranging from 0 to 1.
+    double progress = 3;
+}
+
+message Chain {
+    // Deprecated. The chain is now always assumed to be bitcoin.
+    // The blockchain the node is on (must be bitcoin)
+    string chain = 1 [deprecated = true];
+
+    // The network the node is on (eg regtest, testnet, mainnet)
+    string network = 2;
+}
+
+message ChannelOpenUpdate {
+    ChannelPoint channel_point = 1;
+}
+
+message CloseOutput {
+    // The amount in satoshi of this close output. This amount is the final
+    // commitment balance of the channel and the actual amount paid out on chain
+    // might be smaller due to subtracted fees.
+    int64 amount_sat = 1;
+
+    // The pkScript of the close output.
+    bytes pk_script = 2;
+
+    // Whether this output is for the local or remote node.
+    bool is_local = 3;
+
+    // The TLV encoded custom channel data records for this output, which might
+    // be set for custom channels.
+    bytes custom_channel_data = 4;
+}
+
+message ChannelCloseUpdate {
+    bytes closing_txid = 1;
+
+    bool success = 2;
+
+    // The local channel close output. If the local channel balance was dust to
+    // begin with, this output will not be set.
+    CloseOutput local_close_output = 3;
+
+    // The remote channel close output. If the remote channel balance was dust
+    // to begin with, this output will not be set.
+    CloseOutput remote_close_output = 4;
+
+    // Any additional outputs that might be added for custom channel types.
+    repeated CloseOutput additional_outputs = 5;
+}
+
+message CloseChannelRequest {
+    /*
+    The outpoint (txid:index) of the funding transaction. With this value, Bob
+    will be able to generate a signature for Alice's version of the commitment
+    transaction.
+    */
+    ChannelPoint channel_point = 1;
+
+    // If true, then the channel will be closed forcibly. This means the
+    // current commitment transaction will be signed and broadcast.
+    bool force = 2;
+
+    // The target number of blocks that the closure transaction should be
+    // confirmed by.
+    int32 target_conf = 3;
+
+    // Deprecated, use sat_per_vbyte.
+    // A manual fee rate set in sat/vbyte that should be used when crafting the
+    // closure transaction.
+    int64 sat_per_byte = 4 [deprecated = true];
+
+    /*
+    An optional address to send funds to in the case of a cooperative close.
+    If the channel was opened with an upfront shutdown script and this field
+    is set, the request to close will fail because the channel must pay out
+    to the upfront shutdown addresss.
+    */
+    string delivery_address = 5;
+
+    // A manual fee rate set in sat/vbyte that should be used when crafting the
+    // closure transaction.
+    uint64 sat_per_vbyte = 6;
+
+    // The maximum fee rate the closer is willing to pay.
+    //
+    // NOTE: This field is only respected if we're the initiator of the channel.
+    uint64 max_fee_per_vbyte = 7;
+
+    // If true, then the rpc call will not block while it awaits a closing txid
+    // to be broadcasted to the mempool. To obtain the closing tx one has to
+    // listen to the stream for the particular updates. Moreover if a coop close
+    // is specified and this flag is set to true the coop closing flow will be
+    // initiated even if HTLCs are active on the channel. The channel will wait
+    // until all HTLCs are resolved and then start the coop closing process. The
+    // channel will be disabled in the meantime and will disallow any new HTLCs.
+    bool no_wait = 8;
+}
+
+message CloseStatusUpdate {
+    oneof update {
+        PendingUpdate close_pending = 1;
+        ChannelCloseUpdate chan_close = 3;
+        InstantUpdate close_instant = 4;
+    }
+}
+
+message PendingUpdate {
+    bytes txid = 1;
+    uint32 output_index = 2;
+    int64 fee_per_vbyte = 3;
+    bool local_close_tx = 4;
+}
+
+message InstantUpdate {
+    // The number of pending HTLCs that are currently active on the channel.
+    // These HTLCs need to be resolved before the channel can be closed
+    // cooperatively.
+    int32 num_pending_htlcs = 1;
+}
+
+message ReadyForPsbtFunding {
+    /*
+    The P2WSH address of the channel funding multisig address that the below
+    specified amount in satoshis needs to be sent to.
+    */
+    string funding_address = 1;
+
+    /*
+    The exact amount in satoshis that needs to be sent to the above address to
+    fund the pending channel.
+    */
+    int64 funding_amount = 2;
+
+    /*
+    A raw PSBT that contains the pending channel output. If a base PSBT was
+    provided in the PsbtShim, this is the base PSBT with one additional output.
+    If no base PSBT was specified, this is an otherwise empty PSBT with exactly
+    one output.
+    */
+    bytes psbt = 3;
+}
+
+message BatchOpenChannelRequest {
+    // The list of channels to open.
+    repeated BatchOpenChannel channels = 1;
+
+    // The target number of blocks that the funding transaction should be
+    // confirmed by.
+    int32 target_conf = 2;
+
+    // A manual fee rate set in sat/vByte that should be used when crafting the
+    // funding transaction.
+    int64 sat_per_vbyte = 3;
+
+    // The minimum number of confirmations each one of your outputs used for
+    // the funding transaction must satisfy.
+    int32 min_confs = 4;
+
+    // Whether unconfirmed outputs should be used as inputs for the funding
+    // transaction.
+    bool spend_unconfirmed = 5;
+
+    // An optional label for the batch transaction, limited to 500 characters.
+    string label = 6;
+
+    // The strategy to use for selecting coins during batch opening channels.
+    CoinSelectionStrategy coin_selection_strategy = 7;
+}
+
+message BatchOpenChannel {
+    // The pubkey of the node to open a channel with. When using REST, this
+    // field must be encoded as base64.
+    bytes node_pubkey = 1;
+
+    // The number of satoshis the wallet should commit to the channel.
+    int64 local_funding_amount = 2;
+
+    // The number of satoshis to push to the remote side as part of the initial
+    // commitment state.
+    int64 push_sat = 3;
+
+    // Whether this channel should be private, not announced to the greater
+    // network.
+    bool private = 4;
+
+    // The minimum value in millisatoshi we will require for incoming HTLCs on
+    // the channel.
+    int64 min_htlc_msat = 5;
+
+    // The delay we require on the remote's commitment transaction. If this is
+    // not set, it will be scaled automatically with the channel size.
+    uint32 remote_csv_delay = 6;
+
+    /*
+    Close address is an optional address which specifies the address to which
+    funds should be paid out to upon cooperative close. This field may only be
+    set if the peer supports the option upfront feature bit (call listpeers
+    to check). The remote peer will only accept cooperative closes to this
+    address if it is set.
+
+    Note: If this value is set on channel creation, you will *not* be able to
+    cooperatively close out to a different address.
+    */
+    string close_address = 7;
+
+    /*
+    An optional, unique identifier of 32 random bytes that will be used as the
+    pending channel ID to identify the channel while it is in the pre-pending
+    state.
+    */
+    bytes pending_chan_id = 8;
+
+    /*
+    The explicit commitment type to use. Note this field will only be used if
+    the remote peer supports explicit channel negotiation.
+    */
+    CommitmentType commitment_type = 9;
+
+    /*
+    The maximum amount of coins in millisatoshi that can be pending within
+    the channel. It only applies to the remote party.
+    */
+    uint64 remote_max_value_in_flight_msat = 10;
+
+    /*
+    The maximum number of concurrent HTLCs we will allow the remote party to add
+    to the commitment transaction.
+    */
+    uint32 remote_max_htlcs = 11;
+
+    /*
+    Max local csv is the maximum csv delay we will allow for our own commitment
+    transaction.
+    */
+    uint32 max_local_csv = 12;
+
+    /*
+    If this is true, then a zero-conf channel open will be attempted.
+    */
+    bool zero_conf = 13;
+
+    /*
+    If this is true, then an option-scid-alias channel-type open will be
+    attempted.
+    */
+    bool scid_alias = 14;
+
+    /*
+    The base fee charged regardless of the number of milli-satoshis sent.
+    */
+    uint64 base_fee = 15;
+
+    /*
+    The fee rate in ppm (parts per million) that will be charged in
+    proportion of the value of each forwarded HTLC.
+    */
+    uint64 fee_rate = 16;
+
+    /*
+    If use_base_fee is true the open channel announcement will update the
+    channel base fee with the value specified in base_fee. In the case of
+    a base_fee of 0 use_base_fee is needed downstream to distinguish whether
+    to use the default base fee value specified in the config or 0.
+    */
+    bool use_base_fee = 17;
+
+    /*
+    If use_fee_rate is true the open channel announcement will update the
+    channel fee rate with the value specified in fee_rate. In the case of
+    a fee_rate of 0 use_fee_rate is needed downstream to distinguish whether
+    to use the default fee rate value specified in the config or 0.
+    */
+    bool use_fee_rate = 18;
+
+    /*
+    The number of satoshis we require the remote peer to reserve. This value,
+    if specified, must be above the dust limit and below 20% of the channel
+    capacity.
+    */
+    uint64 remote_chan_reserve_sat = 19;
+
+    /*
+    An optional note-to-self to go along with the channel containing some
+    useful information. This is only ever stored locally and in no way impacts
+    the channel's operation.
+    */
+    string memo = 20;
+}
+
+message BatchOpenChannelResponse {
+    repeated PendingUpdate pending_channels = 1;
+}
+
+message OpenChannelRequest {
+    // A manual fee rate set in sat/vbyte that should be used when crafting the
+    // funding transaction.
+    uint64 sat_per_vbyte = 1;
+
+    /*
+    The pubkey of the node to open a channel with. When using REST, this field
+    must be encoded as base64.
+    */
+    bytes node_pubkey = 2;
+
+    /*
+    The hex encoded pubkey of the node to open a channel with. Deprecated now
+    that the REST gateway supports base64 encoding of bytes fields.
+    */
+    string node_pubkey_string = 3 [deprecated = true];
+
+    // The number of satoshis the wallet should commit to the channel
+    int64 local_funding_amount = 4;
+
+    // The number of satoshis to push to the remote side as part of the initial
+    // commitment state
+    int64 push_sat = 5;
+
+    // The target number of blocks that the funding transaction should be
+    // confirmed by.
+    int32 target_conf = 6;
+
+    // Deprecated, use sat_per_vbyte.
+    // A manual fee rate set in sat/vbyte that should be used when crafting the
+    // funding transaction.
+    int64 sat_per_byte = 7 [deprecated = true];
+
+    // Whether this channel should be private, not announced to the greater
+    // network.
+    bool private = 8;
+
+    // The minimum value in millisatoshi we will require for incoming HTLCs on
+    // the channel.
+    int64 min_htlc_msat = 9;
+
+    // The delay we require on the remote's commitment transaction. If this is
+    // not set, it will be scaled automatically with the channel size.
+    uint32 remote_csv_delay = 10;
+
+    // The minimum number of confirmations each one of your outputs used for
+    // the funding transaction must satisfy.
+    int32 min_confs = 11;
+
+    // Whether unconfirmed outputs should be used as inputs for the funding
+    // transaction.
+    bool spend_unconfirmed = 12;
+
+    /*
+    Close address is an optional address which specifies the address to which
+    funds should be paid out to upon cooperative close. This field may only be
+    set if the peer supports the option upfront feature bit (call listpeers
+    to check). The remote peer will only accept cooperative closes to this
+    address if it is set.
+
+    Note: If this value is set on channel creation, you will *not* be able to
+    cooperatively close out to a different address.
+    */
+    string close_address = 13;
+
+    /*
+    Funding shims are an optional argument that allow the caller to intercept
+    certain funding functionality. For example, a shim can be provided to use a
+    particular key for the commitment key (ideally cold) rather than use one
+    that is generated by the wallet as normal, or signal that signing will be
+    carried out in an interactive manner (PSBT based).
+    */
+    FundingShim funding_shim = 14;
+
+    /*
+    The maximum amount of coins in millisatoshi that can be pending within
+    the channel. It only applies to the remote party.
+    */
+    uint64 remote_max_value_in_flight_msat = 15;
+
+    /*
+    The maximum number of concurrent HTLCs we will allow the remote party to add
+    to the commitment transaction.
+    */
+    uint32 remote_max_htlcs = 16;
+
+    /*
+    Max local csv is the maximum csv delay we will allow for our own commitment
+    transaction.
+    */
+    uint32 max_local_csv = 17;
+
+    /*
+    The explicit commitment type to use. Note this field will only be used if
+    the remote peer supports explicit channel negotiation.
+    */
+    CommitmentType commitment_type = 18;
+
+    /*
+    If this is true, then a zero-conf channel open will be attempted.
+    */
+    bool zero_conf = 19;
+
+    /*
+    If this is true, then an option-scid-alias channel-type open will be
+    attempted.
+    */
+    bool scid_alias = 20;
+
+    /*
+    The base fee charged regardless of the number of milli-satoshis sent.
+    */
+    uint64 base_fee = 21;
+
+    /*
+    The fee rate in ppm (parts per million) that will be charged in
+    proportion of the value of each forwarded HTLC.
+    */
+    uint64 fee_rate = 22;
+
+    /*
+    If use_base_fee is true the open channel announcement will update the
+    channel base fee with the value specified in base_fee. In the case of
+    a base_fee of 0 use_base_fee is needed downstream to distinguish whether
+    to use the default base fee value specified in the config or 0.
+    */
+    bool use_base_fee = 23;
+
+    /*
+    If use_fee_rate is true the open channel announcement will update the
+    channel fee rate with the value specified in fee_rate. In the case of
+    a fee_rate of 0 use_fee_rate is needed downstream to distinguish whether
+    to use the default fee rate value specified in the config or 0.
+    */
+    bool use_fee_rate = 24;
+
+    /*
+    The number of satoshis we require the remote peer to reserve. This value,
+    if specified, must be above the dust limit and below 20% of the channel
+    capacity.
+    */
+    uint64 remote_chan_reserve_sat = 25;
+
+    /*
+    If set, then lnd will attempt to commit all the coins under control of the
+    internal wallet to open the channel, and the LocalFundingAmount field must
+    be zero and is ignored.
+    */
+    bool fund_max = 26;
+
+    /*
+    An optional note-to-self to go along with the channel containing some
+    useful information. This is only ever stored locally and in no way impacts
+    the channel's operation.
+    */
+    string memo = 27;
+
+    /*
+    A list of selected outpoints that are allocated for channel funding.
+    */
+    repeated OutPoint outpoints = 28;
+}
+message OpenStatusUpdate {
+    oneof update {
+        /*
+        Signals that the channel is now fully negotiated and the funding
+        transaction published.
+        */
+        PendingUpdate chan_pending = 1;
+
+        /*
+        Signals that the channel's funding transaction has now reached the
+        required number of confirmations on chain and can be used.
+        */
+        ChannelOpenUpdate chan_open = 3;
+
+        /*
+        Signals that the funding process has been suspended and the construction
+        of a PSBT that funds the channel PK script is now required.
+        */
+        ReadyForPsbtFunding psbt_fund = 5;
+    }
+
+    /*
+    The pending channel ID of the created channel. This value may be used to
+    further the funding flow manually via the FundingStateStep method.
+    */
+    bytes pending_chan_id = 4;
+}
+
+message KeyLocator {
+    // The family of key being identified.
+    int32 key_family = 1;
+
+    // The precise index of the key being identified.
+    int32 key_index = 2;
+}
+
+message KeyDescriptor {
+    /*
+    The raw bytes of the key being identified.
+    */
+    bytes raw_key_bytes = 1;
+
+    /*
+    The key locator that identifies which key to use for signing.
+    */
+    KeyLocator key_loc = 2;
+}
+
+message ChanPointShim {
+    /*
+    The size of the pre-crafted output to be used as the channel point for this
+    channel funding.
+    */
+    int64 amt = 1;
+
+    // The target channel point to refrence in created commitment transactions.
+    ChannelPoint chan_point = 2;
+
+    // Our local key to use when creating the multi-sig output.
+    KeyDescriptor local_key = 3;
+
+    // The key of the remote party to use when creating the multi-sig output.
+    bytes remote_key = 4;
+
+    /*
+    If non-zero, then this will be used as the pending channel ID on the wire
+    protocol to initate the funding request. This is an optional field, and
+    should only be set if the responder is already expecting a specific pending
+    channel ID.
+    */
+    bytes pending_chan_id = 5;
+
+    /*
+    This uint32 indicates if this channel is to be considered 'frozen'. A frozen
+    channel does not allow a cooperative channel close by the initiator. The
+    thaw_height is the height that this restriction stops applying to the
+    channel. The height can be interpreted in two ways: as a relative height if
+    the value is less than 500,000, or as an absolute height otherwise.
+    */
+    uint32 thaw_height = 6;
+
+    /*
+    Indicates that the funding output is using a MuSig2 multi-sig output.
+    */
+    bool musig2 = 7;
+}
+
+message PsbtShim {
+    /*
+    A unique identifier of 32 random bytes that will be used as the pending
+    channel ID to identify the PSBT state machine when interacting with it and
+    on the wire protocol to initiate the funding request.
+    */
+    bytes pending_chan_id = 1;
+
+    /*
+    An optional base PSBT the new channel output will be added to. If this is
+    non-empty, it must be a binary serialized PSBT.
+    */
+    bytes base_psbt = 2;
+
+    /*
+    If a channel should be part of a batch (multiple channel openings in one
+    transaction), it can be dangerous if the whole batch transaction is
+    published too early before all channel opening negotiations are completed.
+    This flag prevents this particular channel from broadcasting the transaction
+    after the negotiation with the remote peer. In a batch of channel openings
+    this flag should be set to true for every channel but the very last.
+    */
+    bool no_publish = 3;
+}
+
+message FundingShim {
+    oneof shim {
+        /*
+        A channel shim where the channel point was fully constructed outside
+        of lnd's wallet and the transaction might already be published.
+        */
+        ChanPointShim chan_point_shim = 1;
+
+        /*
+        A channel shim that uses a PSBT to fund and sign the channel funding
+        transaction.
+        */
+        PsbtShim psbt_shim = 2;
+    }
+}
+
+message FundingShimCancel {
+    // The pending channel ID of the channel to cancel the funding shim for.
+    bytes pending_chan_id = 1;
+}
+
+message FundingPsbtVerify {
+    /*
+    The funded but not yet signed PSBT that sends the exact channel capacity
+    amount to the PK script returned in the open channel message in a previous
+    step.
+    */
+    bytes funded_psbt = 1;
+
+    // The pending channel ID of the channel to get the PSBT for.
+    bytes pending_chan_id = 2;
+
+    /*
+    Can only be used if the no_publish flag was set to true in the OpenChannel
+    call meaning that the caller is solely responsible for publishing the final
+    funding transaction. If skip_finalize is set to true then lnd will not wait
+    for a FundingPsbtFinalize state step and instead assumes that a transaction
+    with the same TXID as the passed in PSBT will eventually confirm.
+    IT IS ABSOLUTELY IMPERATIVE that the TXID of the transaction that is
+    eventually published does have the _same TXID_ as the verified PSBT. That
+    means no inputs or outputs can change, only signatures can be added. If the
+    TXID changes between this call and the publish step then the channel will
+    never be created and the funds will be in limbo.
+    */
+    bool skip_finalize = 3;
+}
+
+message FundingPsbtFinalize {
+    /*
+    The funded PSBT that contains all witness data to send the exact channel
+    capacity amount to the PK script returned in the open channel message in a
+    previous step. Cannot be set at the same time as final_raw_tx.
+    */
+    bytes signed_psbt = 1;
+
+    // The pending channel ID of the channel to get the PSBT for.
+    bytes pending_chan_id = 2;
+
+    /*
+    As an alternative to the signed PSBT with all witness data, the final raw
+    wire format transaction can also be specified directly. Cannot be set at the
+    same time as signed_psbt.
+    */
+    bytes final_raw_tx = 3;
+}
+
+message FundingTransitionMsg {
+    oneof trigger {
+        /*
+        The funding shim to register. This should be used before any
+        channel funding has began by the remote party, as it is intended as a
+        preparatory step for the full channel funding.
+        */
+        FundingShim shim_register = 1;
+
+        // Used to cancel an existing registered funding shim.
+        FundingShimCancel shim_cancel = 2;
+
+        /*
+        Used to continue a funding flow that was initiated to be executed
+        through a PSBT. This step verifies that the PSBT contains the correct
+        outputs to fund the channel.
+        */
+        FundingPsbtVerify psbt_verify = 3;
+
+        /*
+        Used to continue a funding flow that was initiated to be executed
+        through a PSBT. This step finalizes the funded and signed PSBT, finishes
+        negotiation with the peer and finally publishes the resulting funding
+        transaction.
+        */
+        FundingPsbtFinalize psbt_finalize = 4;
+    }
+}
+
+message FundingStateStepResp {
+}
+
+message PendingHTLC {
+    // The direction within the channel that the htlc was sent
+    bool incoming = 1;
+
+    // The total value of the htlc
+    int64 amount = 2;
+
+    // The final output to be swept back to the user's wallet
+    string outpoint = 3;
+
+    // The next block height at which we can spend the current stage
+    uint32 maturity_height = 4;
+
+    /*
+       The number of blocks remaining until the current stage can be swept.
+       Negative values indicate how many blocks have passed since becoming
+       mature.
+    */
+    int32 blocks_til_maturity = 5;
+
+    // Indicates whether the htlc is in its first or second stage of recovery
+    uint32 stage = 6;
+}
+
+message PendingChannelsRequest {
+    // Indicates whether to include the raw transaction hex for
+    // waiting_close_channels.
+    bool include_raw_tx = 1;
+}
+message PendingChannelsResponse {
+    message PendingChannel {
+        string remote_node_pub = 1;
+        string channel_point = 2;
+
+        int64 capacity = 3;
+
+        int64 local_balance = 4;
+        int64 remote_balance = 5;
+
+        // The minimum satoshis this node is required to reserve in its
+        // balance.
+        int64 local_chan_reserve_sat = 6;
+
+        /*
+        The minimum satoshis the other node is required to reserve in its
+        balance.
+        */
+        int64 remote_chan_reserve_sat = 7;
+
+        // The party that initiated opening the channel.
+        Initiator initiator = 8;
+
+        // The commitment type used by this channel.
+        CommitmentType commitment_type = 9;
+
+        // Total number of forwarding packages created in this channel.
+        int64 num_forwarding_packages = 10;
+
+        // A set of flags showing the current state of the channel.
+        string chan_status_flags = 11;
+
+        // Whether this channel is advertised to the network or not.
+        bool private = 12;
+
+        /*
+        An optional note-to-self to go along with the channel containing some
+        useful information. This is only ever stored locally and in no way
+        impacts the channel's operation.
+        */
+        string memo = 13;
+
+        /*
+        Custom channel data that might be populated in custom channels.
+        */
+        bytes custom_channel_data = 34;
+    }
+
+    message PendingOpenChannel {
+        // The pending channel
+        PendingChannel channel = 1;
+
+        /*
+        The amount calculated to be paid in fees for the current set of
+        commitment transactions. The fee amount is persisted with the channel
+        in order to allow the fee amount to be removed and recalculated with
+        each channel state update, including updates that happen after a system
+        restart.
+        */
+        int64 commit_fee = 4;
+
+        // The weight of the commitment transaction
+        int64 commit_weight = 5;
+
+        /*
+        The required number of satoshis per kilo-weight that the requester will
+        pay at all times, for both the funding transaction and commitment
+        transaction. This value can later be updated once the channel is open.
+        */
+        int64 fee_per_kw = 6;
+
+        // Previously used for confirmation_height. Do not reuse.
+        reserved 2;
+
+        // The number of blocks until the funding transaction is considered
+        // expired. If this value gets close to zero, there is a risk that the
+        // channel funding will be canceled by the channel responder. The
+        // channel should be fee bumped using CPFP (see walletrpc.BumpFee) to
+        // ensure that the channel confirms in time. Otherwise a force-close
+        // will be necessary if the channel confirms after the funding
+        // transaction expires. A negative value means the channel responder has
+        // very likely canceled the funding and the channel will never become
+        // fully operational.
+        int32 funding_expiry_blocks = 3;
+
+        // The number of blocks remaining until the channel status changes from
+        // pending to active. A value of 0 indicates that the channel is now
+        // active.
+        //
+        // "Active" here means both channel peers have the channel marked OPEN
+        // and can immediately start using it. For public channels, this does
+        // not imply a channel_announcement has been gossiped. It only becomes
+        // public on the network after 6 on‐chain confirmations.
+        // See BOLT07 "Routing Gossip":
+        // https://github.com/lightning/bolts/blob/master/07-routing-gossip.md
+        //
+        // ZeroConf channels bypass the pending state entirely: they are marked
+        // active immediately upon creation, so they never show up as "pending".
+        uint32 confirmations_until_active = 7;
+
+        // The confirmation height records the block height at which the funding
+        // transaction was first confirmed.
+        uint32 confirmation_height = 8;
+    }
+
+    message WaitingCloseChannel {
+        // The pending channel waiting for closing tx to confirm
+        PendingChannel channel = 1;
+
+        // The balance in satoshis encumbered in this channel
+        int64 limbo_balance = 2;
+
+        /*
+        A list of valid commitment transactions. Any of these can confirm at
+        this point.
+        */
+        Commitments commitments = 3;
+
+        // The transaction id of the closing transaction
+        string closing_txid = 4;
+
+        // The raw hex encoded bytes of the closing transaction. Included if
+        // include_raw_tx in the request is true.
+        string closing_tx_hex = 5;
+    }
+
+    message Commitments {
+        // Hash of the local version of the commitment tx.
+        string local_txid = 1;
+
+        // Hash of the remote version of the commitment tx.
+        string remote_txid = 2;
+
+        // Hash of the remote pending version of the commitment tx.
+        string remote_pending_txid = 3;
+
+        /*
+        The amount in satoshis calculated to be paid in fees for the local
+        commitment.
+        */
+        uint64 local_commit_fee_sat = 4;
+
+        /*
+        The amount in satoshis calculated to be paid in fees for the remote
+        commitment.
+        */
+        uint64 remote_commit_fee_sat = 5;
+
+        /*
+        The amount in satoshis calculated to be paid in fees for the remote
+        pending commitment.
+        */
+        uint64 remote_pending_commit_fee_sat = 6;
+    }
+
+    message ClosedChannel {
+        // The pending channel to be closed
+        PendingChannel channel = 1;
+
+        // The transaction id of the closing transaction
+        string closing_txid = 2;
+    }
+
+    message ForceClosedChannel {
+        // The pending channel to be force closed
+        PendingChannel channel = 1;
+
+        // The transaction id of the closing transaction
+        string closing_txid = 2;
+
+        // The balance in satoshis encumbered in this pending channel
+        int64 limbo_balance = 3;
+
+        // The height at which funds can be swept into the wallet
+        uint32 maturity_height = 4;
+
+        /*
+          Remaining # of blocks until the commitment output can be swept.
+          Negative values indicate how many blocks have passed since becoming
+          mature.
+        */
+        int32 blocks_til_maturity = 5;
+
+        // The total value of funds successfully recovered from this channel
+        int64 recovered_balance = 6;
+
+        repeated PendingHTLC pending_htlcs = 8;
+
+        /*
+          There are three resolution states for the anchor:
+          limbo, lost and recovered. Derive the current state
+          from the limbo and recovered balances.
+        */
+        enum AnchorState {
+            // The recovered_balance is zero and limbo_balance is non-zero.
+            LIMBO = 0;
+            // The recovered_balance is non-zero.
+            RECOVERED = 1;
+            // A state that is neither LIMBO nor RECOVERED.
+            LOST = 2;
+        }
+
+        AnchorState anchor = 9;
+    }
+
+    // The balance in satoshis encumbered in pending channels
+    int64 total_limbo_balance = 1;
+
+    // Channels pending opening
+    repeated PendingOpenChannel pending_open_channels = 2;
+
+    /*
+    Deprecated: Channels pending closing previously contained cooperatively
+    closed channels with a single confirmation. These channels are now
+    considered closed from the time we see them on chain.
+    */
+    repeated ClosedChannel pending_closing_channels = 3 [deprecated = true];
+
+    // Channels pending force closing
+    repeated ForceClosedChannel pending_force_closing_channels = 4;
+
+    // Channels waiting for closing tx to confirm
+    repeated WaitingCloseChannel waiting_close_channels = 5;
+}
+
+message ChannelEventSubscription {
+}
+
+message ChannelEventUpdate {
+    oneof channel {
+        Channel open_channel = 1;
+        ChannelCloseSummary closed_channel = 2;
+        ChannelPoint active_channel = 3;
+        ChannelPoint inactive_channel = 4;
+        PendingUpdate pending_open_channel = 6;
+        ChannelPoint fully_resolved_channel = 7;
+        ChannelPoint channel_funding_timeout = 8;
+    }
+
+    enum UpdateType {
+        OPEN_CHANNEL = 0;
+        CLOSED_CHANNEL = 1;
+        ACTIVE_CHANNEL = 2;
+        INACTIVE_CHANNEL = 3;
+        PENDING_OPEN_CHANNEL = 4;
+        FULLY_RESOLVED_CHANNEL = 5;
+        CHANNEL_FUNDING_TIMEOUT = 6;
+    }
+
+    UpdateType type = 5;
+}
+
+message WalletAccountBalance {
+    // The confirmed balance of the account (with >= 1 confirmations).
+    int64 confirmed_balance = 1;
+
+    // The unconfirmed balance of the account (with 0 confirmations).
+    int64 unconfirmed_balance = 2;
+}
+
+message WalletBalanceRequest {
+    // The wallet account the balance is shown for.
+    // If this is not specified, the balance of the "default" account is shown.
+    string account = 1;
+
+    // The minimum number of confirmations each one of your outputs used for the
+    // funding transaction must satisfy. If this is not specified, the default
+    // value of 1 is used.
+    int32 min_confs = 2;
+}
+
+message WalletBalanceResponse {
+    // The balance of the wallet
+    int64 total_balance = 1;
+
+    // The confirmed balance of a wallet(with >= 1 confirmations)
+    int64 confirmed_balance = 2;
+
+    // The unconfirmed balance of a wallet(with 0 confirmations)
+    int64 unconfirmed_balance = 3;
+
+    // The total amount of wallet UTXOs held in outputs that are locked for
+    // other usage.
+    int64 locked_balance = 5;
+
+    // The amount of reserve required.
+    int64 reserved_balance_anchor_chan = 6;
+
+    // A mapping of each wallet account's name to its balance.
+    map<string, WalletAccountBalance> account_balance = 4;
+}
+
+message Amount {
+    // Value denominated in satoshis.
+    uint64 sat = 1;
+
+    // Value denominated in milli-satoshis.
+    uint64 msat = 2;
+}
+
+message ChannelBalanceRequest {
+}
+message ChannelBalanceResponse {
+    // Deprecated. Sum of channels balances denominated in satoshis
+    int64 balance = 1 [deprecated = true];
+
+    // Deprecated. Sum of channels pending balances denominated in satoshis
+    int64 pending_open_balance = 2 [deprecated = true];
+
+    // Sum of channels local balances.
+    Amount local_balance = 3;
+
+    // Sum of channels remote balances.
+    Amount remote_balance = 4;
+
+    // Sum of channels local unsettled balances.
+    Amount unsettled_local_balance = 5;
+
+    // Sum of channels remote unsettled balances.
+    Amount unsettled_remote_balance = 6;
+
+    // Sum of channels pending local balances.
+    Amount pending_open_local_balance = 7;
+
+    // Sum of channels pending remote balances.
+    Amount pending_open_remote_balance = 8;
+
+    /*
+    Custom channel data that might be populated if there are custom channels
+    present.
+    */
+    bytes custom_channel_data = 9;
+}
+
+message QueryRoutesRequest {
+    // The 33-byte hex-encoded public key for the payment destination
+    string pub_key = 1;
+
+    /*
+    The amount to send expressed in satoshis.
+
+    The fields amt and amt_msat are mutually exclusive.
+    */
+    int64 amt = 2;
+
+    /*
+    The amount to send expressed in millisatoshis.
+
+    The fields amt and amt_msat are mutually exclusive.
+    */
+    int64 amt_msat = 12;
+
+    reserved 3;
+
+    /*
+    An optional CLTV delta from the current height that should be used for the
+    timelock of the final hop. Note that unlike SendPayment, QueryRoutes does
+    not add any additional block padding on top of final_ctlv_delta. This
+    padding of a few blocks needs to be added manually or otherwise failures may
+    happen when a block comes in while the payment is in flight.
+
+    Note: must not be set if making a payment to a blinded path (delta is
+    set by the aggregate parameters provided by blinded_payment_paths)
+    */
+    int32 final_cltv_delta = 4;
+
+    /*
+    The maximum number of satoshis that will be paid as a fee of the payment.
+    This value can be represented either as a percentage of the amount being
+    sent, or as a fixed amount of the maximum fee the user is willing the pay to
+    send the payment. If not specified, lnd will use a default value of 100%
+    fees for small amounts (<=1k sat) or 5% fees for larger amounts.
+    */
+    FeeLimit fee_limit = 5;
+
+    /*
+    A list of nodes to ignore during path finding. When using REST, these fields
+    must be encoded as base64.
+    */
+    repeated bytes ignored_nodes = 6;
+
+    /*
+    Deprecated. A list of edges to ignore during path finding.
+    */
+    repeated EdgeLocator ignored_edges = 7 [deprecated = true];
+
+    /*
+    The source node where the request route should originated from. If empty,
+    self is assumed.
+    */
+    string source_pub_key = 8;
+
+    /*
+    If set to true, edge probabilities from mission control will be used to get
+    the optimal route.
+    */
+    bool use_mission_control = 9;
+
+    /*
+    A list of directed node pairs that will be ignored during path finding.
+    */
+    repeated NodePair ignored_pairs = 10;
+
+    /*
+    An optional maximum total time lock for the route. If the source is empty or
+    ourselves, this should not exceed lnd's `--max-cltv-expiry` setting. If
+    zero, then the value of `--max-cltv-expiry` is used as the limit.
+    */
+    uint32 cltv_limit = 11;
+
+    /*
+    An optional field that can be used to pass an arbitrary set of TLV records
+    to a peer which understands the new records. This can be used to pass
+    application specific data during the payment attempt. If the destination
+    does not support the specified records, an error will be returned.
+    Record types are required to be in the custom range >= 65536. When using
+    REST, the values must be encoded as base64.
+    */
+    map<uint64, bytes> dest_custom_records = 13;
+
+    /*
+    Deprecated, use outgoing_chan_ids. The channel id of the channel that must
+    be taken to the first hop. If zero, any channel may be used.
+    */
+    uint64 outgoing_chan_id = 14 [jstype = JS_STRING, deprecated = true];
+
+    /*
+    The pubkey of the last hop of the route. If empty, any hop may be used.
+    */
+    bytes last_hop_pubkey = 15;
+
+    /*
+    Optional route hints to reach the destination through private channels.
+    */
+    repeated lnrpc.RouteHint route_hints = 16;
+
+    /*
+    An optional blinded path(s) to reach the destination. Note that the
+    introduction node must be provided as the first hop in the route.
+    */
+    repeated BlindedPaymentPath blinded_payment_paths = 19;
+
+    /*
+    Features assumed to be supported by the final node. All transitive feature
+    dependencies must also be set properly. For a given feature bit pair, either
+    optional or remote may be set, but not both. If this field is nil or empty,
+    the router will try to load destination features from the graph as a
+    fallback.
+
+    Note: must not be set if making a payment to a blinded route (features
+    are provided in blinded_payment_paths).
+    */
+    repeated lnrpc.FeatureBit dest_features = 17;
+
+    /*
+    The time preference for this payment. Set to -1 to optimize for fees
+    only, to 1 to optimize for reliability only or a value inbetween for a mix.
+    */
+    double time_pref = 18;
+
+    /*
+    The channel ids of the channels allowed for the first hop. If empty, any
+    channel may be used.
+    */
+    repeated uint64 outgoing_chan_ids = 20;
+}
+
+message NodePair {
+    /*
+    The sending node of the pair. When using REST, this field must be encoded as
+    base64.
+    */
+    bytes from = 1;
+
+    /*
+    The receiving node of the pair. When using REST, this field must be encoded
+    as base64.
+    */
+    bytes to = 2;
+}
+
+message EdgeLocator {
+    // The short channel id of this edge.
+    uint64 channel_id = 1 [jstype = JS_STRING];
+
+    /*
+    The direction of this edge. If direction_reverse is false, the direction
+    of this edge is from the channel endpoint with the lexicographically smaller
+    pub key to the endpoint with the larger pub key. If direction_reverse is
+    is true, the edge goes the other way.
+    */
+    bool direction_reverse = 2;
+}
+
+message QueryRoutesResponse {
+    /*
+    The route that results from the path finding operation. This is still a
+    repeated field to retain backwards compatibility.
+    */
+    repeated Route routes = 1;
+
+    /*
+    The success probability of the returned route based on the current mission
+    control state. [EXPERIMENTAL]
+    */
+    double success_prob = 2;
+}
+
+message Hop {
+    /*
+    The unique channel ID for the channel. The first 3 bytes are the block
+    height, the next 3 the index within the block, and the last 2 bytes are the
+    output index for the channel.
+    */
+    uint64 chan_id = 1 [jstype = JS_STRING];
+    int64 chan_capacity = 2 [deprecated = true];
+    int64 amt_to_forward = 3 [deprecated = true];
+    int64 fee = 4 [deprecated = true];
+    uint32 expiry = 5;
+    int64 amt_to_forward_msat = 6;
+    int64 fee_msat = 7;
+
+    /*
+    An optional public key of the hop. If the public key is given, the payment
+    can be executed without relying on a copy of the channel graph.
+    */
+    string pub_key = 8;
+
+    /*
+    If set to true, then this hop will be encoded using the new variable length
+    TLV format. Note that if any custom tlv_records below are specified, then
+    this field MUST be set to true for them to be encoded properly.
+    */
+    bool tlv_payload = 9 [deprecated = true];
+
+    /*
+    An optional TLV record that signals the use of an MPP payment. If present,
+    the receiver will enforce that the same mpp_record is included in the final
+    hop payload of all non-zero payments in the HTLC set. If empty, a regular
+    single-shot payment is or was attempted.
+    */
+    MPPRecord mpp_record = 10;
+
+    /*
+    An optional TLV record that signals the use of an AMP payment. If present,
+    the receiver will treat all received payments including the same
+    (payment_addr, set_id) pair  as being part of one logical payment. The
+    payment will be settled by XORing the root_share's together and deriving the
+    child hashes and preimages according to BOLT XX. Must be used in conjunction
+    with mpp_record.
+    */
+    AMPRecord amp_record = 12;
+
+    /*
+    An optional set of key-value TLV records. This is useful within the context
+    of the SendToRoute call as it allows callers to specify arbitrary K-V pairs
+    to drop off at each hop within the onion.
+    */
+    map<uint64, bytes> custom_records = 11;
+
+    // The payment metadata to send along with the payment to the payee.
+    bytes metadata = 13;
+
+    /*
+    Blinding point is an optional blinding point included for introduction
+    nodes in blinded paths. This field is mandatory for hops that represents
+    the introduction point in a blinded path.
+    */
+    bytes blinding_point = 14;
+
+    /*
+    Encrypted data is a receiver-produced blob of data that provides hops
+    in a blinded route with forwarding data. As this data is encrypted by
+    the recipient, we will not be able to parse it - it is essentially an
+    arbitrary blob of data from our node's perspective. This field is
+    mandatory for all hops in a blinded path, including the introduction
+    node.
+    */
+    bytes encrypted_data = 15;
+
+    /*
+    The total amount that is sent to the recipient (possibly across multiple
+    HTLCs), as specified by the sender when making a payment to a blinded path.
+    This value is only set in the final hop payload of a blinded payment. This
+    value is analogous to the MPPRecord that is used for regular (non-blinded)
+    MPP payments.
+    */
+    uint64 total_amt_msat = 16;
+}
+
+message MPPRecord {
+    /*
+    A unique, random identifier used to authenticate the sender as the intended
+    payer of a multi-path payment. The payment_addr must be the same for all
+    subpayments, and match the payment_addr provided in the receiver's invoice.
+    The same payment_addr must be used on all subpayments. This is also called
+    payment secret in specifications (e.g. BOLT 11).
+    */
+    bytes payment_addr = 11;
+
+    /*
+    The total amount in milli-satoshis being sent as part of a larger multi-path
+    payment. The caller is responsible for ensuring subpayments to the same node
+    and payment_hash sum exactly to total_amt_msat. The same
+    total_amt_msat must be used on all subpayments.
+    */
+    int64 total_amt_msat = 10;
+}
+
+message AMPRecord {
+    bytes root_share = 1;
+
+    bytes set_id = 2;
+
+    uint32 child_index = 3;
+}
+
+/*
+A path through the channel graph which runs over one or more channels in
+succession. This struct carries all the information required to craft the
+Sphinx onion packet, and send the payment along the first hop in the path. A
+route is only selected as valid if all the channels have sufficient capacity to
+carry the initial payment amount after fees are accounted for.
+*/
+message Route {
+    /*
+    The cumulative (final) time lock across the entire route. This is the CLTV
+    value that should be extended to the first hop in the route. All other hops
+    will decrement the time-lock as advertised, leaving enough time for all
+    hops to wait for or present the payment preimage to complete the payment.
+    */
+    uint32 total_time_lock = 1;
+
+    /*
+    The sum of the fees paid at each hop within the final route. In the case
+    of a one-hop payment, this value will be zero as we don't need to pay a fee
+    to ourselves.
+    */
+    int64 total_fees = 2 [deprecated = true];
+
+    /*
+    The total amount of funds required to complete a payment over this route.
+    This value includes the cumulative fees at each hop. As a result, the HTLC
+    extended to the first-hop in the route will need to have at least this many
+    satoshis, otherwise the route will fail at an intermediate node due to an
+    insufficient amount of fees.
+    */
+    int64 total_amt = 3 [deprecated = true];
+
+    /*
+    Contains details concerning the specific forwarding details at each hop.
+    */
+    repeated Hop hops = 4;
+
+    /*
+    The total fees in millisatoshis.
+    */
+    int64 total_fees_msat = 5;
+
+    /*
+    The total amount in millisatoshis.
+    */
+    int64 total_amt_msat = 6;
+
+    /*
+    The actual on-chain amount that was sent out to the first hop. This value is
+    only different from the total_amt_msat field if this is a custom channel
+    payment and the value transported in the HTLC is different from the BTC
+    amount in the HTLC. If this value is zero, then this is an old payment that
+    didn't have this value yet and can be ignored.
+    */
+    int64 first_hop_amount_msat = 7;
+
+    /*
+    Custom channel data that might be populated in custom channels.
+    */
+    bytes custom_channel_data = 8;
+}
+
+message NodeInfoRequest {
+    // The 33-byte hex-encoded compressed public of the target node
+    string pub_key = 1;
+
+    // If true, will include all known channels associated with the node.
+    bool include_channels = 2;
+
+    // If true, will include announcements' signatures into ChannelEdge.
+    // Depends on include_channels.
+    bool include_auth_proof = 3;
+}
+
+message NodeInfo {
+    /*
+    An individual vertex/node within the channel graph. A node is
+    connected to other nodes by one or more channel edges emanating from it. As
+    the graph is directed, a node will also have an incoming edge attached to
+    it for each outgoing edge.
+    */
+    LightningNode node = 1;
+
+    // The total number of channels for the node.
+    uint32 num_channels = 2;
+
+    // The sum of all channels capacity for the node, denominated in satoshis.
+    int64 total_capacity = 3;
+
+    // A list of all public channels for the node.
+    repeated ChannelEdge channels = 4;
+}
+
+/*
+An individual vertex/node within the channel graph. A node is
+connected to other nodes by one or more channel edges emanating from it. As the
+graph is directed, a node will also have an incoming edge attached to it for
+each outgoing edge.
+*/
+message LightningNode {
+    uint32 last_update = 1;
+    string pub_key = 2;
+    string alias = 3;
+    repeated NodeAddress addresses = 4;
+    string color = 5;
+    map<uint32, Feature> features = 6;
+
+    // Custom node announcement tlv records.
+    map<uint64, bytes> custom_records = 7;
+}
+
+message NodeAddress {
+    string network = 1;
+    string addr = 2;
+}
+
+message RoutingPolicy {
+    uint32 time_lock_delta = 1;
+    int64 min_htlc = 2;
+    int64 fee_base_msat = 3;
+    int64 fee_rate_milli_msat = 4;
+    bool disabled = 5;
+    uint64 max_htlc_msat = 6;
+    uint32 last_update = 7;
+
+    // Custom channel update tlv records. These are customized fields that are
+    // not defined by LND and cannot be extracted.
+    map<uint64, bytes> custom_records = 8;
+
+    int32 inbound_fee_base_msat = 9;
+    int32 inbound_fee_rate_milli_msat = 10;
+}
+
+/*
+ChannelAuthProof is the authentication proof (the signature portion) for a
+channel. Using the four signatures contained in the struct, and some
+auxiliary knowledge (the funding script, node identities, and outpoint) nodes
+on the network are able to validate the authenticity and existence of a
+channel.
+*/
+message ChannelAuthProof {
+    // node_sig1 are the raw bytes of the first node signature encoded
+    // in DER format.
+    bytes node_sig1 = 1;
+
+    // bitcoin_sig1 are the raw bytes of the first bitcoin signature of the
+    // MultiSigKey key of the channel encoded in DER format.
+    bytes bitcoin_sig1 = 2;
+
+    // node_sig2 are the raw bytes of the second node signature encoded
+    // in DER format.
+    bytes node_sig2 = 3;
+
+    // bitcoin_sig2 are the raw bytes of the second bitcoin signature of the
+    // MultiSigKey key of the channel encoded in DER format.
+    bytes bitcoin_sig2 = 4;
+}
+
+/*
+A fully authenticated channel along with all its unique attributes.
+Once an authenticated channel announcement has been processed on the network,
+then an instance of ChannelEdgeInfo encapsulating the channels attributes is
+stored. The other portions relevant to routing policy of a channel are stored
+within a ChannelEdgePolicy for each direction of the channel.
+*/
+message ChannelEdge {
+    /*
+    The unique channel ID for the channel. The first 3 bytes are the block
+    height, the next 3 the index within the block, and the last 2 bytes are the
+    output index for the channel.
+    */
+    uint64 channel_id = 1 [jstype = JS_STRING];
+    string chan_point = 2;
+
+    uint32 last_update = 3 [deprecated = true];
+
+    string node1_pub = 4;
+    string node2_pub = 5;
+
+    int64 capacity = 6;
+
+    RoutingPolicy node1_policy = 7;
+    RoutingPolicy node2_policy = 8;
+
+    // Custom channel announcement tlv records.
+    map<uint64, bytes> custom_records = 9;
+
+    // Authentication proof for this channel. This proof contains a set of
+    // signatures binding four identities, which attests to the legitimacy of
+    // the advertised channel. This only is available for advertised channels.
+    // This field is not filled by default. Pass include_auth_proof flag to
+    // DescribeGraph, GetNodeInfo or GetChanInfo to get this data.
+    ChannelAuthProof auth_proof = 10;
+}
+
+message ChannelGraphRequest {
+    /*
+    Whether unannounced channels are included in the response or not. If set,
+    unannounced channels are included. Unannounced channels are both private
+    channels, and public channels that are not yet announced to the network.
+    */
+    bool include_unannounced = 1;
+
+    // If true, will include announcements' signatures into ChannelEdge.
+    bool include_auth_proof = 2;
+}
+
+// Returns a new instance of the directed channel graph.
+message ChannelGraph {
+    // The list of `LightningNode`s in this channel graph
+    repeated LightningNode nodes = 1;
+
+    // The list of `ChannelEdge`s in this channel graph
+    repeated ChannelEdge edges = 2;
+}
+
+enum NodeMetricType {
+    UNKNOWN = 0;
+    BETWEENNESS_CENTRALITY = 1;
+}
+
+message NodeMetricsRequest {
+    // The requested node metrics.
+    repeated NodeMetricType types = 1;
+}
+
+message NodeMetricsResponse {
+    /*
+    Betweenness centrality is the sum of the ratio of shortest paths that pass
+    through the node for each pair of nodes in the graph (not counting paths
+    starting or ending at this node).
+    Map of node pubkey to betweenness centrality of the node. Normalized
+    values are in the [0,1] closed interval.
+    */
+    map<string, FloatMetric> betweenness_centrality = 1;
+}
+
+message FloatMetric {
+    // Arbitrary float value.
+    double value = 1;
+
+    // The value normalized to [0,1] or [-1,1].
+    double normalized_value = 2;
+}
+
+message ChanInfoRequest {
+    /*
+    The unique channel ID for the channel. The first 3 bytes are the block
+    height, the next 3 the index within the block, and the last 2 bytes are the
+    output index for the channel.
+    */
+    uint64 chan_id = 1 [jstype = JS_STRING];
+
+    // The channel point of the channel in format funding_txid:output_index. If
+    // chan_id is specified, this field is ignored.
+    string chan_point = 2;
+
+    // If true, will include announcements' signatures into ChannelEdge.
+    bool include_auth_proof = 3;
+}
+
+message NetworkInfoRequest {
+}
+message NetworkInfo {
+    uint32 graph_diameter = 1;
+    double avg_out_degree = 2;
+    uint32 max_out_degree = 3;
+
+    uint32 num_nodes = 4;
+    uint32 num_channels = 5;
+
+    int64 total_network_capacity = 6;
+
+    double avg_channel_size = 7;
+    int64 min_channel_size = 8;
+    int64 max_channel_size = 9;
+    int64 median_channel_size_sat = 10;
+
+    // The number of edges marked as zombies.
+    uint64 num_zombie_chans = 11;
+
+    // TODO(roasbeef): fee rate info, expiry
+    //  * also additional RPC for tracking fee info once in
+}
+
+message StopRequest {
+}
+message StopResponse {
+    // The status of the stop operation.
+    string status = 1;
+}
+
+message GraphTopologySubscription {
+}
+message GraphTopologyUpdate {
+    repeated NodeUpdate node_updates = 1;
+    repeated ChannelEdgeUpdate channel_updates = 2;
+    repeated ClosedChannelUpdate closed_chans = 3;
+}
+message NodeUpdate {
+    /*
+    Deprecated, use node_addresses.
+    */
+    repeated string addresses = 1 [deprecated = true];
+
+    string identity_key = 2;
+
+    /*
+    Deprecated, use features.
+    */
+    bytes global_features = 3 [deprecated = true];
+
+    string alias = 4;
+    string color = 5;
+    repeated NodeAddress node_addresses = 7;
+
+    /*
+    Features that the node has advertised in the init message, node
+    announcements and invoices.
+    */
+    map<uint32, Feature> features = 6;
+}
+message ChannelEdgeUpdate {
+    /*
+    The unique channel ID for the channel. The first 3 bytes are the block
+    height, the next 3 the index within the block, and the last 2 bytes are the
+    output index for the channel.
+    */
+    uint64 chan_id = 1 [jstype = JS_STRING];
+
+    ChannelPoint chan_point = 2;
+
+    int64 capacity = 3;
+
+    RoutingPolicy routing_policy = 4;
+
+    string advertising_node = 5;
+    string connecting_node = 6;
+}
+message ClosedChannelUpdate {
+    /*
+    The unique channel ID for the channel. The first 3 bytes are the block
+    height, the next 3 the index within the block, and the last 2 bytes are the
+    output index for the channel.
+    */
+    uint64 chan_id = 1 [jstype = JS_STRING];
+    int64 capacity = 2;
+    uint32 closed_height = 3;
+    ChannelPoint chan_point = 4;
+}
+
+message HopHint {
+    // The public key of the node at the start of the channel.
+    string node_id = 1;
+
+    // The unique identifier of the channel.
+    uint64 chan_id = 2 [jstype = JS_STRING];
+
+    // The base fee of the channel denominated in millisatoshis.
+    uint32 fee_base_msat = 3;
+
+    /*
+    The fee rate of the channel for sending one satoshi across it denominated in
+    millionths of a satoshi.
+    */
+    uint32 fee_proportional_millionths = 4;
+
+    // The time-lock delta of the channel.
+    uint32 cltv_expiry_delta = 5;
+}
+
+message SetID {
+    bytes set_id = 1;
+}
+
+message RouteHint {
+    /*
+    A list of hop hints that when chained together can assist in reaching a
+    specific destination.
+    */
+    repeated HopHint hop_hints = 1;
+}
+
+message BlindedPaymentPath {
+    // The blinded path to send the payment to.
+    BlindedPath blinded_path = 1;
+
+    // The base fee for the blinded path provided, expressed in msat.
+    uint64 base_fee_msat = 2;
+
+    /*
+    The proportional fee for the blinded path provided, expressed in parts
+    per million.
+    */
+    uint32 proportional_fee_rate = 3;
+
+    /*
+    The total CLTV delta for the blinded path provided, including the
+    final CLTV delta for the receiving node.
+    */
+    uint32 total_cltv_delta = 4;
+
+    /*
+    The minimum hltc size that may be sent over the blinded path, expressed
+    in msat.
+    */
+    uint64 htlc_min_msat = 5;
+
+    /*
+    The maximum htlc size that may be sent over the blinded path, expressed
+    in msat.
+    */
+    uint64 htlc_max_msat = 6;
+
+    // The feature bits for the route.
+    repeated FeatureBit features = 7;
+}
+
+message BlindedPath {
+    // The unblinded pubkey of the introduction node for the route.
+    bytes introduction_node = 1;
+
+    // The ephemeral pubkey used by nodes in the blinded route.
+    bytes blinding_point = 2;
+
+    /*
+    A set of blinded node keys and data blobs for the blinded portion of the
+    route. Note that the first hop is expected to be the introduction node,
+    so the route is always expected to have at least one hop.
+    */
+    repeated BlindedHop blinded_hops = 3;
+}
+
+message BlindedHop {
+    // The blinded public key of the node.
+    bytes blinded_node = 1;
+
+    // An encrypted blob of data provided to the blinded node.
+    bytes encrypted_data = 2;
+}
+
+message AMPInvoiceState {
+    // The state the HTLCs associated with this setID are in.
+    InvoiceHTLCState state = 1;
+
+    // The settle index of this HTLC set, if the invoice state is settled.
+    uint64 settle_index = 2;
+
+    // The time this HTLC set was settled expressed in unix epoch.
+    int64 settle_time = 3;
+
+    // The total amount paid for the sub-invoice expressed in milli satoshis.
+    int64 amt_paid_msat = 5;
+}
+
+message Invoice {
+    /*
+    An optional memo to attach along with the invoice. Used for record keeping
+    purposes for the invoice's creator, and will also be set in the description
+    field of the encoded payment request if the description_hash field is not
+    being used.
+    */
+    string memo = 1;
+
+    reserved 2;
+
+    /*
+    The hex-encoded preimage (32 byte) which will allow settling an incoming
+    HTLC payable to this preimage. When using REST, this field must be encoded
+    as base64.
+    */
+    bytes r_preimage = 3;
+
+    /*
+    The hash of the preimage. When using REST, this field must be encoded as
+    base64.
+    Note: Output only, don't specify for creating an invoice.
+    */
+    bytes r_hash = 4;
+
+    /*
+    The value of this invoice in satoshis
+
+    The fields value and value_msat are mutually exclusive.
+    */
+    int64 value = 5;
+
+    /*
+    The value of this invoice in millisatoshis
+
+    The fields value and value_msat are mutually exclusive.
+    */
+    int64 value_msat = 23;
+
+    /*
+    Whether this invoice has been fulfilled.
+
+    The field is deprecated. Use the state field instead (compare to SETTLED).
+    */
+    bool settled = 6 [deprecated = true];
+
+    /*
+    When this invoice was created.
+    Measured in seconds since the unix epoch.
+    Note: Output only, don't specify for creating an invoice.
+    */
+    int64 creation_date = 7;
+
+    /*
+    When this invoice was settled.
+    Measured in seconds since the unix epoch.
+    Note: Output only, don't specify for creating an invoice.
+    */
+    int64 settle_date = 8;
+
+    /*
+    A bare-bones invoice for a payment within the Lightning Network. With the
+    details of the invoice, the sender has all the data necessary to send a
+    payment to the recipient.
+    Note: Output only, don't specify for creating an invoice.
+    */
+    string payment_request = 9;
+
+    /*
+    Hash (SHA-256) of a description of the payment. Used if the description of
+    payment (memo) is too long to naturally fit within the description field
+    of an encoded payment request. When using REST, this field must be encoded
+    as base64.
+    */
+    bytes description_hash = 10;
+
+    // Payment request expiry time in seconds. Default is 86400 (24 hours).
+    int64 expiry = 11;
+
+    // Fallback on-chain address.
+    string fallback_addr = 12;
+
+    // Delta to use for the time-lock of the CLTV extended to the final hop.
+    uint64 cltv_expiry = 13;
+
+    /*
+    Route hints that can each be individually used to assist in reaching the
+    invoice's destination.
+    */
+    repeated RouteHint route_hints = 14;
+
+    // Whether this invoice should include routing hints for private channels.
+    // Note: When enabled, if value and value_msat are zero, a large number of
+    // hints with these channels can be included, which might not be desirable.
+    bool private = 15;
+
+    /*
+    The "add" index of this invoice. Each newly created invoice will increment
+    this index making it monotonically increasing. Callers to the
+    SubscribeInvoices call can use this to instantly get notified of all added
+    invoices with an add_index greater than this one.
+    Note: Output only, don't specify for creating an invoice.
+    */
+    uint64 add_index = 16;
+
+    /*
+    The "settle" index of this invoice. Each newly settled invoice will
+    increment this index making it monotonically increasing. Callers to the
+    SubscribeInvoices call can use this to instantly get notified of all
+    settled invoices with an settle_index greater than this one.
+    Note: Output only, don't specify for creating an invoice.
+    */
+    uint64 settle_index = 17;
+
+    // Deprecated, use amt_paid_sat or amt_paid_msat.
+    int64 amt_paid = 18 [deprecated = true];
+
+    /*
+    The amount that was accepted for this invoice, in satoshis. This will ONLY
+    be set if this invoice has been settled or accepted. We provide this field
+    as if the invoice was created with a zero value, then we need to record what
+    amount was ultimately accepted. Additionally, it's possible that the sender
+    paid MORE that was specified in the original invoice. So we'll record that
+    here as well.
+    Note: Output only, don't specify for creating an invoice.
+    */
+    int64 amt_paid_sat = 19;
+
+    /*
+    The amount that was accepted for this invoice, in millisatoshis. This will
+    ONLY be set if this invoice has been settled or accepted. We provide this
+    field as if the invoice was created with a zero value, then we need to
+    record what amount was ultimately accepted. Additionally, it's possible that
+    the sender paid MORE that was specified in the original invoice. So we'll
+    record that here as well.
+    Note: Output only, don't specify for creating an invoice.
+    */
+    int64 amt_paid_msat = 20;
+
+    enum InvoiceState {
+        OPEN = 0;
+        SETTLED = 1;
+        CANCELED = 2;
+        ACCEPTED = 3;
+    }
+
+    /*
+    The state the invoice is in.
+    Note: Output only, don't specify for creating an invoice.
+    */
+    InvoiceState state = 21;
+
+    /*
+    List of HTLCs paying to this invoice [EXPERIMENTAL].
+    Note: Output only, don't specify for creating an invoice.
+    */
+    repeated InvoiceHTLC htlcs = 22;
+
+    /*
+    List of features advertised on the invoice.
+    Note: Output only, don't specify for creating an invoice.
+    */
+    map<uint32, Feature> features = 24;
+
+    /*
+    Indicates if this invoice was a spontaneous payment that arrived via keysend
+    [EXPERIMENTAL].
+    Note: Output only, don't specify for creating an invoice.
+    */
+    bool is_keysend = 25;
+
+    /*
+    The payment address of this invoice. This is also called payment secret in
+    specifications (e.g. BOLT 11). This value will be used in MPP payments, and
+    also for newer invoices that always require the MPP payload for added
+    end-to-end security.
+    Note: Output only, don't specify for creating an invoice.
+    */
+    bytes payment_addr = 26;
+
+    /*
+    Signals whether or not this is an AMP invoice.
+    */
+    bool is_amp = 27;
+
+    /*
+    [EXPERIMENTAL]:
+
+    Maps a 32-byte hex-encoded set ID to the sub-invoice AMP state for the
+    given set ID. This field is always populated for AMP invoices, and can be
+    used along side LookupInvoice to obtain the HTLC information related to a
+    given sub-invoice.
+    Note: Output only, don't specify for creating an invoice.
+    */
+    map<string, AMPInvoiceState> amp_invoice_state = 28;
+
+    /*
+    Signals that the invoice should include blinded paths to hide the true
+    identity of the recipient.
+    */
+    bool is_blinded = 29;
+
+    /*
+    Config values to use when creating blinded paths for this invoice. These
+    can be used to override the defaults config values provided in by the
+    global config. This field is only used if is_blinded is true.
+    */
+    BlindedPathConfig blinded_path_config = 30;
+}
+
+message BlindedPathConfig {
+    /*
+    The minimum number of real hops to include in a blinded path. This doesn't
+    include our node, so if the minimum is 1, then the path will contain at
+    minimum our node along with an introduction node hop. If it is zero then
+    the shortest path will use our node as an introduction node.
+    */
+    optional uint32 min_num_real_hops = 1;
+
+    /*
+    The number of hops to include in a blinded path. This doesn't include our
+    node, so if it is 1, then the path will contain our node along with an
+    introduction node or dummy node hop. If paths shorter than NumHops is
+    found, then they will be padded using dummy hops.
+    */
+    optional uint32 num_hops = 2;
+
+    /*
+    The maximum number of blinded paths to select and add to an invoice.
+    */
+    optional uint32 max_num_paths = 3;
+
+    /*
+    A list of node IDs of nodes that should not be used in any of our generated
+    blinded paths.
+    */
+    repeated bytes node_omission_list = 4;
+
+    /*
+    The chained channels list specified via channel id (separated by commas),
+    starting from a channel owned by the receiver node.
+    */
+    repeated uint64 incoming_channel_list = 5;
+}
+
+enum InvoiceHTLCState {
+    ACCEPTED = 0;
+    SETTLED = 1;
+    CANCELED = 2;
+}
+
+// Details of an HTLC that paid to an invoice
+message InvoiceHTLC {
+    // Short channel id over which the htlc was received.
+    uint64 chan_id = 1 [jstype = JS_STRING];
+
+    // Index identifying the htlc on the channel.
+    uint64 htlc_index = 2;
+
+    // The amount of the htlc in msat.
+    uint64 amt_msat = 3;
+
+    // Block height at which this htlc was accepted.
+    int32 accept_height = 4;
+
+    // Time at which this htlc was accepted.
+    int64 accept_time = 5;
+
+    // Time at which this htlc was settled or canceled.
+    int64 resolve_time = 6;
+
+    // Block height at which this htlc expires.
+    int32 expiry_height = 7;
+
+    // Current state the htlc is in.
+    InvoiceHTLCState state = 8;
+
+    // Custom tlv records.
+    map<uint64, bytes> custom_records = 9;
+
+    // The total amount of the mpp payment in msat.
+    uint64 mpp_total_amt_msat = 10;
+
+    // Details relevant to AMP HTLCs, only populated if this is an AMP HTLC.
+    AMP amp = 11;
+
+    /*
+    Custom channel data that might be populated in custom channels.
+    */
+    bytes custom_channel_data = 12;
+}
+
+// Details specific to AMP HTLCs.
+message AMP {
+    // An n-of-n secret share of the root seed from which child payment hashes
+    // and preimages are derived.
+    bytes root_share = 1;
+
+    // An identifier for the HTLC set that this HTLC belongs to.
+    bytes set_id = 2;
+
+    // A nonce used to randomize the child preimage and child hash from a given
+    // root_share.
+    uint32 child_index = 3;
+
+    // The payment hash of the AMP HTLC.
+    bytes hash = 4;
+
+    // The preimage used to settle this AMP htlc. This field will only be
+    // populated if the invoice is in InvoiceState_ACCEPTED or
+    // InvoiceState_SETTLED.
+    bytes preimage = 5;
+}
+
+message AddInvoiceResponse {
+    bytes r_hash = 1;
+
+    /*
+    A bare-bones invoice for a payment within the Lightning Network. With the
+    details of the invoice, the sender has all the data necessary to send a
+    payment to the recipient.
+    */
+    string payment_request = 2;
+
+    /*
+    The "add" index of this invoice. Each newly created invoice will increment
+    this index making it monotonically increasing. Callers to the
+    SubscribeInvoices call can use this to instantly get notified of all added
+    invoices with an add_index greater than this one.
+    */
+    uint64 add_index = 16;
+
+    /*
+    The payment address of the generated invoice. This is also called
+    payment secret in specifications (e.g. BOLT 11). This value should be used
+    in all payments for this invoice as we require it for end to end security.
+    */
+    bytes payment_addr = 17;
+}
+message PaymentHash {
+    /*
+    The hex-encoded payment hash of the invoice to be looked up. The passed
+    payment hash must be exactly 32 bytes, otherwise an error is returned.
+    Deprecated now that the REST gateway supports base64 encoding of bytes
+    fields.
+    */
+    string r_hash_str = 1 [deprecated = true];
+
+    /*
+    The payment hash of the invoice to be looked up. When using REST, this field
+    must be encoded as base64.
+    */
+    bytes r_hash = 2;
+}
+
+message ListInvoiceRequest {
+    /*
+    If set, only invoices that are not settled and not canceled will be returned
+    in the response.
+    */
+    bool pending_only = 1;
+
+    /*
+    The index of an invoice that will be used as either the start or end of a
+    query to determine which invoices should be returned in the response.
+    */
+    uint64 index_offset = 4;
+
+    // The max number of invoices to return in the response to this query.
+    uint64 num_max_invoices = 5;
+
+    /*
+    If set, the invoices returned will result from seeking backwards from the
+    specified index offset. This can be used to paginate backwards.
+    */
+    bool reversed = 6;
+
+    // If set, returns all invoices with a creation date greater than or equal
+    // to it. Measured in seconds since the unix epoch.
+    uint64 creation_date_start = 7;
+
+    // If set, returns all invoices with a creation date less than or equal to
+    // it. Measured in seconds since the unix epoch.
+    uint64 creation_date_end = 8;
+}
+
+message ListInvoiceResponse {
+    /*
+    A list of invoices from the time slice of the time series specified in the
+    request.
+    */
+    repeated Invoice invoices = 1;
+
+    /*
+    The index of the last item in the set of returned invoices. This can be used
+    to seek further, pagination style.
+    */
+    uint64 last_index_offset = 2;
+
+    /*
+    The index of the last item in the set of returned invoices. This can be used
+    to seek backwards, pagination style.
+    */
+    uint64 first_index_offset = 3;
+}
+
+message InvoiceSubscription {
+    /*
+    If specified (non-zero), then we'll first start by sending out
+    notifications for all added indexes with an add_index greater than this
+    value. This allows callers to catch up on any events they missed while they
+    weren't connected to the streaming RPC.
+    */
+    uint64 add_index = 1;
+
+    /*
+    If specified (non-zero), then we'll first start by sending out
+    notifications for all settled indexes with an settle_index greater than
+    this value. This allows callers to catch up on any events they missed while
+    they weren't connected to the streaming RPC.
+    */
+    uint64 settle_index = 2;
+}
+
+message DelCanceledInvoiceReq {
+    // Invoice payment hash to delete.
+    string invoice_hash = 1;
+}
+
+message DelCanceledInvoiceResp {
+    // The status of the delete operation.
+    string status = 1;
+}
+
+enum PaymentFailureReason {
+    /*
+    Payment isn't failed (yet).
+    */
+    FAILURE_REASON_NONE = 0;
+
+    /*
+    There are more routes to try, but the payment timeout was exceeded.
+    */
+    FAILURE_REASON_TIMEOUT = 1;
+
+    /*
+    All possible routes were tried and failed permanently. Or were no
+    routes to the destination at all.
+    */
+    FAILURE_REASON_NO_ROUTE = 2;
+
+    /*
+    A non-recoverable error has occured.
+    */
+    FAILURE_REASON_ERROR = 3;
+
+    /*
+    Payment details incorrect (unknown hash, invalid amt or
+    invalid final cltv delta)
+    */
+    FAILURE_REASON_INCORRECT_PAYMENT_DETAILS = 4;
+
+    /*
+    Insufficient local balance.
+    */
+    FAILURE_REASON_INSUFFICIENT_BALANCE = 5;
+
+    /*
+    The payment was canceled.
+    */
+    FAILURE_REASON_CANCELED = 6;
+}
+
+message Payment {
+    // The payment hash
+    string payment_hash = 1;
+
+    // Deprecated, use value_sat or value_msat.
+    int64 value = 2 [deprecated = true];
+
+    // Deprecated, use creation_time_ns
+    int64 creation_date = 3 [deprecated = true];
+
+    reserved 4;
+
+    // Deprecated, use fee_sat or fee_msat.
+    int64 fee = 5 [deprecated = true];
+
+    // The payment preimage
+    string payment_preimage = 6;
+
+    // The value of the payment in satoshis
+    int64 value_sat = 7;
+
+    // The value of the payment in milli-satoshis
+    int64 value_msat = 8;
+
+    // The optional payment request being fulfilled.
+    string payment_request = 9;
+
+    enum PaymentStatus {
+        // Deprecated. This status will never be returned.
+        UNKNOWN = 0 [deprecated = true];
+
+        // Payment has inflight HTLCs.
+        IN_FLIGHT = 1;
+
+        // Payment is settled.
+        SUCCEEDED = 2;
+
+        // Payment is failed.
+        FAILED = 3;
+
+        // Payment is created and has not attempted any HTLCs.
+        INITIATED = 4;
+    }
+
+    // The status of the payment.
+    PaymentStatus status = 10;
+
+    //  The fee paid for this payment in satoshis
+    int64 fee_sat = 11;
+
+    //  The fee paid for this payment in milli-satoshis
+    int64 fee_msat = 12;
+
+    // The time in UNIX nanoseconds at which the payment was created.
+    int64 creation_time_ns = 13;
+
+    // The HTLCs made in attempt to settle the payment.
+    repeated HTLCAttempt htlcs = 14;
+
+    /*
+    The creation index of this payment. Each payment can be uniquely identified
+    by this index, which may not strictly increment by 1 for payments made in
+    older versions of lnd.
+    */
+    uint64 payment_index = 15;
+
+    PaymentFailureReason failure_reason = 16;
+
+    /*
+    The custom TLV records that were sent to the first hop as part of the HTLC
+    wire message for this payment.
+    */
+    map<uint64, bytes> first_hop_custom_records = 17;
+}
+
+message HTLCAttempt {
+    // The unique ID that is used for this attempt.
+    uint64 attempt_id = 7;
+
+    enum HTLCStatus {
+        IN_FLIGHT = 0;
+        SUCCEEDED = 1;
+        FAILED = 2;
+    }
+
+    // The status of the HTLC.
+    HTLCStatus status = 1;
+
+    // The route taken by this HTLC.
+    Route route = 2;
+
+    // The time in UNIX nanoseconds at which this HTLC was sent.
+    int64 attempt_time_ns = 3;
+
+    /*
+    The time in UNIX nanoseconds at which this HTLC was settled or failed.
+    This value will not be set if the HTLC is still IN_FLIGHT.
+    */
+    int64 resolve_time_ns = 4;
+
+    // Detailed htlc failure info.
+    Failure failure = 5;
+
+    // The preimage that was used to settle the HTLC.
+    bytes preimage = 6;
+}
+
+message ListPaymentsRequest {
+    /*
+    If true, then return payments that have not yet fully completed. This means
+    that pending payments, as well as failed payments will show up if this
+    field is set to true. This flag doesn't change the meaning of the indices,
+    which are tied to individual payments.
+    */
+    bool include_incomplete = 1;
+
+    /*
+    The index of a payment that will be used as either the start or end of a
+    query to determine which payments should be returned in the response. The
+    index_offset is exclusive. In the case of a zero index_offset, the query
+    will start with the oldest payment when paginating forwards, or will end
+    with the most recent payment when paginating backwards.
+    */
+    uint64 index_offset = 2;
+
+    // The maximal number of payments returned in the response to this query.
+    uint64 max_payments = 3;
+
+    /*
+    If set, the payments returned will result from seeking backwards from the
+    specified index offset. This can be used to paginate backwards. The order
+    of the returned payments is always oldest first (ascending index order).
+    */
+    bool reversed = 4;
+
+    /*
+    If set, all payments (complete and incomplete, independent of the
+    max_payments parameter) will be counted. Note that setting this to true will
+    increase the run time of the call significantly on systems that have a lot
+    of payments, as all of them have to be iterated through to be counted.
+    */
+    bool count_total_payments = 5;
+
+    // If set, returns all payments with a creation date greater than or equal
+    // to it. Measured in seconds since the unix epoch.
+    uint64 creation_date_start = 6;
+
+    // If set, returns all payments with a creation date less than or equal to
+    // it. Measured in seconds since the unix epoch.
+    uint64 creation_date_end = 7;
+}
+
+message ListPaymentsResponse {
+    // The list of payments
+    repeated Payment payments = 1;
+
+    /*
+    The index of the first item in the set of returned payments. This can be
+    used as the index_offset to continue seeking backwards in the next request.
+    */
+    uint64 first_index_offset = 2;
+
+    /*
+    The index of the last item in the set of returned payments. This can be used
+    as the index_offset to continue seeking forwards in the next request.
+    */
+    uint64 last_index_offset = 3;
+
+    /*
+    Will only be set if count_total_payments in the request was set. Represents
+    the total number of payments (complete and incomplete, independent of the
+    number of payments requested in the query) currently present in the payments
+    database.
+    */
+    uint64 total_num_payments = 4;
+}
+
+message DeletePaymentRequest {
+    // Payment hash to delete.
+    bytes payment_hash = 1;
+
+    /*
+    Only delete failed HTLCs from the payment, not the payment itself.
+    */
+    bool failed_htlcs_only = 2;
+}
+
+message DeleteAllPaymentsRequest {
+    // Only delete failed payments.
+    bool failed_payments_only = 1;
+
+    /*
+    Only delete failed HTLCs from payments, not the payment itself.
+    */
+    bool failed_htlcs_only = 2;
+
+    // Delete all payments. NOTE: Using this option requires careful
+    // consideration as it is a destructive operation.
+    bool all_payments = 3;
+}
+
+message DeletePaymentResponse {
+    // The status of the delete operation.
+    string status = 1;
+}
+
+message DeleteAllPaymentsResponse {
+    // The status of the delete operation.
+    string status = 1;
+}
+
+message AbandonChannelRequest {
+    ChannelPoint channel_point = 1;
+
+    bool pending_funding_shim_only = 2;
+
+    /*
+    Override the requirement for being in dev mode by setting this to true and
+    confirming the user knows what they are doing and this is a potential foot
+    gun to lose funds if used on active channels.
+    */
+    bool i_know_what_i_am_doing = 3;
+}
+
+message AbandonChannelResponse {
+    // The status of the abandon operation.
+    string status = 1;
+}
+
+message DebugLevelRequest {
+    bool show = 1;
+    string level_spec = 2;
+}
+message DebugLevelResponse {
+    string sub_systems = 1;
+}
+
+message PayReqString {
+    // The payment request string to be decoded
+    string pay_req = 1;
+}
+message PayReq {
+    string destination = 1;
+    string payment_hash = 2;
+    int64 num_satoshis = 3;
+    int64 timestamp = 4;
+    int64 expiry = 5;
+    string description = 6;
+    string description_hash = 7;
+    string fallback_addr = 8;
+    int64 cltv_expiry = 9;
+    repeated RouteHint route_hints = 10;
+    bytes payment_addr = 11;
+    int64 num_msat = 12;
+    map<uint32, Feature> features = 13;
+    repeated BlindedPaymentPath blinded_paths = 14;
+}
+
+enum FeatureBit {
+    DATALOSS_PROTECT_REQ = 0;
+    DATALOSS_PROTECT_OPT = 1;
+    INITIAL_ROUING_SYNC = 3;
+    UPFRONT_SHUTDOWN_SCRIPT_REQ = 4;
+    UPFRONT_SHUTDOWN_SCRIPT_OPT = 5;
+    GOSSIP_QUERIES_REQ = 6;
+    GOSSIP_QUERIES_OPT = 7;
+    TLV_ONION_REQ = 8;
+    TLV_ONION_OPT = 9;
+    EXT_GOSSIP_QUERIES_REQ = 10;
+    EXT_GOSSIP_QUERIES_OPT = 11;
+    STATIC_REMOTE_KEY_REQ = 12;
+    STATIC_REMOTE_KEY_OPT = 13;
+    PAYMENT_ADDR_REQ = 14;
+    PAYMENT_ADDR_OPT = 15;
+    MPP_REQ = 16;
+    MPP_OPT = 17;
+    WUMBO_CHANNELS_REQ = 18;
+    WUMBO_CHANNELS_OPT = 19;
+    ANCHORS_REQ = 20;
+    ANCHORS_OPT = 21;
+    ANCHORS_ZERO_FEE_HTLC_REQ = 22;
+    ANCHORS_ZERO_FEE_HTLC_OPT = 23;
+    ROUTE_BLINDING_REQUIRED = 24;
+    ROUTE_BLINDING_OPTIONAL = 25;
+    AMP_REQ = 30;
+    AMP_OPT = 31;
+}
+
+message Feature {
+    string name = 2;
+    bool is_required = 3;
+    bool is_known = 4;
+}
+
+message FeeReportRequest {
+}
+message ChannelFeeReport {
+    // The short channel id that this fee report belongs to.
+    uint64 chan_id = 5 [jstype = JS_STRING];
+
+    // The channel that this fee report belongs to.
+    string channel_point = 1;
+
+    // The base fee charged regardless of the number of milli-satoshis sent.
+    int64 base_fee_msat = 2;
+
+    // The amount charged per milli-satoshis transferred expressed in
+    // millionths of a satoshi.
+    int64 fee_per_mil = 3;
+
+    // The effective fee rate in milli-satoshis. Computed by dividing the
+    // fee_per_mil value by 1 million.
+    double fee_rate = 4;
+
+    // The base fee charged regardless of the number of milli-satoshis sent.
+    int32 inbound_base_fee_msat = 6;
+
+    // The amount charged per milli-satoshis transferred expressed in
+    // millionths of a satoshi.
+    int32 inbound_fee_per_mil = 7;
+}
+
+message FeeReportResponse {
+    // An array of channel fee reports which describes the current fee schedule
+    // for each channel.
+    repeated ChannelFeeReport channel_fees = 1;
+
+    // The total amount of fee revenue (in satoshis) the switch has collected
+    // over the past 24 hrs.
+    uint64 day_fee_sum = 2;
+
+    // The total amount of fee revenue (in satoshis) the switch has collected
+    // over the past 1 week.
+    uint64 week_fee_sum = 3;
+
+    // The total amount of fee revenue (in satoshis) the switch has collected
+    // over the past 1 month.
+    uint64 month_fee_sum = 4;
+}
+
+message InboundFee {
+    // The inbound base fee charged regardless of the number of milli-satoshis
+    // received in the channel. By default, only negative values are accepted.
+    int32 base_fee_msat = 1;
+
+    // The effective inbound fee rate in micro-satoshis (parts per million).
+    // By default, only negative values are accepted.
+    int32 fee_rate_ppm = 2;
+}
+
+message PolicyUpdateRequest {
+    oneof scope {
+        // If set, then this update applies to all currently active channels.
+        bool global = 1;
+
+        // If set, this update will target a specific channel.
+        ChannelPoint chan_point = 2;
+    }
+
+    // The base fee charged regardless of the number of milli-satoshis sent.
+    int64 base_fee_msat = 3;
+
+    // The effective fee rate in milli-satoshis. The precision of this value
+    // goes up to 6 decimal places, so 1e-6.
+    double fee_rate = 4;
+
+    // The effective fee rate in micro-satoshis (parts per million).
+    uint32 fee_rate_ppm = 9;
+
+    // The required timelock delta for HTLCs forwarded over the channel.
+    uint32 time_lock_delta = 5;
+
+    // If set, the maximum HTLC size in milli-satoshis. If unset, the maximum
+    // HTLC will be unchanged.
+    uint64 max_htlc_msat = 6;
+
+    // The minimum HTLC size in milli-satoshis. Only applied if
+    // min_htlc_msat_specified is true.
+    uint64 min_htlc_msat = 7;
+
+    // If true, min_htlc_msat is applied.
+    bool min_htlc_msat_specified = 8;
+
+    // Optional inbound fee. If unset, the previously set value will be
+    // retained [EXPERIMENTAL].
+    InboundFee inbound_fee = 10;
+
+    // Under unknown circumstances a channel can exist with a missing edge in
+    // the graph database. This can cause an 'edge not found' error when calling
+    // `getchaninfo` and/or cause the default channel policy to be used during
+    // forwards. Setting this flag will recreate the edge if not found, allowing
+    // updating this channel policy and fixing the missing edge problem for this
+    // channel permanently. For fields not set in this command, the default
+    // policy will be created.
+    bool create_missing_edge = 11;
+}
+
+enum UpdateFailure {
+    UPDATE_FAILURE_UNKNOWN = 0;
+    UPDATE_FAILURE_PENDING = 1;
+    UPDATE_FAILURE_NOT_FOUND = 2;
+    UPDATE_FAILURE_INTERNAL_ERR = 3;
+    UPDATE_FAILURE_INVALID_PARAMETER = 4;
+}
+
+message FailedUpdate {
+    // The outpoint in format txid:n
+    OutPoint outpoint = 1;
+
+    // Reason for the policy update failure.
+    UpdateFailure reason = 2;
+
+    // A string representation of the policy update error.
+    string update_error = 3;
+}
+
+message PolicyUpdateResponse {
+    // List of failed policy updates.
+    repeated FailedUpdate failed_updates = 1;
+}
+
+message ForwardingHistoryRequest {
+    // Start time is the starting point of the forwarding history request. All
+    // records beyond this point will be included, respecting the end time, and
+    // the index offset.
+    uint64 start_time = 1;
+
+    // End time is the end point of the forwarding history request. The
+    // response will carry at most 50k records between the start time and the
+    // end time. The index offset can be used to implement pagination.
+    uint64 end_time = 2;
+
+    // Index offset is the offset in the time series to start at. As each
+    // response can only contain 50k records, callers can use this to skip
+    // around within a packed time series.
+    uint32 index_offset = 3;
+
+    // The max number of events to return in the response to this query.
+    uint32 num_max_events = 4;
+
+    // Informs the server if the peer alias should be looked up for each
+    // forwarding event.
+    bool peer_alias_lookup = 5;
+
+    // List of incoming channel ids to filter htlcs received from a
+    // particular channel
+    repeated uint64 incoming_chan_ids = 6;
+
+    // List of outgoing channel ids to filter htlcs being forwarded to a
+    // particular channel
+    repeated uint64 outgoing_chan_ids = 7;
+}
+message ForwardingEvent {
+    // Timestamp is the time (unix epoch offset) that this circuit was
+    // completed. Deprecated by timestamp_ns.
+    uint64 timestamp = 1 [deprecated = true];
+
+    // The incoming channel ID that carried the HTLC that created the circuit.
+    uint64 chan_id_in = 2 [jstype = JS_STRING];
+
+    // The outgoing channel ID that carried the preimage that completed the
+    // circuit.
+    uint64 chan_id_out = 4 [jstype = JS_STRING];
+
+    // The total amount (in satoshis) of the incoming HTLC that created half
+    // the circuit.
+    uint64 amt_in = 5;
+
+    // The total amount (in satoshis) of the outgoing HTLC that created the
+    // second half of the circuit.
+    uint64 amt_out = 6;
+
+    // The total fee (in satoshis) that this payment circuit carried.
+    uint64 fee = 7;
+
+    // The total fee (in milli-satoshis) that this payment circuit carried.
+    uint64 fee_msat = 8;
+
+    // The total amount (in milli-satoshis) of the incoming HTLC that created
+    // half the circuit.
+    uint64 amt_in_msat = 9;
+
+    // The total amount (in milli-satoshis) of the outgoing HTLC that created
+    // the second half of the circuit.
+    uint64 amt_out_msat = 10;
+
+    // The number of nanoseconds elapsed since January 1, 1970 UTC when this
+    // circuit was completed.
+    uint64 timestamp_ns = 11;
+
+    // The peer alias of the incoming channel.
+    string peer_alias_in = 12;
+
+    // The peer alias of the outgoing channel.
+    string peer_alias_out = 13;
+
+    // The ID of the incoming HTLC in the payment circuit. This field is
+    // optional and is unset for forwarding events happened before v0.20.
+    optional uint64 incoming_htlc_id = 14;
+
+    // The ID of the outgoing HTLC in the payment circuit. This field is
+    // optional and may be unset for legacy forwarding events.
+    optional uint64 outgoing_htlc_id = 15;
+
+    // TODO(roasbeef): add settlement latency?
+    //  * use FPE on the chan id?
+    //  * also list failures?
+}
+message ForwardingHistoryResponse {
+    // A list of forwarding events from the time slice of the time series
+    // specified in the request.
+    repeated ForwardingEvent forwarding_events = 1;
+
+    // The index of the last time in the set of returned forwarding events. Can
+    // be used to seek further, pagination style.
+    uint32 last_offset_index = 2;
+}
+
+message ExportChannelBackupRequest {
+    // The target channel point to obtain a back up for.
+    ChannelPoint chan_point = 1;
+}
+
+message ChannelBackup {
+    /*
+    Identifies the channel that this backup belongs to.
+    */
+    ChannelPoint chan_point = 1;
+
+    /*
+    Is an encrypted single-chan backup. this can be passed to
+    RestoreChannelBackups, or the WalletUnlocker Init and Unlock methods in
+    order to trigger the recovery protocol. When using REST, this field must be
+    encoded as base64.
+    */
+    bytes chan_backup = 2;
+}
+
+message MultiChanBackup {
+    /*
+    Is the set of all channels that are included in this multi-channel backup.
+    */
+    repeated ChannelPoint chan_points = 1;
+
+    /*
+    A single encrypted blob containing all the static channel backups of the
+    channel listed above. This can be stored as a single file or blob, and
+    safely be replaced with any prior/future versions. When using REST, this
+    field must be encoded as base64.
+    */
+    bytes multi_chan_backup = 2;
+}
+
+message ChanBackupExportRequest {
+}
+message ChanBackupSnapshot {
+    /*
+    The set of new channels that have been added since the last channel backup
+    snapshot was requested.
+    */
+    ChannelBackups single_chan_backups = 1;
+
+    /*
+    A multi-channel backup that covers all open channels currently known to
+    lnd.
+    */
+    MultiChanBackup multi_chan_backup = 2;
+}
+
+message ChannelBackups {
+    /*
+    A set of single-chan static channel backups.
+    */
+    repeated ChannelBackup chan_backups = 1;
+}
+
+message RestoreChanBackupRequest {
+    oneof backup {
+        /*
+        The channels to restore as a list of channel/backup pairs.
+        */
+        ChannelBackups chan_backups = 1;
+
+        /*
+        The channels to restore in the packed multi backup format. When using
+        REST, this field must be encoded as base64.
+        */
+        bytes multi_chan_backup = 2;
+    }
+}
+message RestoreBackupResponse {
+    // The number of channels successfully restored.
+    uint32 num_restored = 1;
+}
+
+message ChannelBackupSubscription {
+}
+
+message VerifyChanBackupResponse {
+    repeated string chan_points = 1;
+}
+
+message MacaroonPermission {
+    // The entity a permission grants access to.
+    string entity = 1;
+
+    // The action that is granted.
+    string action = 2;
+}
+message BakeMacaroonRequest {
+    // The list of permissions the new macaroon should grant.
+    repeated MacaroonPermission permissions = 1;
+
+    // The root key ID used to create the macaroon, must be a positive integer.
+    uint64 root_key_id = 2;
+
+    /*
+    Informs the RPC on whether to allow external permissions that LND is not
+    aware of.
+    */
+    bool allow_external_permissions = 3;
+}
+message BakeMacaroonResponse {
+    // The hex encoded macaroon, serialized in binary format.
+    string macaroon = 1;
+}
+
+message ListMacaroonIDsRequest {
+}
+message ListMacaroonIDsResponse {
+    // The list of root key IDs that are in use.
+    repeated uint64 root_key_ids = 1;
+}
+
+message DeleteMacaroonIDRequest {
+    // The root key ID to be removed.
+    uint64 root_key_id = 1;
+}
+message DeleteMacaroonIDResponse {
+    // A boolean indicates that the deletion is successful.
+    bool deleted = 1;
+}
+
+message MacaroonPermissionList {
+    // A list of macaroon permissions.
+    repeated MacaroonPermission permissions = 1;
+}
+
+message ListPermissionsRequest {
+}
+message ListPermissionsResponse {
+    /*
+    A map between all RPC method URIs and their required macaroon permissions to
+    access them.
+    */
+    map<string, MacaroonPermissionList> method_permissions = 1;
+}
+
+message Failure {
+    enum FailureCode {
+        /*
+        The numbers assigned in this enumeration match the failure codes as
+        defined in BOLT #4. Because protobuf 3 requires enums to start with 0,
+        a RESERVED value is added.
+        */
+        RESERVED = 0;
+
+        INCORRECT_OR_UNKNOWN_PAYMENT_DETAILS = 1;
+        INCORRECT_PAYMENT_AMOUNT = 2;
+        FINAL_INCORRECT_CLTV_EXPIRY = 3;
+        FINAL_INCORRECT_HTLC_AMOUNT = 4;
+        FINAL_EXPIRY_TOO_SOON = 5;
+        INVALID_REALM = 6;
+        EXPIRY_TOO_SOON = 7;
+        INVALID_ONION_VERSION = 8;
+        INVALID_ONION_HMAC = 9;
+        INVALID_ONION_KEY = 10;
+        AMOUNT_BELOW_MINIMUM = 11;
+        FEE_INSUFFICIENT = 12;
+        INCORRECT_CLTV_EXPIRY = 13;
+        CHANNEL_DISABLED = 14;
+        TEMPORARY_CHANNEL_FAILURE = 15;
+        REQUIRED_NODE_FEATURE_MISSING = 16;
+        REQUIRED_CHANNEL_FEATURE_MISSING = 17;
+        UNKNOWN_NEXT_PEER = 18;
+        TEMPORARY_NODE_FAILURE = 19;
+        PERMANENT_NODE_FAILURE = 20;
+        PERMANENT_CHANNEL_FAILURE = 21;
+        EXPIRY_TOO_FAR = 22;
+        MPP_TIMEOUT = 23;
+        INVALID_ONION_PAYLOAD = 24;
+        INVALID_ONION_BLINDING = 25;
+
+        /*
+        An internal error occurred.
+        */
+        INTERNAL_FAILURE = 997;
+
+        /*
+        The error source is known, but the failure itself couldn't be decoded.
+        */
+        UNKNOWN_FAILURE = 998;
+
+        /*
+        An unreadable failure result is returned if the received failure message
+        cannot be decrypted. In that case the error source is unknown.
+        */
+        UNREADABLE_FAILURE = 999;
+    }
+
+    // Failure code as defined in the Lightning spec
+    FailureCode code = 1;
+
+    reserved 2;
+
+    // An optional channel update message.
+    ChannelUpdate channel_update = 3;
+
+    // A failure type-dependent htlc value.
+    uint64 htlc_msat = 4;
+
+    // The sha256 sum of the onion payload.
+    bytes onion_sha_256 = 5;
+
+    // A failure type-dependent cltv expiry value.
+    uint32 cltv_expiry = 6;
+
+    // A failure type-dependent flags value.
+    uint32 flags = 7;
+
+    /*
+    The position in the path of the intermediate or final node that generated
+    the failure message. Position zero is the sender node.
+    **/
+    uint32 failure_source_index = 8;
+
+    // A failure type-dependent block height.
+    uint32 height = 9;
+}
+
+message ChannelUpdate {
+    /*
+    The signature that validates the announced data and proves the ownership
+    of node id.
+    */
+    bytes signature = 1;
+
+    /*
+    The target chain that this channel was opened within. This value
+    should be the genesis hash of the target chain. Along with the short
+    channel ID, this uniquely identifies the channel globally in a
+    blockchain.
+    */
+    bytes chain_hash = 2;
+
+    /*
+    The unique description of the funding transaction.
+    */
+    uint64 chan_id = 3 [jstype = JS_STRING];
+
+    /*
+    A timestamp that allows ordering in the case of multiple announcements.
+    We should ignore the message if timestamp is not greater than the
+    last-received.
+    */
+    uint32 timestamp = 4;
+
+    /*
+    The bitfield that describes whether optional fields are present in this
+    update. Currently, the least-significant bit must be set to 1 if the
+    optional field MaxHtlc is present.
+    */
+    uint32 message_flags = 10;
+
+    /*
+    The bitfield that describes additional meta-data concerning how the
+    update is to be interpreted. Currently, the least-significant bit must be
+    set to 0 if the creating node corresponds to the first node in the
+    previously sent channel announcement and 1 otherwise. If the second bit
+    is set, then the channel is set to be disabled.
+    */
+    uint32 channel_flags = 5;
+
+    /*
+    The minimum number of blocks this node requires to be added to the expiry
+    of HTLCs. This is a security parameter determined by the node operator.
+    This value represents the required gap between the time locks of the
+    incoming and outgoing HTLC's set to this node.
+    */
+    uint32 time_lock_delta = 6;
+
+    /*
+    The minimum HTLC value which will be accepted.
+    */
+    uint64 htlc_minimum_msat = 7;
+
+    /*
+    The base fee that must be used for incoming HTLC's to this particular
+    channel. This value will be tacked onto the required for a payment
+    independent of the size of the payment.
+    */
+    uint32 base_fee = 8;
+
+    /*
+    The fee rate that will be charged per millionth of a satoshi.
+    */
+    uint32 fee_rate = 9;
+
+    /*
+    The maximum HTLC value which will be accepted.
+    */
+    uint64 htlc_maximum_msat = 11;
+
+    /*
+    The set of data that was appended to this message, some of which we may
+    not actually know how to iterate or parse. By holding onto this data, we
+    ensure that we're able to properly validate the set of signatures that
+    cover these new fields, and ensure we're able to make upgrades to the
+    network in a forwards compatible manner.
+    */
+    bytes extra_opaque_data = 12;
+}
+
+message MacaroonId {
+    bytes nonce = 1;
+    bytes storageId = 2;
+    repeated Op ops = 3;
+}
+
+message Op {
+    string entity = 1;
+    repeated string actions = 2;
+}
+
+message CheckMacPermRequest {
+    // The macaroon to check permissions for, serialized in binary format. For
+    // a macaroon to be valid, it must have been issued by lnd, must succeed all
+    // caveat conditions, and must contain all of the permissions specified in
+    // the permissions field.
+    bytes macaroon = 1;
+
+    // The list of permissions the macaroon should be checked against. Only if
+    // the macaroon contains all of these permissions, it is considered valid.
+    // If the list of permissions given is empty, then the macaroon is
+    // considered valid only based on issuance authority and caveat validity.
+    // An empty list of permissions is therefore equivalent to saying "skip
+    // checking permissions" (unless check_default_perms_from_full_method is
+    // specified).
+    repeated MacaroonPermission permissions = 2;
+
+    // The RPC method to check the macaroon against. This is only used if there
+    // are custom `uri:<rpcpackage>.<ServiceName>/<MethodName>` permissions in
+    // the permission list above. To check a macaroon against the list of
+    // permissions of a certain RPC method, query the `ListPermissions` RPC
+    // first, extract the permissions for the method, and then pass them in the
+    // `permissions` field above.
+    string fullMethod = 3;
+
+    // If this field is set to true, then the permissions list above MUST be
+    // empty. The default permissions for the provided fullMethod will be used
+    // to check the macaroon. This is equivalent to looking up the permissions
+    // for a method in the `ListPermissions` RPC and then calling this RPC with
+    // the permission list returned from that call. Without this flag, the list
+    // of permissions must be non-empty for the check to actually perform a
+    // permission check.
+    bool check_default_perms_from_full_method = 4;
+}
+
+message CheckMacPermResponse {
+    bool valid = 1;
+}
+
+message RPCMiddlewareRequest {
+    /*
+    The unique ID of the intercepted original gRPC request. Useful for mapping
+    request to response when implementing full duplex message interception. For
+    streaming requests, this will be the same ID for all incoming and outgoing
+    middleware intercept messages of the _same_ stream.
+    */
+    uint64 request_id = 1;
+
+    /*
+    The raw bytes of the complete macaroon as sent by the gRPC client in the
+    original request. This might be empty for a request that doesn't require
+    macaroons such as the wallet unlocker RPCs.
+    */
+    bytes raw_macaroon = 2;
+
+    /*
+    The parsed condition of the macaroon's custom caveat for convenient access.
+    This field only contains the value of the custom caveat that the handling
+    middleware has registered itself for. The condition _must_ be validated for
+    messages of intercept_type stream_auth and request!
+    */
+    string custom_caveat_condition = 3;
+
+    /*
+    There are three types of messages that will be sent to the middleware for
+    inspection and approval: Stream authentication, request and response
+    interception. The first two can only be accepted (=forward to main RPC
+    server) or denied (=return error to client). Intercepted responses can also
+    be replaced/overwritten.
+    */
+    oneof intercept_type {
+        /*
+        Intercept stream authentication: each new streaming RPC call that is
+        initiated against lnd and contains the middleware's custom macaroon
+        caveat can be approved or denied based upon the macaroon in the stream
+        header. This message will only be sent for streaming RPCs, unary RPCs
+        must handle the macaroon authentication in the request interception to
+        avoid an additional message round trip between lnd and the middleware.
+        */
+        StreamAuth stream_auth = 4;
+
+        /*
+        Intercept incoming gRPC client request message: all incoming messages,
+        both on streaming and unary RPCs, are forwarded to the middleware for
+        inspection. For unary RPC messages the middleware is also expected to
+        validate the custom macaroon caveat of the request.
+        */
+        RPCMessage request = 5;
+
+        /*
+        Intercept outgoing gRPC response message: all outgoing messages, both on
+        streaming and unary RPCs, are forwarded to the middleware for inspection
+        and amendment. The response in this message is the original response as
+        it was generated by the main RPC server. It can either be accepted
+        (=forwarded to the client), replaced/overwritten with a new message of
+        the same type, or replaced by an error message.
+        */
+        RPCMessage response = 6;
+
+        /*
+        This is used to indicate to the client that the server has successfully
+        registered the interceptor. This is only used in the very first message
+        that the server sends to the client after the client sends the server
+        the middleware registration message.
+        */
+        bool reg_complete = 8;
+    }
+
+    /*
+    The unique message ID of this middleware intercept message. There can be
+    multiple middleware intercept messages per single gRPC request (one for the
+    incoming request and one for the outgoing response) or gRPC stream (one for
+    each incoming message and one for each outgoing response). This message ID
+    must be referenced when responding (accepting/rejecting/modifying) to an
+    intercept message.
+    */
+    uint64 msg_id = 7;
+
+    /*
+    The metadata pairs that were sent along with the original gRPC request via
+    the golang context.Context using explicit [gRPC
+    metadata](https://grpc.io/docs/guides/metadata/). Context values are not
+    propagated via gRPC and so we send any pairs along explicitly here so that
+    the interceptor can access them.
+    */
+    map<string, MetadataValues> metadata_pairs = 9;
+}
+
+message MetadataValues {
+    /*
+    The set of metadata values that correspond to the metadata key.
+    */
+    repeated string values = 1;
+}
+
+message StreamAuth {
+    /*
+    The full URI (in the format /<rpcpackage>.<ServiceName>/MethodName, for
+    example /lnrpc.Lightning/GetInfo) of the streaming RPC method that was just
+    established.
+    */
+    string method_full_uri = 1;
+}
+
+message RPCMessage {
+    /*
+    The full URI (in the format /<rpcpackage>.<ServiceName>/MethodName, for
+    example /lnrpc.Lightning/GetInfo) of the RPC method the message was sent
+    to/from.
+    */
+    string method_full_uri = 1;
+
+    /*
+    Indicates whether the message was sent over a streaming RPC method or not.
+    */
+    bool stream_rpc = 2;
+
+    /*
+    The full canonical gRPC name of the message type (in the format
+    <rpcpackage>.TypeName, for example lnrpc.GetInfoRequest). In case of an
+    error being returned from lnd, this simply contains the string "error".
+    */
+    string type_name = 3;
+
+    /*
+    The full content of the gRPC message, serialized in the binary protobuf
+    format.
+    */
+    bytes serialized = 4;
+
+    /*
+    Indicates that the response from lnd was an error, not a gRPC response. If
+    this is set to true then the type_name contains the string "error" and
+    serialized contains the error string.
+    */
+    bool is_error = 5;
+}
+
+message RPCMiddlewareResponse {
+    /*
+    The request message ID this response refers to. Must always be set when
+    giving feedback to an intercept but is ignored for the initial registration
+    message.
+    */
+    uint64 ref_msg_id = 1;
+
+    /*
+    The middleware can only send two types of messages to lnd: The initial
+    registration message that identifies the middleware and after that only
+    feedback messages to requests sent to the middleware.
+    */
+    oneof middleware_message {
+        /*
+        The registration message identifies the middleware that's being
+        registered in lnd. The registration message must be sent immediately
+        after initiating the RegisterRpcMiddleware stream, otherwise lnd will
+        time out the attempt and terminate the request. NOTE: The middleware
+        will only receive interception messages for requests that contain a
+        macaroon with the custom caveat that the middleware declares it is
+        responsible for handling in the registration message! As a security
+        measure, _no_ middleware can intercept requests made with _unencumbered_
+        macaroons!
+        */
+        MiddlewareRegistration register = 2;
+
+        /*
+        The middleware received an interception request and gives feedback to
+        it. The request_id indicates what message the feedback refers to.
+        */
+        InterceptFeedback feedback = 3;
+    }
+}
+
+message MiddlewareRegistration {
+    /*
+    The name of the middleware to register. The name should be as informative
+    as possible and is logged on registration.
+    */
+    string middleware_name = 1;
+
+    /*
+    The name of the custom macaroon caveat that this middleware is responsible
+    for. Only requests/responses that contain a macaroon with the registered
+    custom caveat are forwarded for interception to the middleware. The
+    exception being the read-only mode: All requests/responses are forwarded to
+    a middleware that requests read-only access but such a middleware won't be
+    allowed to _alter_ responses. As a security measure, _no_ middleware can
+    change responses to requests made with _unencumbered_ macaroons!
+    NOTE: Cannot be used at the same time as read_only_mode.
+    */
+    string custom_macaroon_caveat_name = 2;
+
+    /*
+    Instead of defining a custom macaroon caveat name a middleware can register
+    itself for read-only access only. In that mode all requests/responses are
+    forwarded to the middleware but the middleware isn't allowed to alter any of
+    the responses.
+    NOTE: Cannot be used at the same time as custom_macaroon_caveat_name.
+    */
+    bool read_only_mode = 3;
+}
+
+message InterceptFeedback {
+    /*
+    The error to return to the user. If this is non-empty, the incoming gRPC
+    stream/request is aborted and the error is returned to the gRPC client. If
+    this value is empty, it means the middleware accepts the stream/request/
+    response and the processing of it can continue.
+    */
+    string error = 1;
+
+    /*
+    A boolean indicating that the gRPC message should be replaced/overwritten.
+    This boolean is needed because in protobuf an empty message is serialized as
+    a 0-length or nil byte slice and we wouldn't be able to distinguish between
+    an empty replacement message and the "don't replace anything" case.
+    */
+    bool replace_response = 2;
+
+    /*
+    If the replace_response field is set to true, this field must contain the
+    binary serialized gRPC message in the protobuf format.
+    */
+    bytes replacement_serialized = 3;
+}

--- a/lampo-lnd/proto/routerrpc/router.proto
+++ b/lampo-lnd/proto/routerrpc/router.proto
@@ -1,0 +1,1136 @@
+syntax = "proto3";
+
+package routerrpc;
+
+import "lightning.proto";
+
+option go_package = "github.com/lightningnetwork/lnd/lnrpc/routerrpc";
+
+/*
+ * Comments in this file will be directly parsed into the API
+ * Documentation as descriptions of the associated method, message, or field.
+ * These descriptions should go right above the definition of the object, and
+ * can be in either block or // comment format.
+ *
+ * An RPC method can be matched to an lncli command by placing a line in the
+ * beginning of the description in exactly the following format:
+ * lncli: `methodname`
+ *
+ * Failure to specify the exact name of the command will cause documentation
+ * generation to fail.
+ *
+ * More information on how exactly the gRPC documentation is generated from
+ * this proto file can be found here:
+ * https://github.com/lightninglabs/lightning-api
+ */
+
+// Router is a service that offers advanced interaction with the router
+// subsystem of the daemon.
+service Router {
+    /*
+    SendPaymentV2 attempts to route a payment described by the passed
+    PaymentRequest to the final destination. The call returns a stream of
+    payment updates. When using this RPC, make sure to set a fee limit, as the
+    default routing fee limit is 0 sats. Without a non-zero fee limit only
+    routes without fees will be attempted which often fails with
+    FAILURE_REASON_NO_ROUTE.
+    */
+    rpc SendPaymentV2 (SendPaymentRequest) returns (stream lnrpc.Payment);
+
+    /* lncli: `trackpayment`
+    TrackPaymentV2 returns an update stream for the payment identified by the
+    payment hash.
+    */
+    rpc TrackPaymentV2 (TrackPaymentRequest) returns (stream lnrpc.Payment);
+
+    /*
+    TrackPayments returns an update stream for every payment that is not in a
+    terminal state. Note that if payments are in-flight while starting a new
+    subscription, the start of the payment stream could produce out-of-order
+    and/or duplicate events. In order to get updates for every in-flight
+    payment attempt make sure to subscribe to this method before initiating any
+    payments.
+    */
+    rpc TrackPayments (TrackPaymentsRequest) returns (stream lnrpc.Payment);
+
+    /*
+    EstimateRouteFee allows callers to obtain a lower bound w.r.t how much it
+    may cost to send an HTLC to the target end destination.
+    */
+    rpc EstimateRouteFee (RouteFeeRequest) returns (RouteFeeResponse);
+
+    /*
+    Deprecated, use SendToRouteV2. SendToRoute attempts to make a payment via
+    the specified route. This method differs from SendPayment in that it
+    allows users to specify a full route manually. This can be used for
+    things like rebalancing, and atomic swaps. It differs from the newer
+    SendToRouteV2 in that it doesn't return the full HTLC information.
+    */
+    rpc SendToRoute (SendToRouteRequest) returns (SendToRouteResponse) {
+        option deprecated = true;
+    }
+
+    /*
+    SendToRouteV2 attempts to make a payment via the specified route. This
+    method differs from SendPayment in that it allows users to specify a full
+    route manually. This can be used for things like rebalancing, and atomic
+    swaps.
+    */
+    rpc SendToRouteV2 (SendToRouteRequest) returns (lnrpc.HTLCAttempt);
+
+    /* lncli: `resetmc`
+    ResetMissionControl clears all mission control state and starts with a clean
+    slate.
+    */
+    rpc ResetMissionControl (ResetMissionControlRequest)
+        returns (ResetMissionControlResponse);
+
+    /* lncli: `querymc`
+    QueryMissionControl exposes the internal mission control state to callers.
+    It is a development feature.
+    */
+    rpc QueryMissionControl (QueryMissionControlRequest)
+        returns (QueryMissionControlResponse);
+
+    /* lncli: `importmc`
+    XImportMissionControl is an experimental API that imports the state provided
+    to the internal mission control's state, using all results which are more
+    recent than our existing values. These values will only be imported
+    in-memory, and will not be persisted across restarts.
+    */
+    rpc XImportMissionControl (XImportMissionControlRequest)
+        returns (XImportMissionControlResponse);
+
+    /* lncli: `getmccfg`
+    GetMissionControlConfig returns mission control's current config.
+    */
+    rpc GetMissionControlConfig (GetMissionControlConfigRequest)
+        returns (GetMissionControlConfigResponse);
+
+    /* lncli: `setmccfg`
+    SetMissionControlConfig will set mission control's config, if the config
+    provided is valid.
+    */
+    rpc SetMissionControlConfig (SetMissionControlConfigRequest)
+        returns (SetMissionControlConfigResponse);
+
+    /* lncli: `queryprob`
+    Deprecated. QueryProbability returns the current success probability
+    estimate for a given node pair and amount. The call returns a zero success
+    probability if no channel is available or if the amount violates min/max
+    HTLC constraints.
+    */
+    rpc QueryProbability (QueryProbabilityRequest)
+        returns (QueryProbabilityResponse);
+
+    /* lncli: `buildroute`
+    BuildRoute builds a fully specified route based on a list of hop public
+    keys. It retrieves the relevant channel policies from the graph in order to
+    calculate the correct fees and time locks.
+    Note that LND will use its default final_cltv_delta if no value is supplied.
+    Make sure to add the correct final_cltv_delta depending on the invoice
+    restriction. Moreover the caller has to make sure to provide the
+    payment_addr if the route is paying an invoice which signaled it.
+    */
+    rpc BuildRoute (BuildRouteRequest) returns (BuildRouteResponse);
+
+    /*
+    SubscribeHtlcEvents creates a uni-directional stream from the server to
+    the client which delivers a stream of htlc events.
+    */
+    rpc SubscribeHtlcEvents (SubscribeHtlcEventsRequest)
+        returns (stream HtlcEvent);
+
+    /*
+    Deprecated, use SendPaymentV2. SendPayment attempts to route a payment
+    described by the passed PaymentRequest to the final destination. The call
+    returns a stream of payment status updates.
+    */
+    rpc SendPayment (SendPaymentRequest) returns (stream PaymentStatus) {
+        option deprecated = true;
+    }
+
+    /*
+    Deprecated, use TrackPaymentV2. TrackPayment returns an update stream for
+    the payment identified by the payment hash.
+    */
+    rpc TrackPayment (TrackPaymentRequest) returns (stream PaymentStatus) {
+        option deprecated = true;
+    }
+
+    /**
+    HtlcInterceptor dispatches a bi-directional streaming RPC in which
+    Forwarded HTLC requests are sent to the client and the client responds with
+    a boolean that tells LND if this htlc should be intercepted.
+    In case of interception, the htlc can be either settled, cancelled or
+    resumed later by using the ResolveHoldForward endpoint.
+    */
+    rpc HtlcInterceptor (stream ForwardHtlcInterceptResponse)
+        returns (stream ForwardHtlcInterceptRequest);
+
+    /* lncli: `updatechanstatus`
+    UpdateChanStatus attempts to manually set the state of a channel
+    (enabled, disabled, or auto). A manual "disable" request will cause the
+    channel to stay disabled until a subsequent manual request of either
+    "enable" or "auto".
+    */
+    rpc UpdateChanStatus (UpdateChanStatusRequest)
+        returns (UpdateChanStatusResponse);
+
+    /*
+    XAddLocalChanAliases is an experimental API that creates a set of new
+    channel SCID alias mappings. The final total set of aliases in the manager
+    after the add operation is returned. This is only a locally stored alias,
+    and will not be communicated to the channel peer via any message. Therefore,
+    routing over such an alias will only work if the peer also calls this same
+    RPC on their end. If an alias already exists, an error is returned
+    */
+    rpc XAddLocalChanAliases (AddAliasesRequest) returns (AddAliasesResponse);
+
+    /*
+    XDeleteLocalChanAliases is an experimental API that deletes a set of alias
+    mappings. The final total set of aliases in the manager after the delete
+    operation is returned. The deletion will not be communicated to the channel
+    peer via any message.
+    */
+    rpc XDeleteLocalChanAliases (DeleteAliasesRequest)
+        returns (DeleteAliasesResponse);
+
+    /*
+    XFindBaseLocalChanAlias is an experimental API that looks up the base scid
+    for a local chan alias that was registered during the current runtime.
+    */
+    rpc XFindBaseLocalChanAlias (FindBaseAliasRequest)
+        returns (FindBaseAliasResponse);
+}
+
+message SendPaymentRequest {
+    // The identity pubkey of the payment recipient
+    bytes dest = 1;
+
+    /*
+    Number of satoshis to send.
+
+    The fields amt and amt_msat are mutually exclusive.
+    */
+    int64 amt = 2;
+
+    // The hash to use within the payment's HTLC
+    bytes payment_hash = 3;
+
+    /*
+    The CLTV delta from the current height that should be used to set the
+    timelock for the final hop.
+    */
+    int32 final_cltv_delta = 4;
+
+    /*
+    A bare-bones invoice for a payment within the Lightning Network.  With the
+    details of the invoice, the sender has all the data necessary to send a
+    payment to the recipient. The amount in the payment request may be zero. In
+    that case it is required to set the amt field as well. If no payment request
+    is specified, the following fields are required: dest, amt and payment_hash.
+    */
+    string payment_request = 5;
+
+    /*
+    An optional limit, expressed in seconds, on the time to wait before
+    attempting the first HTLC. Once HTLCs are in flight, the payment will
+    not be aborted until the HTLCs are either settled or failed. If the field
+    is not set or is explicitly set to zero, the default value of 60 seconds
+    will be applied.
+    */
+    int32 timeout_seconds = 6;
+
+    /*
+    The maximum number of satoshis that will be paid as a fee of the payment.
+    If this field is left to the default value of 0, only zero-fee routes will
+    be considered. This usually means single hop routes connecting directly to
+    the destination. To send the payment without a fee limit, use max int here.
+
+    The fields fee_limit_sat and fee_limit_msat are mutually exclusive.
+    */
+    int64 fee_limit_sat = 7;
+
+    /*
+    Deprecated, use outgoing_chan_ids. The channel id of the channel that must
+    be taken to the first hop. If zero, any channel may be used (unless
+    outgoing_chan_ids are set).
+    */
+    uint64 outgoing_chan_id = 8 [jstype = JS_STRING, deprecated = true];
+
+    /*
+    An optional maximum total time lock for the route. This should not
+    exceed lnd's `--max-cltv-expiry` setting. If zero, then the value of
+    `--max-cltv-expiry` is enforced.
+    */
+    int32 cltv_limit = 9;
+
+    /*
+    Optional route hints to reach the destination through private channels.
+    */
+    repeated lnrpc.RouteHint route_hints = 10;
+
+    /*
+    An optional field that can be used to pass an arbitrary set of TLV records
+    to a peer which understands the new records. This can be used to pass
+    application specific data during the payment attempt. Record types are
+    required to be in the custom range >= 65536. When using REST, the values
+    must be encoded as base64.
+    */
+    map<uint64, bytes> dest_custom_records = 11;
+
+    /*
+    Number of millisatoshis to send.
+
+    The fields amt and amt_msat are mutually exclusive.
+    */
+    int64 amt_msat = 12;
+
+    /*
+    The maximum number of millisatoshis that will be paid as a fee of the
+    payment. If this field is left to the default value of 0, only zero-fee
+    routes will be considered. This usually means single hop routes connecting
+    directly to the destination. To send the payment without a fee limit, use
+    max int here.
+
+    The fields fee_limit_sat and fee_limit_msat are mutually exclusive.
+    */
+    int64 fee_limit_msat = 13;
+
+    /*
+    The pubkey of the last hop of the route. If empty, any hop may be used.
+    */
+    bytes last_hop_pubkey = 14;
+
+    // If set, circular payments to self are permitted.
+    bool allow_self_payment = 15;
+
+    /*
+    Features assumed to be supported by the final node. All transitive feature
+    dependencies must also be set properly. For a given feature bit pair, either
+    optional or remote may be set, but not both. If this field is nil or empty,
+    the router will try to load destination features from the graph as a
+    fallback.
+    */
+    repeated lnrpc.FeatureBit dest_features = 16;
+
+    /*
+    The maximum number of partial payments that may be use to complete the full
+    amount.
+    */
+    uint32 max_parts = 17;
+
+    /*
+    If set, only the final payment update is streamed back. Intermediate updates
+    that show which htlcs are still in flight are suppressed.
+    */
+    bool no_inflight_updates = 18;
+
+    /*
+    The channel ids of the channels are allowed for the first hop. If empty,
+    any channel may be used.
+    */
+    repeated uint64 outgoing_chan_ids = 19;
+
+    /*
+    An optional payment addr to be included within the last hop of the route.
+    This is also called payment secret in specifications (e.g. BOLT 11).
+    */
+    bytes payment_addr = 20;
+
+    /*
+    The largest payment split that should be attempted when making a payment if
+    splitting is necessary. Setting this value will effectively cause lnd to
+    split more aggressively, vs only when it thinks it needs to. Note that this
+    value is in milli-satoshis.
+    */
+    uint64 max_shard_size_msat = 21;
+
+    /*
+    If set, an AMP-payment will be attempted.
+    */
+    bool amp = 22;
+
+    /*
+    The time preference for this payment. Set to -1 to optimize for fees
+    only, to 1 to optimize for reliability only or a value inbetween for a mix.
+    */
+    double time_pref = 23;
+
+    /*
+    If set, the payment loop can be interrupted by manually canceling the
+    payment context, even before the payment timeout is reached. Note that the
+    payment may still succeed after cancellation, as in-flight attempts can
+    still settle afterwards. Canceling will only prevent further attempts from
+    being sent.
+    */
+    bool cancelable = 24;
+
+    /*
+    An optional field that can be used to pass an arbitrary set of TLV records
+    to the first hop peer of this payment. This can be used to pass application
+    specific data during the payment attempt. Record types are required to be in
+    the custom range >= 65536. When using REST, the values must be encoded as
+    base64.
+    */
+    map<uint64, bytes> first_hop_custom_records = 25;
+}
+
+message TrackPaymentRequest {
+    // The hash of the payment to look up.
+    bytes payment_hash = 1;
+
+    /*
+    If set, only the final payment update is streamed back. Intermediate updates
+    that show which htlcs are still in flight are suppressed.
+    */
+    bool no_inflight_updates = 2;
+}
+
+message TrackPaymentsRequest {
+    /*
+    If set, only the final payment updates are streamed back. Intermediate
+    updates that show which htlcs are still in flight are suppressed.
+    */
+    bool no_inflight_updates = 1;
+}
+
+message RouteFeeRequest {
+    /*
+    The destination one wishes to obtain a routing fee quote to. If set, this
+    parameter requires the amt_sat parameter also to be set. This parameter
+    combination triggers a graph based routing fee estimation as opposed to a
+    payment probe based estimate in case a payment request is provided. The
+    graph based estimation is an algorithm that is executed on the in memory
+    graph. Hence its runtime is significantly shorter than a payment probe
+    estimation that sends out actual payments to the network.
+    */
+    bytes dest = 1;
+
+    /*
+    The amount one wishes to send to the target destination. It is only to be
+    used in combination with the dest parameter.
+    */
+    int64 amt_sat = 2;
+
+    /*
+    A payment request of the target node that the route fee request is intended
+    for. Its parameters are input to probe payments that estimate routing fees.
+    The timeout parameter can be specified to set a maximum time on the probing
+    attempt. Cannot be used in combination with dest and amt_sat.
+    */
+    string payment_request = 3;
+
+    /*
+    A user preference of how long a probe payment should maximally be allowed to
+    take, denoted in seconds. The probing payment loop is aborted if this
+    timeout is reached. Note that the probing process itself can take longer
+    than the timeout if the HTLC becomes delayed or stuck. Canceling the context
+    of this call will not cancel the payment loop, the duration is only
+    controlled by the timeout parameter.
+    */
+    uint32 timeout = 4;
+}
+
+message RouteFeeResponse {
+    /*
+    A lower bound of the estimated fee to the target destination within the
+    network, expressed in milli-satoshis.
+    */
+    int64 routing_fee_msat = 1;
+
+    /*
+    An estimate of the worst case time delay that can occur. Note that callers
+    will still need to factor in the final CLTV delta of the last hop into this
+    value.
+    */
+    int64 time_lock_delay = 2;
+
+    /*
+    An indication whether a probing payment succeeded or whether and why it
+    failed. FAILURE_REASON_NONE indicates success.
+    */
+    lnrpc.PaymentFailureReason failure_reason = 5;
+}
+
+message SendToRouteRequest {
+    // The payment hash to use for the HTLC.
+    bytes payment_hash = 1;
+
+    // Route that should be used to attempt to complete the payment.
+    lnrpc.Route route = 2;
+
+    /*
+    Whether the payment should be marked as failed when a temporary error is
+    returned from the given route. Set it to true so the payment won't be
+    failed unless a terminal error is occurred, such as payment timeout, no
+    routes, incorrect payment details, or insufficient funds.
+    */
+    bool skip_temp_err = 3;
+
+    /*
+    An optional field that can be used to pass an arbitrary set of TLV records
+    to the first hop peer of this payment. This can be used to pass application
+    specific data during the payment attempt. Record types are required to be in
+    the custom range >= 65536. When using REST, the values must be encoded as
+    base64.
+    */
+    map<uint64, bytes> first_hop_custom_records = 4;
+}
+
+message SendToRouteResponse {
+    // The preimage obtained by making the payment.
+    bytes preimage = 1;
+
+    // The failure message in case the payment failed.
+    lnrpc.Failure failure = 2;
+}
+
+message ResetMissionControlRequest {
+}
+
+message ResetMissionControlResponse {
+}
+
+message QueryMissionControlRequest {
+}
+
+// QueryMissionControlResponse contains mission control state.
+message QueryMissionControlResponse {
+    reserved 1;
+
+    // Node pair-level mission control state.
+    repeated PairHistory pairs = 2;
+}
+
+message XImportMissionControlRequest {
+    // Node pair-level mission control state to be imported.
+    repeated PairHistory pairs = 1;
+
+    // Whether to force override MC pair history. Note that even with force
+    // override the failure pair is imported before the success pair and both
+    // still clamp existing failure/success amounts.
+    bool force = 2;
+}
+
+message XImportMissionControlResponse {
+}
+
+// PairHistory contains the mission control state for a particular node pair.
+message PairHistory {
+    // The source node pubkey of the pair.
+    bytes node_from = 1;
+
+    // The destination node pubkey of the pair.
+    bytes node_to = 2;
+
+    reserved 3, 4, 5, 6;
+
+    PairData history = 7;
+}
+
+message PairData {
+    // Time of last failure.
+    int64 fail_time = 1;
+
+    /*
+    Lowest amount that failed to forward rounded to whole sats. This may be
+    set to zero if the failure is independent of amount.
+    */
+    int64 fail_amt_sat = 2;
+
+    /*
+    Lowest amount that failed to forward in millisats. This may be
+    set to zero if the failure is independent of amount.
+    */
+    int64 fail_amt_msat = 4;
+
+    reserved 3;
+
+    // Time of last success.
+    int64 success_time = 5;
+
+    // Highest amount that we could successfully forward rounded to whole sats.
+    int64 success_amt_sat = 6;
+
+    // Highest amount that we could successfully forward in millisats.
+    int64 success_amt_msat = 7;
+}
+
+message GetMissionControlConfigRequest {
+}
+
+message GetMissionControlConfigResponse {
+    /*
+    Mission control's currently active config.
+    */
+    MissionControlConfig config = 1;
+}
+
+message SetMissionControlConfigRequest {
+    /*
+    The config to set for mission control. Note that all values *must* be set,
+    because the full config will be applied.
+    */
+    MissionControlConfig config = 1;
+}
+
+message SetMissionControlConfigResponse {
+}
+
+message MissionControlConfig {
+    /*
+    Deprecated, use AprioriParameters. The amount of time mission control will
+    take to restore a penalized node or channel back to 50% success probability,
+    expressed in seconds. Setting this value to a higher value will penalize
+    failures for longer, making mission control less likely to route through
+    nodes and channels that we have previously recorded failures for.
+    */
+    uint64 half_life_seconds = 1 [deprecated = true];
+
+    /*
+    Deprecated, use AprioriParameters. The probability of success mission
+    control should assign to hop in a route where it has no other information
+    available. Higher values will make mission control more willing to try hops
+    that we have no information about, lower values will discourage trying these
+    hops.
+    */
+    float hop_probability = 2 [deprecated = true];
+
+    /*
+    Deprecated, use AprioriParameters. The importance that mission control
+    should place on historical results, expressed as a value in [0;1]. Setting
+    this value to 1 will ignore all historical payments and just use the hop
+    probability to assess the probability of success for each hop. A zero value
+    ignores hop probability completely and relies entirely on historical
+    results, unless none are available.
+    */
+    float weight = 3 [deprecated = true];
+
+    /*
+    The maximum number of payment results that mission control will store.
+    */
+    uint32 maximum_payment_results = 4;
+
+    /*
+    The minimum time that must have passed since the previously recorded failure
+    before we raise the failure amount.
+    */
+    uint64 minimum_failure_relax_interval = 5;
+
+    enum ProbabilityModel {
+        APRIORI = 0;
+        BIMODAL = 1;
+    }
+
+    /*
+    ProbabilityModel defines which probability estimator should be used in
+    pathfinding. Note that the bimodal estimator is experimental.
+    */
+    ProbabilityModel model = 6;
+
+    /*
+    EstimatorConfig is populated dependent on the estimator type.
+    */
+    oneof EstimatorConfig {
+        AprioriParameters apriori = 7;
+        BimodalParameters bimodal = 8;
+    }
+}
+
+message BimodalParameters {
+    /*
+    NodeWeight defines how strongly other previous forwardings on channels of a
+    router should be taken into account when computing a channel's probability
+    to route. The allowed values are in the range [0, 1], where a value of 0
+    means that only direct information about a channel is taken into account.
+    */
+    double node_weight = 1;
+
+    /*
+    ScaleMsat describes the scale over which channels statistically have some
+    liquidity left. The value determines how quickly the bimodal distribution
+    drops off from the edges of a channel. A larger value (compared to typical
+    channel capacities) means that the drop off is slow and that channel
+    balances are distributed more uniformly. A small value leads to the
+    assumption of very unbalanced channels.
+    */
+    uint64 scale_msat = 2;
+
+    /*
+    DecayTime describes the information decay of knowledge about previous
+    successes and failures in channels. The smaller the decay time, the quicker
+    we forget about past forwardings.
+    */
+    uint64 decay_time = 3;
+}
+
+message AprioriParameters {
+    /*
+    The amount of time mission control will take to restore a penalized node
+    or channel back to 50% success probability, expressed in seconds. Setting
+    this value to a higher value will penalize failures for longer, making
+    mission control less likely to route through nodes and channels that we
+    have previously recorded failures for.
+    */
+    uint64 half_life_seconds = 1;
+
+    /*
+    The probability of success mission control should assign to hop in a route
+    where it has no other information available. Higher values will make mission
+    control more willing to try hops that we have no information about, lower
+    values will discourage trying these hops.
+    */
+    double hop_probability = 2;
+
+    /*
+    The importance that mission control should place on historical results,
+    expressed as a value in [0;1]. Setting this value to 1 will ignore all
+    historical payments and just use the hop probability to assess the
+    probability of success for each hop. A zero value ignores hop probability
+    completely and relies entirely on historical results, unless none are
+    available.
+    */
+    double weight = 3;
+
+    /*
+    The fraction of a channel's capacity that we consider to have liquidity. For
+    amounts that come close to or exceed the fraction, an additional penalty is
+    applied. A value of 1.0 disables the capacity factor. Allowed values are in
+    [0.75, 1.0].
+    */
+    double capacity_fraction = 4;
+}
+
+message QueryProbabilityRequest {
+    // The source node pubkey of the pair.
+    bytes from_node = 1;
+
+    // The destination node pubkey of the pair.
+    bytes to_node = 2;
+
+    // The amount for which to calculate a probability.
+    int64 amt_msat = 3;
+}
+
+message QueryProbabilityResponse {
+    // The success probability for the requested pair.
+    double probability = 1;
+
+    // The historical data for the requested pair.
+    PairData history = 2;
+}
+
+message BuildRouteRequest {
+    /*
+    The amount to send expressed in msat. If set to zero, the minimum routable
+    amount is used.
+    */
+    int64 amt_msat = 1;
+
+    /*
+    CLTV delta from the current height that should be used for the timelock
+    of the final hop
+    */
+    int32 final_cltv_delta = 2;
+
+    /*
+    The channel id of the channel that must be taken to the first hop. If zero,
+    any channel may be used.
+    */
+    uint64 outgoing_chan_id = 3 [jstype = JS_STRING];
+
+    /*
+    A list of hops that defines the route. This does not include the source hop
+    pubkey.
+    */
+    repeated bytes hop_pubkeys = 4;
+
+    /*
+    An optional payment addr to be included within the last hop of the route.
+    This is also called payment secret in specifications (e.g. BOLT 11).
+    */
+    bytes payment_addr = 5;
+
+    /*
+    An optional field that can be used to pass an arbitrary set of TLV records
+    to the first hop peer of this payment. This can be used to pass application
+    specific data during the payment attempt. Record types are required to be in
+    the custom range >= 65536. When using REST, the values must be encoded as
+    base64.
+    */
+    map<uint64, bytes> first_hop_custom_records = 6;
+}
+
+message BuildRouteResponse {
+    /*
+    Fully specified route that can be used to execute the payment.
+    */
+    lnrpc.Route route = 1;
+}
+
+message SubscribeHtlcEventsRequest {
+}
+
+/*
+HtlcEvent contains the htlc event that was processed. These are served on a
+best-effort basis; events are not persisted, delivery is not guaranteed
+(in the event of a crash in the switch, forward events may be lost) and
+some events may be replayed upon restart. Events consumed from this package
+should be de-duplicated by the htlc's unique combination of incoming and
+outgoing channel id and htlc id. [EXPERIMENTAL]
+*/
+message HtlcEvent {
+    /*
+    The short channel id that the incoming htlc arrived at our node on. This
+    value is zero for sends.
+    */
+    uint64 incoming_channel_id = 1;
+
+    /*
+    The short channel id that the outgoing htlc left our node on. This value
+    is zero for receives.
+    */
+    uint64 outgoing_channel_id = 2;
+
+    /*
+    Incoming id is the index of the incoming htlc in the incoming channel.
+    This value is zero for sends.
+    */
+    uint64 incoming_htlc_id = 3;
+
+    /*
+    Outgoing id is the index of the outgoing htlc in the outgoing channel.
+    This value is zero for receives.
+    */
+    uint64 outgoing_htlc_id = 4;
+
+    /*
+    The time in unix nanoseconds that the event occurred.
+    */
+    uint64 timestamp_ns = 5;
+
+    enum EventType {
+        UNKNOWN = 0;
+        SEND = 1;
+        RECEIVE = 2;
+        FORWARD = 3;
+    }
+
+    /*
+    The event type indicates whether the htlc was part of a send, receive or
+    forward.
+    */
+    EventType event_type = 6;
+
+    oneof event {
+        ForwardEvent forward_event = 7;
+        ForwardFailEvent forward_fail_event = 8;
+        SettleEvent settle_event = 9;
+        LinkFailEvent link_fail_event = 10;
+        SubscribedEvent subscribed_event = 11;
+        FinalHtlcEvent final_htlc_event = 12;
+    }
+}
+
+message HtlcInfo {
+    // The timelock on the incoming htlc.
+    uint32 incoming_timelock = 1;
+
+    // The timelock on the outgoing htlc.
+    uint32 outgoing_timelock = 2;
+
+    // The amount of the incoming htlc.
+    uint64 incoming_amt_msat = 3;
+
+    // The amount of the outgoing htlc.
+    uint64 outgoing_amt_msat = 4;
+}
+
+message ForwardEvent {
+    // Info contains details about the htlc that was forwarded.
+    HtlcInfo info = 1;
+}
+
+message ForwardFailEvent {
+}
+
+message SettleEvent {
+    // The revealed preimage.
+    bytes preimage = 1;
+}
+
+message FinalHtlcEvent {
+    bool settled = 1;
+    bool offchain = 2;
+}
+
+message SubscribedEvent {
+}
+
+message LinkFailEvent {
+    // Info contains details about the htlc that we failed.
+    HtlcInfo info = 1;
+
+    // FailureCode is the BOLT error code for the failure.
+    lnrpc.Failure.FailureCode wire_failure = 2;
+
+    /*
+    FailureDetail provides additional information about the reason for the
+    failure. This detail enriches the information provided by the wire message
+    and may be 'no detail' if the wire message requires no additional metadata.
+    */
+    FailureDetail failure_detail = 3;
+
+    // A string representation of the link failure.
+    string failure_string = 4;
+}
+
+enum FailureDetail {
+    UNKNOWN = 0;
+    NO_DETAIL = 1;
+    ONION_DECODE = 2;
+    LINK_NOT_ELIGIBLE = 3;
+    ON_CHAIN_TIMEOUT = 4;
+    HTLC_EXCEEDS_MAX = 5;
+    INSUFFICIENT_BALANCE = 6;
+    INCOMPLETE_FORWARD = 7;
+    HTLC_ADD_FAILED = 8;
+    FORWARDS_DISABLED = 9;
+    INVOICE_CANCELED = 10;
+    INVOICE_UNDERPAID = 11;
+    INVOICE_EXPIRY_TOO_SOON = 12;
+    INVOICE_NOT_OPEN = 13;
+    MPP_INVOICE_TIMEOUT = 14;
+    ADDRESS_MISMATCH = 15;
+    SET_TOTAL_MISMATCH = 16;
+    SET_TOTAL_TOO_LOW = 17;
+    SET_OVERPAID = 18;
+    UNKNOWN_INVOICE = 19;
+    INVALID_KEYSEND = 20;
+    MPP_IN_PROGRESS = 21;
+    CIRCULAR_ROUTE = 22;
+}
+
+enum PaymentState {
+    /*
+    Payment is still in flight.
+    */
+    IN_FLIGHT = 0;
+
+    /*
+    Payment completed successfully.
+    */
+    SUCCEEDED = 1;
+
+    /*
+    There are more routes to try, but the payment timeout was exceeded.
+    */
+    FAILED_TIMEOUT = 2;
+
+    /*
+    All possible routes were tried and failed permanently. Or were no
+    routes to the destination at all.
+    */
+    FAILED_NO_ROUTE = 3;
+
+    /*
+    A non-recoverable error has occurred.
+    */
+    FAILED_ERROR = 4;
+
+    /*
+    Payment details incorrect (unknown hash, invalid amt or
+    invalid final cltv delta)
+    */
+    FAILED_INCORRECT_PAYMENT_DETAILS = 5;
+
+    /*
+    Insufficient local balance.
+    */
+    FAILED_INSUFFICIENT_BALANCE = 6;
+}
+
+message PaymentStatus {
+    // Current state the payment is in.
+    PaymentState state = 1;
+
+    /*
+    The pre-image of the payment when state is SUCCEEDED.
+    */
+    bytes preimage = 2;
+
+    reserved 3;
+
+    /*
+    The HTLCs made in attempt to settle the payment [EXPERIMENTAL].
+    */
+    repeated lnrpc.HTLCAttempt htlcs = 4;
+}
+
+message CircuitKey {
+    /// The id of the channel that the is part of this circuit.
+    uint64 chan_id = 1;
+
+    /// The index of the incoming htlc in the incoming channel.
+    uint64 htlc_id = 2;
+}
+
+message ForwardHtlcInterceptRequest {
+    /*
+    The key of this forwarded htlc. It defines the incoming channel id and
+    the index in this channel.
+    */
+    CircuitKey incoming_circuit_key = 1;
+
+    // The incoming htlc amount.
+    uint64 incoming_amount_msat = 5;
+
+    // The incoming htlc expiry.
+    uint32 incoming_expiry = 6;
+
+    /*
+    The htlc payment hash. This value is not guaranteed to be unique per
+    request.
+    */
+    bytes payment_hash = 2;
+
+    // The requested outgoing channel id for this forwarded htlc. Because of
+    // non-strict forwarding, this isn't necessarily the channel over which the
+    // packet will be forwarded eventually. A different channel to the same peer
+    // may be selected as well.
+    uint64 outgoing_requested_chan_id = 7;
+
+    // The outgoing htlc amount.
+    uint64 outgoing_amount_msat = 3;
+
+    // The outgoing htlc expiry.
+    uint32 outgoing_expiry = 4;
+
+    // Any custom records that were present in the payload.
+    map<uint64, bytes> custom_records = 8;
+
+    // The onion blob for the next hop
+    bytes onion_blob = 9;
+
+    // The block height at which this htlc will be auto-failed to prevent the
+    // channel from force-closing.
+    int32 auto_fail_height = 10;
+
+    // The custom records of the peer's incoming p2p wire message.
+    map<uint64, bytes> in_wire_custom_records = 11;
+}
+
+/**
+ForwardHtlcInterceptResponse enables the caller to resolve a previously hold
+forward. The caller can choose either to:
+- `Resume`: Execute the default behavior (usually forward).
+- `ResumeModified`: Execute the default behavior (usually forward) with HTLC
+                    field modifications.
+- `Reject`: Fail the htlc backwards.
+- `Settle`: Settle this htlc with a given preimage.
+*/
+message ForwardHtlcInterceptResponse {
+    /**
+    The key of this forwarded htlc. It defines the incoming channel id and
+    the index in this channel.
+    */
+    CircuitKey incoming_circuit_key = 1;
+
+    // The resolve action for this intercepted htlc.
+    ResolveHoldForwardAction action = 2;
+
+    // The preimage in case the resolve action is Settle.
+    bytes preimage = 3;
+
+    // Encrypted failure message in case the resolve action is Fail.
+    //
+    // If failure_message is specified, the failure_code field must be set
+    // to zero.
+    bytes failure_message = 4;
+
+    // Return the specified failure code in case the resolve action is Fail. The
+    // message data fields are populated automatically.
+    //
+    // If a non-zero failure_code is specified, failure_message must not be set.
+    //
+    // For backwards-compatibility reasons, TEMPORARY_CHANNEL_FAILURE is the
+    // default value for this field.
+    lnrpc.Failure.FailureCode failure_code = 5;
+
+    // The amount that was set on the p2p wire message of the incoming HTLC.
+    // This field is ignored if the action is not RESUME_MODIFIED or the amount
+    // is zero.
+    uint64 in_amount_msat = 6;
+
+    // The amount to set on the p2p wire message of the resumed HTLC. This field
+    // is ignored if the action is not RESUME_MODIFIED or the amount is zero.
+    uint64 out_amount_msat = 7;
+
+    // Any custom records that should be set on the p2p wire message message of
+    // the resumed HTLC. This field is ignored if the action is not
+    // RESUME_MODIFIED.
+    //
+    // This map will merge with the existing set of custom records (if any),
+    // replacing any conflicting types. Note that there currently is no support
+    // for deleting existing custom records (they can only be replaced).
+    map<uint64, bytes> out_wire_custom_records = 8;
+}
+
+enum ResolveHoldForwardAction {
+    // SETTLE is an action that is used to settle an HTLC instead of forwarding
+    // it.
+    SETTLE = 0;
+
+    // FAIL is an action that is used to fail an HTLC backwards.
+    FAIL = 1;
+
+    // RESUME is an action that is used to resume a forward HTLC.
+    RESUME = 2;
+
+    // RESUME_MODIFIED is an action that is used to resume a hold forward HTLC
+    // with modifications specified during interception.
+    RESUME_MODIFIED = 3;
+}
+
+message UpdateChanStatusRequest {
+    lnrpc.ChannelPoint chan_point = 1;
+
+    ChanStatusAction action = 2;
+}
+
+enum ChanStatusAction {
+    ENABLE = 0;
+    DISABLE = 1;
+    AUTO = 2;
+}
+
+message UpdateChanStatusResponse {
+}
+
+message AddAliasesRequest {
+    repeated lnrpc.AliasMap alias_maps = 1;
+}
+
+message AddAliasesResponse {
+    repeated lnrpc.AliasMap alias_maps = 1;
+}
+
+message DeleteAliasesRequest {
+    repeated lnrpc.AliasMap alias_maps = 1;
+}
+
+message DeleteAliasesResponse {
+    repeated lnrpc.AliasMap alias_maps = 1;
+}
+
+message FindBaseAliasRequest {
+    // The alias we want to look up the base scid for.
+    uint64 alias = 1;
+}
+
+message FindBaseAliasResponse {
+    // The base scid that resulted from the base scid look up.
+    uint64 base = 1;
+}

--- a/lampo-lnd/src/auth/macaroon.rs
+++ b/lampo-lnd/src/auth/macaroon.rs
@@ -1,0 +1,344 @@
+//! LND-compatible macaroon bakery for lampo's REST surface.
+//!
+//! Zeus treats the macaroon as an opaque hex credential in the
+//! `Grpc-Metadata-macaroon` header. We bake credentials with HMAC-SHA256
+//! chained caveats (entity/action permissions) and verify them fail-closed.
+
+use std::collections::HashSet;
+use std::fs::{self, OpenOptions};
+use std::io::Write;
+use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
+use std::path::{Path, PathBuf};
+
+use hmac::{Hmac, Mac};
+use rand::RngCore;
+use sha2::Sha256;
+use thiserror::Error;
+
+type HmacSha256 = Hmac<Sha256>;
+
+const ROOT_KEY_LEN: usize = 32;
+const MAX_MACAROON_BYTES: usize = 16 * 1024;
+
+/// LND-style entity/action permission.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct Permission {
+    pub entity: &'static str,
+    pub action: &'static str,
+}
+
+impl Permission {
+    pub const fn new(entity: &'static str, action: &'static str) -> Self {
+        Self { entity, action }
+    }
+
+    pub fn caveat(self) -> String {
+        format!("{}:{}", self.entity, self.action)
+    }
+
+    pub fn parse(raw: &str) -> Option<(String, String)> {
+        let (entity, action) = raw.split_once(':')?;
+        if entity.is_empty() || action.is_empty() {
+            return None;
+        }
+        Some((entity.to_string(), action.to_string()))
+    }
+}
+
+pub const INFO_READ: Permission = Permission::new("info", "read");
+pub const OFFCHAIN_READ: Permission = Permission::new("offchain", "read");
+pub const OFFCHAIN_WRITE: Permission = Permission::new("offchain", "write");
+pub const ONCHAIN_READ: Permission = Permission::new("onchain", "read");
+pub const ONCHAIN_WRITE: Permission = Permission::new("onchain", "write");
+pub const ADDRESS_READ: Permission = Permission::new("address", "read");
+pub const ADDRESS_WRITE: Permission = Permission::new("address", "write");
+pub const PEERS_READ: Permission = Permission::new("peers", "read");
+pub const PEERS_WRITE: Permission = Permission::new("peers", "write");
+pub const INVOICES_READ: Permission = Permission::new("invoices", "read");
+pub const INVOICES_WRITE: Permission = Permission::new("invoices", "write");
+
+/// Full admin permission set (LND admin.macaroon equivalent for our subset).
+pub const ADMIN_PERMS: &[Permission] = &[
+    INFO_READ,
+    OFFCHAIN_READ,
+    OFFCHAIN_WRITE,
+    ONCHAIN_READ,
+    ONCHAIN_WRITE,
+    ADDRESS_READ,
+    ADDRESS_WRITE,
+    PEERS_READ,
+    PEERS_WRITE,
+    INVOICES_READ,
+    INVOICES_WRITE,
+];
+
+pub const READONLY_PERMS: &[Permission] = &[
+    INFO_READ,
+    OFFCHAIN_READ,
+    ONCHAIN_READ,
+    ADDRESS_READ,
+    PEERS_READ,
+    INVOICES_READ,
+];
+
+pub const INVOICE_PERMS: &[Permission] = &[INVOICES_READ, INVOICES_WRITE, INFO_READ];
+
+#[derive(Debug, Error)]
+pub enum AuthError {
+    #[error("missing macaroon")]
+    Missing,
+    #[error("malformed macaroon")]
+    Malformed,
+    #[error("macaroon too large")]
+    TooLarge,
+    #[error("invalid macaroon signature")]
+    InvalidSignature,
+    #[error("permission denied")]
+    PermissionDenied,
+    #[error("unknown caveat: {0}")]
+    UnknownCaveat(String),
+    #[error("io error: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("{0}")]
+    Other(String),
+}
+
+#[derive(Clone)]
+pub struct MacaroonBakery {
+    root_key: [u8; ROOT_KEY_LEN],
+    macaroon_dir: PathBuf,
+}
+
+impl MacaroonBakery {
+    /// Load or create the bakery under `macaroon_dir`.
+    ///
+    /// Existing root keys are never silently rotated. File modes are forced to
+    /// owner-only when we create them.
+    pub fn load_or_create(macaroon_dir: impl AsRef<Path>) -> Result<Self, AuthError> {
+        let macaroon_dir = macaroon_dir.as_ref().to_path_buf();
+        ensure_secure_dir(&macaroon_dir)?;
+
+        let root_path = macaroon_dir.join("macaroon_root_key");
+        let root_key = if root_path.exists() {
+            load_root_key(&root_path)?
+        } else {
+            let mut key = [0u8; ROOT_KEY_LEN];
+            rand::thread_rng().fill_bytes(&mut key);
+            write_secret_file(&root_path, &key)?;
+            key
+        };
+
+        let bakery = Self {
+            root_key,
+            macaroon_dir,
+        };
+        bakery.ensure_default_macaroons()?;
+        Ok(bakery)
+    }
+
+    pub fn macaroon_dir(&self) -> &Path {
+        &self.macaroon_dir
+    }
+
+    pub fn admin_macaroon_path(&self) -> PathBuf {
+        self.macaroon_dir.join("admin.macaroon")
+    }
+
+    fn ensure_default_macaroons(&self) -> Result<(), AuthError> {
+        self.write_macaroon_if_missing("admin.macaroon", ADMIN_PERMS)?;
+        self.write_macaroon_if_missing("readonly.macaroon", READONLY_PERMS)?;
+        self.write_macaroon_if_missing("invoice.macaroon", INVOICE_PERMS)?;
+        Ok(())
+    }
+
+    fn write_macaroon_if_missing(&self, name: &str, perms: &[Permission]) -> Result<(), AuthError> {
+        let path = self.macaroon_dir.join(name);
+        if path.exists() {
+            return Ok(());
+        }
+        let bytes = self.bake(name, perms)?;
+        write_secret_file(&path, &bytes)?;
+        Ok(())
+    }
+
+    pub fn bake(&self, identifier: &str, perms: &[Permission]) -> Result<Vec<u8>, AuthError> {
+        let mut caveats: Vec<String> = perms.iter().map(|p| p.caveat()).collect();
+        caveats.sort();
+        caveats.dedup();
+
+        let mut payload = Vec::new();
+        payload.extend_from_slice(b"lampo-macaroon-v1\0");
+        payload.extend_from_slice(identifier.as_bytes());
+        payload.push(0);
+        for caveat in &caveats {
+            payload.extend_from_slice(caveat.as_bytes());
+            payload.push(0);
+        }
+
+        let mut mac = HmacSha256::new_from_slice(&self.root_key)
+            .map_err(|e| AuthError::Other(e.to_string()))?;
+        mac.update(&payload);
+        let sig = mac.finalize().into_bytes();
+
+        payload.extend_from_slice(&sig);
+        Ok(payload)
+    }
+
+    pub fn verify_hex(&self, hex_macaroon: &str, required: Permission) -> Result<(), AuthError> {
+        if hex_macaroon.len() > MAX_MACAROON_BYTES * 2 {
+            return Err(AuthError::TooLarge);
+        }
+        let bytes = hex::decode(hex_macaroon.trim()).map_err(|_| AuthError::Malformed)?;
+        self.verify(&bytes, required)
+    }
+
+    pub fn verify(&self, macaroon: &[u8], required: Permission) -> Result<(), AuthError> {
+        if macaroon.len() > MAX_MACAROON_BYTES {
+            return Err(AuthError::TooLarge);
+        }
+        if macaroon.len() < 32 + 18 {
+            return Err(AuthError::Malformed);
+        }
+
+        let (payload, sig) = macaroon.split_at(macaroon.len() - 32);
+        let mut mac = HmacSha256::new_from_slice(&self.root_key)
+            .map_err(|e| AuthError::Other(e.to_string()))?;
+        mac.update(payload);
+        mac.verify_slice(sig)
+            .map_err(|_| AuthError::InvalidSignature)?;
+
+        if !payload.starts_with(b"lampo-macaroon-v1\0") {
+            return Err(AuthError::Malformed);
+        }
+        let rest = &payload["lampo-macaroon-v1\0".len()..];
+        let parts: Vec<&[u8]> = rest.split(|b| *b == 0).filter(|p| !p.is_empty()).collect();
+        if parts.is_empty() {
+            return Err(AuthError::Malformed);
+        }
+
+        // parts[0] = identifier; remaining = caveats
+        let mut granted: HashSet<(String, String)> = HashSet::new();
+        for raw in &parts[1..] {
+            let text = std::str::from_utf8(raw).map_err(|_| AuthError::Malformed)?;
+            let Some((entity, action)) = Permission::parse(text) else {
+                return Err(AuthError::UnknownCaveat(text.to_string()));
+            };
+            granted.insert((entity, action));
+        }
+
+        if granted.contains(&(required.entity.to_string(), required.action.to_string())) {
+            Ok(())
+        } else {
+            Err(AuthError::PermissionDenied)
+        }
+    }
+
+    pub fn admin_macaroon_hex(&self) -> Result<String, AuthError> {
+        let bytes = fs::read(self.admin_macaroon_path())?;
+        Ok(hex::encode(bytes))
+    }
+}
+
+fn ensure_secure_dir(path: &Path) -> Result<(), AuthError> {
+    if path.exists() {
+        let meta = fs::metadata(path)?;
+        if !meta.is_dir() {
+            return Err(AuthError::Other(format!(
+                "macaroon path is not a directory: {}",
+                path.display()
+            )));
+        }
+    } else {
+        fs::create_dir_all(path)?;
+    }
+    let mut perms = fs::metadata(path)?.permissions();
+    perms.set_mode(0o700);
+    fs::set_permissions(path, perms)?;
+    Ok(())
+}
+
+fn load_root_key(path: &Path) -> Result<[u8; ROOT_KEY_LEN], AuthError> {
+    let meta = fs::symlink_metadata(path)?;
+    if meta.file_type().is_symlink() {
+        return Err(AuthError::Other(
+            "macaroon root key must not be a symlink".into(),
+        ));
+    }
+    let bytes = fs::read(path)?;
+    if bytes.len() != ROOT_KEY_LEN {
+        return Err(AuthError::Other(format!(
+            "macaroon root key must be {ROOT_KEY_LEN} bytes"
+        )));
+    }
+    let mut key = [0u8; ROOT_KEY_LEN];
+    key.copy_from_slice(&bytes);
+    Ok(key)
+}
+
+fn write_secret_file(path: &Path, bytes: &[u8]) -> Result<(), AuthError> {
+    if path.exists() {
+        return Err(AuthError::Other(format!(
+            "refusing to overwrite existing secret {}",
+            path.display()
+        )));
+    }
+    let mut file = OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .mode(0o600)
+        .open(path)?;
+    file.write_all(bytes)?;
+    file.sync_all()?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[test]
+    fn bake_and_verify_admin() {
+        let dir = tempdir().unwrap();
+        let bakery = MacaroonBakery::load_or_create(dir.path()).unwrap();
+        let hex = bakery.admin_macaroon_hex().unwrap();
+        bakery.verify_hex(&hex, INFO_READ).unwrap();
+        bakery.verify_hex(&hex, OFFCHAIN_WRITE).unwrap();
+    }
+
+    #[test]
+    fn readonly_cannot_pay() {
+        let dir = tempdir().unwrap();
+        let bakery = MacaroonBakery::load_or_create(dir.path()).unwrap();
+        let bytes = std::fs::read(dir.path().join("readonly.macaroon")).unwrap();
+        let hex = hex::encode(bytes);
+        bakery.verify_hex(&hex, INFO_READ).unwrap();
+        assert!(matches!(
+            bakery.verify_hex(&hex, OFFCHAIN_WRITE),
+            Err(AuthError::PermissionDenied)
+        ));
+    }
+
+    #[test]
+    fn tampered_macaroon_rejected() {
+        let dir = tempdir().unwrap();
+        let bakery = MacaroonBakery::load_or_create(dir.path()).unwrap();
+        let mut hex = bakery.admin_macaroon_hex().unwrap();
+        // Flip last nibble.
+        let last = hex.pop().unwrap();
+        hex.push(if last == '0' { '1' } else { '0' });
+        assert!(matches!(
+            bakery.verify_hex(&hex, INFO_READ),
+            Err(AuthError::InvalidSignature)
+        ));
+    }
+
+    #[test]
+    fn restart_reuses_root_key() {
+        let dir = tempdir().unwrap();
+        let first = MacaroonBakery::load_or_create(dir.path()).unwrap();
+        let hex = first.admin_macaroon_hex().unwrap();
+        let second = MacaroonBakery::load_or_create(dir.path()).unwrap();
+        second.verify_hex(&hex, INFO_READ).unwrap();
+    }
+}

--- a/lampo-lnd/src/auth/macaroon.rs
+++ b/lampo-lnd/src/auth/macaroon.rs
@@ -185,14 +185,42 @@ impl MacaroonBakery {
     }
 
     pub fn verify_hex(&self, hex_macaroon: &str, required: Permission) -> Result<(), AuthError> {
+        let granted = self.permissions_from_hex(hex_macaroon)?;
+        if granted.contains(&(required.entity.to_string(), required.action.to_string())) {
+            Ok(())
+        } else {
+            Err(AuthError::PermissionDenied)
+        }
+    }
+
+    /// Verify the macaroon's signature and caveat encoding without requiring
+    /// a particular permission. Route handlers perform the authorization
+    /// decision after middleware has rejected malformed credentials.
+    pub fn verify_hex_signature(&self, hex_macaroon: &str) -> Result<(), AuthError> {
+        self.permissions_from_hex(hex_macaroon).map(|_| ())
+    }
+
+    fn permissions_from_hex(
+        &self,
+        hex_macaroon: &str,
+    ) -> Result<HashSet<(String, String)>, AuthError> {
         if hex_macaroon.len() > MAX_MACAROON_BYTES * 2 {
             return Err(AuthError::TooLarge);
         }
         let bytes = hex::decode(hex_macaroon.trim()).map_err(|_| AuthError::Malformed)?;
-        self.verify(&bytes, required)
+        self.permissions(&bytes)
     }
 
     pub fn verify(&self, macaroon: &[u8], required: Permission) -> Result<(), AuthError> {
+        let granted = self.permissions(macaroon)?;
+        if granted.contains(&(required.entity.to_string(), required.action.to_string())) {
+            Ok(())
+        } else {
+            Err(AuthError::PermissionDenied)
+        }
+    }
+
+    fn permissions(&self, macaroon: &[u8]) -> Result<HashSet<(String, String)>, AuthError> {
         if macaroon.len() > MAX_MACAROON_BYTES {
             return Err(AuthError::TooLarge);
         }
@@ -226,11 +254,7 @@ impl MacaroonBakery {
             granted.insert((entity, action));
         }
 
-        if granted.contains(&(required.entity.to_string(), required.action.to_string())) {
-            Ok(())
-        } else {
-            Err(AuthError::PermissionDenied)
-        }
+        Ok(granted)
     }
 
     pub fn admin_macaroon_hex(&self) -> Result<String, AuthError> {
@@ -317,6 +341,14 @@ mod tests {
             bakery.verify_hex(&hex, OFFCHAIN_WRITE),
             Err(AuthError::PermissionDenied)
         ));
+    }
+
+    #[test]
+    fn signature_check_accepts_least_privilege_macaroon() {
+        let dir = tempdir().unwrap();
+        let bakery = MacaroonBakery::load_or_create(dir.path()).unwrap();
+        let bytes = bakery.bake("payments-only", &[OFFCHAIN_WRITE]).unwrap();
+        bakery.verify_hex_signature(&hex::encode(bytes)).unwrap();
     }
 
     #[test]

--- a/lampo-lnd/src/auth/middleware.rs
+++ b/lampo-lnd/src/auth/middleware.rs
@@ -1,0 +1,97 @@
+//! Request middleware that rejects missing/invalid macaroons before
+//! Actix body extractors run. Per-route permission checks still happen
+//! inside handlers.
+
+use std::future::{ready, Ready};
+use std::rc::Rc;
+
+use actix_web::body::EitherBody;
+use actix_web::dev::{Service, ServiceRequest, ServiceResponse, Transform};
+use actix_web::web::Data;
+use actix_web::{Error, HttpResponse};
+use futures_util::future::LocalBoxFuture;
+
+use crate::auth::{AuthError, INFO_READ};
+use crate::routes::AppState;
+
+pub struct RequireMacaroon;
+
+impl<S, B> Transform<S, ServiceRequest> for RequireMacaroon
+where
+    S: Service<ServiceRequest, Response = ServiceResponse<B>, Error = Error> + 'static,
+    B: 'static,
+{
+    type Response = ServiceResponse<EitherBody<B>>;
+    type Error = Error;
+    type InitError = ();
+    type Transform = RequireMacaroonMiddleware<S>;
+    type Future = Ready<Result<Self::Transform, Self::InitError>>;
+
+    fn new_transform(&self, service: S) -> Self::Future {
+        ready(Ok(RequireMacaroonMiddleware {
+            service: Rc::new(service),
+        }))
+    }
+}
+
+pub struct RequireMacaroonMiddleware<S> {
+    service: Rc<S>,
+}
+
+impl<S, B> Service<ServiceRequest> for RequireMacaroonMiddleware<S>
+where
+    S: Service<ServiceRequest, Response = ServiceResponse<B>, Error = Error> + 'static,
+    B: 'static,
+{
+    type Response = ServiceResponse<EitherBody<B>>;
+    type Error = Error;
+    type Future = LocalBoxFuture<'static, Result<Self::Response, Self::Error>>;
+
+    actix_web::dev::forward_ready!(service);
+
+    fn call(&self, req: ServiceRequest) -> Self::Future {
+        let service = self.service.clone();
+
+        Box::pin(async move {
+            let bakery = req.app_data::<Data<AppState>>().map(|s| s.bakery.clone());
+
+            let Some(bakery) = bakery else {
+                let resp = actix_web::HttpResponse::InternalServerError().json(serde_json::json!({
+                    "code": 500,
+                    "message": "missing app state",
+                    "details": []
+                }));
+                return Ok(req.into_response(resp).map_into_right_body());
+            };
+
+            // All default macaroons include info:read. Verifying it here
+            // rejects missing/tampered credentials before JSON body parsing.
+            if let Err(err) = crate::routes::authorize(req.request(), &bakery, INFO_READ) {
+                let (status, message) = match err {
+                    AuthError::Missing
+                    | AuthError::Malformed
+                    | AuthError::InvalidSignature
+                    | AuthError::TooLarge => {
+                        (actix_web::http::StatusCode::UNAUTHORIZED, err.to_string())
+                    }
+                    AuthError::PermissionDenied | AuthError::UnknownCaveat(_) => {
+                        (actix_web::http::StatusCode::FORBIDDEN, err.to_string())
+                    }
+                    AuthError::Io(_) | AuthError::Other(_) => (
+                        actix_web::http::StatusCode::INTERNAL_SERVER_ERROR,
+                        err.to_string(),
+                    ),
+                };
+                let resp = actix_web::HttpResponse::build(status).json(serde_json::json!({
+                    "code": status.as_u16(),
+                    "message": message,
+                    "details": []
+                }));
+                return Ok(req.into_response(resp).map_into_right_body());
+            }
+
+            let res = service.call(req).await?;
+            Ok(res.map_into_left_body())
+        })
+    }
+}

--- a/lampo-lnd/src/auth/middleware.rs
+++ b/lampo-lnd/src/auth/middleware.rs
@@ -11,7 +11,7 @@ use actix_web::web::Data;
 use actix_web::Error;
 use futures_util::future::LocalBoxFuture;
 
-use crate::auth::{AuthError, INFO_READ};
+use crate::auth::AuthError;
 use crate::routes::AppState;
 
 pub struct RequireMacaroon;
@@ -64,9 +64,11 @@ where
                 return Ok(req.into_response(resp).map_into_right_body());
             };
 
-            // All default macaroons include info:read. Verifying it here
-            // rejects missing/tampered credentials before JSON body parsing.
-            if let Err(err) = crate::routes::authorize(req.request(), &bakery, INFO_READ) {
+            // Authenticate before body parsing. Authorization remains
+            // route-specific so least-privilege macaroons are usable.
+            let result = crate::routes::extract_macaroon_hex(req.request())
+                .and_then(|macaroon| bakery.verify_hex_signature(&macaroon));
+            if let Err(err) = result {
                 let (status, message) = match err {
                     AuthError::Missing
                     | AuthError::Malformed

--- a/lampo-lnd/src/auth/middleware.rs
+++ b/lampo-lnd/src/auth/middleware.rs
@@ -8,7 +8,7 @@ use std::rc::Rc;
 use actix_web::body::EitherBody;
 use actix_web::dev::{Service, ServiceRequest, ServiceResponse, Transform};
 use actix_web::web::Data;
-use actix_web::{Error, HttpResponse};
+use actix_web::Error;
 use futures_util::future::LocalBoxFuture;
 
 use crate::auth::{AuthError, INFO_READ};

--- a/lampo-lnd/src/auth/mod.rs
+++ b/lampo-lnd/src/auth/mod.rs
@@ -1,0 +1,9 @@
+mod macaroon;
+mod middleware;
+
+pub use macaroon::{
+    AuthError, MacaroonBakery, Permission, ADDRESS_WRITE, ADMIN_PERMS, INFO_READ, INVOICES_READ,
+    INVOICES_WRITE, OFFCHAIN_READ, OFFCHAIN_WRITE, ONCHAIN_READ, ONCHAIN_WRITE, PEERS_READ,
+    PEERS_WRITE, READONLY_PERMS,
+};
+pub use middleware::RequireMacaroon;

--- a/lampo-lnd/src/convert.rs
+++ b/lampo-lnd/src/convert.rs
@@ -1,0 +1,31 @@
+//! Conversion helpers between lampo models and LND proto messages.
+
+pub fn chain_network(network: &str) -> String {
+    match network {
+        "bitcoin" | "mainnet" => "mainnet".to_string(),
+        "testnet" => "testnet".to_string(),
+        "regtest" => "regtest".to_string(),
+        "signet" => "signet".to_string(),
+        other => other.to_string(),
+    }
+}
+
+/// Accept Zeus/LND path params as either hex or base64 payment hashes.
+pub fn normalize_r_hash(raw: &str) -> Option<String> {
+    let trimmed = raw.trim();
+    if trimmed.len() == 64 && trimmed.chars().all(|c| c.is_ascii_hexdigit()) {
+        return Some(trimmed.to_lowercase());
+    }
+    use base64::Engine;
+    let engine = base64::engine::general_purpose::STANDARD;
+    let engine_url = base64::engine::general_purpose::URL_SAFE_NO_PAD;
+    if let Ok(bytes) = engine
+        .decode(trimmed)
+        .or_else(|_| engine_url.decode(trimmed))
+    {
+        if bytes.len() == 32 {
+            return Some(hex::encode(bytes));
+        }
+    }
+    None
+}

--- a/lampo-lnd/src/lib.rs
+++ b/lampo-lnd/src/lib.rs
@@ -1,0 +1,23 @@
+//! LND-compatible REST API for lampo.
+//!
+//! Approach C: proto-derived (`prost`/`pbjson`) types, handwritten Actix
+//! routes, TLS + macaroon bakery. Zeus talks to this surface as if it were
+//! a remote LND node.
+
+pub mod auth;
+pub mod convert;
+pub mod routes;
+pub mod server;
+pub mod tls;
+
+#[cfg(test)]
+mod wire_tests;
+
+pub mod lnrpc {
+    include!(concat!(env!("OUT_DIR"), "/lnrpc.rs"));
+    include!(concat!(env!("OUT_DIR"), "/lnrpc.serde.rs"));
+}
+
+pub use auth::{AuthError, MacaroonBakery, Permission};
+pub use server::{run, spawn, LndRestConfig};
+pub use tls::{TlsError, TlsMaterial};

--- a/lampo-lnd/src/routes/handlers.rs
+++ b/lampo-lnd/src/routes/handlers.rs
@@ -90,6 +90,17 @@ async fn get_info(req: HttpRequest, state: web::Data<AppState>) -> HttpResponse 
         .to_string();
     let alias = lampod.conf().alias.clone().unwrap_or_default();
     let network = convert::chain_network(&lampod.conf().network.to_string());
+    let channels = lampod.channel_manager().manager().list_channels();
+    let num_pending_channels = channels.iter().filter(|c| !c.is_channel_ready).count() as u32;
+    let num_active_channels = channels.iter().filter(|c| c.is_usable).count() as u32;
+    let num_inactive_channels = channels
+        .iter()
+        .filter(|c| c.is_channel_ready && !c.is_usable)
+        .count() as u32;
+    let synced_to_chain = match (height, lampod.wallet_manager().wallet_tips().await) {
+        (Some(best_height), Ok(wallet_height)) => wallet_height.to_consensus_u32() >= best_height,
+        _ => false,
+    };
     let mut uris = Vec::new();
     if let Some(addr) = lampod.conf().announce_addr.clone() {
         uris.push(format!("{}@{}:{}", node_id, addr, lampod.conf().port));
@@ -101,14 +112,14 @@ async fn get_info(req: HttpRequest, state: web::Data<AppState>) -> HttpResponse 
         identity_pubkey: node_id,
         alias,
         color: "#3399ff".to_string(),
-        num_pending_channels: 0,
-        num_active_channels: lampod.channel_manager().list_channels().channels.len() as u32,
-        num_inactive_channels: 0,
+        num_pending_channels,
+        num_active_channels,
+        num_inactive_channels,
         num_peers: lampod.peer_manager().manager().list_peers().len() as u32,
         block_height: height.unwrap_or_default(),
         block_hash: block_hash.to_string(),
         best_header_timestamp: 0,
-        synced_to_chain: true,
+        synced_to_chain,
         synced_to_graph: true,
         chains: vec![lnrpc::Chain {
             network,
@@ -195,7 +206,7 @@ async fn list_channels(req: HttpRequest, state: web::Data<AppState>) -> HttpResp
                 .map(|o| format!("{}:{}", o.txid, o.index))
                 .unwrap_or_default();
             lnrpc::Channel {
-                active: c.is_channel_ready,
+                active: c.is_usable,
                 remote_pubkey: c.counterparty.node_id.to_string(),
                 channel_point,
                 chan_id: c.short_channel_id.unwrap_or_default(),
@@ -502,9 +513,14 @@ async fn decode_payreq(
                 .get("expiry_time")
                 .and_then(|v| v.as_u64())
                 .unwrap_or(0);
+            let payment_hash = value
+                .get("payment_hash")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string();
             proto_json(&lnrpc::PayReq {
                 destination,
-                payment_hash: String::new(),
+                payment_hash,
                 num_satoshis: (amount_msat / 1000) as i64,
                 timestamp: 0,
                 expiry: expiry as i64,
@@ -532,12 +548,55 @@ struct SendPaymentBody {
     amt: i64,
     #[serde(default)]
     amt_msat: i64,
+    #[serde(default, alias = "fee_limit_sat")]
+    fee_limit_sat: i64,
+    #[serde(default, alias = "fee_limit_msat")]
+    fee_limit_msat: i64,
 }
 
-async fn pay_invoice(
-    state: &AppState,
-    body: &SendPaymentBody,
-) -> Result<lnrpc::SendResponse, String> {
+struct PaymentOutcome {
+    response: lnrpc::SendResponse,
+    value_msat: u64,
+    fee_msat: u64,
+}
+
+fn max_fee_msat(body: &SendPaymentBody) -> Result<u64, String> {
+    if body.fee_limit_sat < 0 || body.fee_limit_msat < 0 {
+        return Err("fee limits must not be negative".into());
+    }
+    if body.fee_limit_sat > 0 && body.fee_limit_msat > 0 {
+        return Err("fee_limit_sat and fee_limit_msat are mutually exclusive".into());
+    }
+    if body.fee_limit_msat > 0 {
+        Ok(body.fee_limit_msat as u64)
+    } else {
+        (body.fee_limit_sat as u64)
+            .checked_mul(1000)
+            .ok_or_else(|| "fee_limit_sat is too large".to_string())
+    }
+}
+
+fn route_value_and_fee(value: &JsonValue, fallback_value_msat: u64) -> (u64, u64) {
+    let path_hop_fees = value
+        .get("path")
+        .and_then(|v| v.as_array())
+        .map(|path| {
+            path.iter()
+                .filter_map(|hop| hop.get("hop_fee_msat").and_then(|fee| fee.as_u64()))
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
+    // LDK stores the delivered value in the final non-blinded RouteHop's
+    // `fee_msat`; preceding hops contain routing fees.
+    let routed_value_msat = path_hop_fees.last().copied();
+    let total_hop_msat: u64 = path_hop_fees.iter().sum();
+    (
+        routed_value_msat.unwrap_or(fallback_value_msat),
+        total_hop_msat.saturating_sub(routed_value_msat.unwrap_or(0)),
+    )
+}
+
+async fn pay_invoice(state: &AppState, body: &SendPaymentBody) -> Result<PaymentOutcome, String> {
     if body.payment_request.is_empty() {
         return Err("payment_request is required".into());
     }
@@ -548,9 +607,18 @@ async fn pay_invoice(
     } else {
         None
     };
+    let max_fee_msat = max_fee_msat(body)?;
+    let invoice_amount_msat = state
+        .lampod
+        .offchain_manager()
+        .decode_invoice(&body.payment_request)
+        .ok()
+        .and_then(|invoice| invoice.amount_milli_satoshis());
+    let value_msat = invoice_amount_msat.or(amount_msat).unwrap_or(0);
     let request = request::Pay {
         invoice_str: body.payment_request.clone(),
         amount: amount_msat,
+        max_fee_msat: Some(max_fee_msat),
         bolt12: None,
         timeout: Default::default(),
     };
@@ -575,17 +643,28 @@ async fn pay_invoice(
         .and_then(|v| v.as_str())
         .unwrap_or("")
         .to_string();
+    let (value_msat, fee_msat) = route_value_and_fee(&value, value_msat);
 
     if state_str != "Success" {
         return Err(format!("payment failed with state {state_str}"));
     }
 
-    Ok(lnrpc::SendResponse {
-        payment_error: String::new(),
-        payment_preimage: Bytes::from(hex::decode(payment_preimage).unwrap_or_default()),
-        payment_hash: Bytes::from(hex::decode(payment_hash).unwrap_or_default()),
-        payment_route: None,
-        ..Default::default()
+    Ok(PaymentOutcome {
+        response: lnrpc::SendResponse {
+            payment_error: String::new(),
+            payment_preimage: Bytes::from(hex::decode(payment_preimage).unwrap_or_default()),
+            payment_hash: Bytes::from(hex::decode(payment_hash).unwrap_or_default()),
+            payment_route: Some(lnrpc::Route {
+                total_fees: (fee_msat / 1000) as i64,
+                total_amt: (value_msat.saturating_add(fee_msat) / 1000) as i64,
+                total_fees_msat: fee_msat as i64,
+                total_amt_msat: value_msat.saturating_add(fee_msat) as i64,
+                ..Default::default()
+            }),
+            ..Default::default()
+        },
+        value_msat,
+        fee_msat,
     })
 }
 
@@ -599,8 +678,11 @@ async fn send_payment_sync(
         return auth_error(e);
     }
     match pay_invoice(&state, &body).await {
-        Ok(resp) => proto_json(&resp),
-        Err(e) => internal_error(e),
+        Ok(outcome) => proto_json(&outcome.response),
+        Err(e) => proto_json(&lnrpc::SendResponse {
+            payment_error: e,
+            ..Default::default()
+        }),
     }
 }
 
@@ -615,16 +697,16 @@ async fn router_send(
         return auth_error(e);
     }
     match pay_invoice(&state, &body).await {
-        Ok(resp) => {
+        Ok(outcome) => {
             use base64::Engine;
             let engine = base64::engine::general_purpose::STANDARD;
             let status = json::json!({
                 "result": {
                     "status": "SUCCEEDED",
-                    "paymentHash": engine.encode(&resp.payment_hash),
-                    "paymentPreimage": engine.encode(&resp.payment_preimage),
-                    "feeMsat": "0",
-                    "valueMsat": "0"
+                    "paymentHash": engine.encode(&outcome.response.payment_hash),
+                    "paymentPreimage": engine.encode(&outcome.response.payment_preimage),
+                    "feeMsat": outcome.fee_msat.to_string(),
+                    "valueMsat": outcome.value_msat.to_string()
                 }
             });
             let line = format!("{}\n", status);
@@ -694,7 +776,7 @@ async fn open_channel(
     {
         Ok(value) => {
             let txid = value
-                .get("tx")
+                .get("txid")
                 .and_then(|v| v.as_str())
                 .unwrap_or("")
                 .to_string();
@@ -741,7 +823,22 @@ async fn close_channel(
     )
     .await
     {
-        Ok(_) => HttpResponse::Ok().json(json::json!({})),
+        Ok(_) => {
+            let update = lnrpc::CloseStatusUpdate {
+                update: Some(lnrpc::close_status_update::Update::ChanClose(
+                    lnrpc::ChannelCloseUpdate {
+                        success: true,
+                        ..Default::default()
+                    },
+                )),
+            };
+            match serde_json::to_value(update) {
+                Ok(update) => HttpResponse::Ok()
+                    .content_type("application/json")
+                    .body(format!("{}\n", json::json!({ "result": update }))),
+                Err(e) => internal_error(e),
+            }
+        }
         Err(e) => internal_error(e),
     }
 }
@@ -760,4 +857,38 @@ async fn list_transactions(req: HttpRequest, state: web::Data<AppState>) -> Http
         return auth_error(e);
     }
     proto_json(&lnrpc::TransactionDetails::default())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_zeus_fee_limit_and_payment_request() {
+        let body: SendPaymentBody = serde_json::from_value(json::json!({
+            "paymentRequest": "lnbc1...",
+            "feeLimitMsat": 1234
+        }))
+        .unwrap();
+        assert_eq!(body.payment_request, "lnbc1...");
+        assert_eq!(max_fee_msat(&body).unwrap(), 1234);
+    }
+
+    #[test]
+    fn zero_fee_limit_is_preserved() {
+        let body: SendPaymentBody =
+            serde_json::from_value(json::json!({ "paymentRequest": "lnbc1..." })).unwrap();
+        assert_eq!(max_fee_msat(&body).unwrap(), 0);
+    }
+
+    #[test]
+    fn derives_value_and_fee_from_ldk_route_hops() {
+        let result = json::json!({
+            "path": [
+                { "hop_fee_msat": 1250 },
+                { "hop_fee_msat": 100_000 }
+            ]
+        });
+        assert_eq!(route_value_and_fee(&result, 0), (100_000, 1250));
+    }
 }

--- a/lampo-lnd/src/routes/handlers.rs
+++ b/lampo-lnd/src/routes/handlers.rs
@@ -614,6 +614,13 @@ where
     }
 }
 
+fn deserialize_i64<'de, D>(deserializer: D) -> Result<i64, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    deserialize_optional_i64(deserializer).map(Option::unwrap_or_default)
+}
+
 #[derive(Clone, Copy)]
 enum PaymentEndpoint {
     Sync,
@@ -847,8 +854,18 @@ struct OpenChannelBody {
     node_pubkey_string: String,
     #[serde(default, alias = "node_pubkey")]
     node_pubkey: String,
-    #[serde(default, alias = "local_funding_amount")]
+    #[serde(
+        default,
+        alias = "local_funding_amount",
+        deserialize_with = "deserialize_i64"
+    )]
     local_funding_amount: i64,
+    #[serde(
+        default,
+        alias = "push_sat",
+        deserialize_with = "deserialize_optional_i64"
+    )]
+    push_sat: Option<i64>,
     #[serde(default)]
     private: bool,
 }
@@ -872,6 +889,20 @@ fn open_channel_node_id(body: &OpenChannelBody) -> Result<String, String> {
         .map_err(|_| "nodePubkey is not a valid compressed public key".into())
 }
 
+fn open_channel_push_msat(body: &OpenChannelBody) -> Result<Option<u64>, String> {
+    let Some(push_sat) = body.push_sat else {
+        return Ok(None);
+    };
+    if push_sat < 0 || push_sat > body.local_funding_amount {
+        return Err("pushSat must be between zero and localFundingAmount".into());
+    }
+    u64::try_from(push_sat)
+        .map_err(|_| "pushSat must not be negative".to_string())?
+        .checked_mul(1000)
+        .map(Some)
+        .ok_or_else(|| "pushSat is too large".to_string())
+}
+
 #[post("/v1/channels")]
 async fn open_channel(
     req: HttpRequest,
@@ -888,13 +919,18 @@ async fn open_channel(
     if body.local_funding_amount <= 0 {
         return internal_error("local_funding_amount is required");
     }
+    let push_msat = match open_channel_push_msat(&body) {
+        Ok(push_msat) => push_msat,
+        Err(e) => return internal_error(e),
+    };
+    let expected_node_id = node_id.clone();
     let request = request::OpenChannel {
         node_id,
         amount: body.local_funding_amount as u64,
         public: !body.private,
         port: None,
         addr: None,
-        push_msat: None,
+        push_msat,
     };
     match lampod::jsonrpc::open_channel::json_fundchannel(
         &state.lampod,
@@ -908,13 +944,32 @@ async fn open_channel(
                 .and_then(|v| v.as_str())
                 .unwrap_or("")
                 .to_string();
+            let output_index = state
+                .lampod
+                .channel_manager()
+                .manager()
+                .list_channels()
+                .into_iter()
+                .filter(|channel| channel.counterparty.node_id.to_string() == expected_node_id)
+                .filter_map(|channel| channel.funding_txo)
+                .find(|outpoint| outpoint.txid.to_string() == txid)
+                .map(|outpoint| outpoint.index as u32);
+            let Some(output_index) = output_index else {
+                return internal_error("funding output index is not available");
+            };
             proto_json(&lnrpc::ChannelPoint {
                 funding_txid: Some(lnrpc::channel_point::FundingTxid::FundingTxidStr(txid)),
-                output_index: 0,
+                output_index,
             })
         }
         Err(e) => internal_error(e),
     }
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct CloseChannelQuery {
+    #[serde(default)]
+    force: bool,
 }
 
 #[delete("/v1/channels/{funding_txid}/{output_index}")]
@@ -922,6 +977,7 @@ async fn close_channel(
     req: HttpRequest,
     state: web::Data<AppState>,
     path: web::Path<(String, u32)>,
+    query: web::Query<CloseChannelQuery>,
 ) -> HttpResponse {
     if let Err(e) = authorize(&req, &state.bakery, OFFCHAIN_WRITE) {
         return auth_error(e);
@@ -944,6 +1000,7 @@ async fn close_channel(
     let request = request::CloseChannel {
         node_id: channel.counterparty.node_id.to_string(),
         channel_id: Some(channel.channel_id.to_string()),
+        force: query.force,
     };
     match lampod::jsonrpc::channels::json_close(
         &state.lampod,
@@ -1058,6 +1115,28 @@ mod tests {
         }))
         .unwrap();
         assert_eq!(open_channel_node_id(&body).unwrap(), public.to_string());
+    }
+
+    #[test]
+    fn preserves_channel_push_amount_and_force_close_query() {
+        let body: OpenChannelBody = serde_json::from_value(json::json!({
+            "nodePubkeyString": "02",
+            "localFundingAmount": "100000",
+            "pushSat": "25000"
+        }))
+        .unwrap();
+        assert_eq!(open_channel_push_msat(&body).unwrap(), Some(25_000_000));
+
+        let excessive: OpenChannelBody = serde_json::from_value(json::json!({
+            "nodePubkeyString": "02",
+            "localFundingAmount": 100000,
+            "pushSat": 100001
+        }))
+        .unwrap();
+        assert!(open_channel_push_msat(&excessive).is_err());
+
+        let query = web::Query::<CloseChannelQuery>::from_query("force=true").unwrap();
+        assert!(query.force);
     }
 
     #[test]

--- a/lampo-lnd/src/routes/handlers.rs
+++ b/lampo-lnd/src/routes/handlers.rs
@@ -1,0 +1,761 @@
+//! HTTP route handlers matching LND grpc-gateway paths.
+use actix_web::{delete, get, post, web, HttpRequest, HttpResponse};
+use bytes::Bytes;
+use lampo_common::json;
+use lampo_common::model::request;
+use serde::Deserialize;
+use serde_json::Value as JsonValue;
+
+use crate::auth::{
+    AuthError, ADDRESS_WRITE, INFO_READ, INVOICES_READ, INVOICES_WRITE, OFFCHAIN_READ,
+    OFFCHAIN_WRITE, ONCHAIN_READ, PEERS_READ, PEERS_WRITE,
+};
+use crate::convert;
+use crate::lnrpc;
+use crate::routes::{authorize, AppState};
+
+pub fn configure(cfg: &mut web::ServiceConfig) {
+    cfg.service(get_info)
+        .service(wallet_balance)
+        .service(channel_balance)
+        .service(list_channels)
+        .service(pending_channels)
+        .service(closed_channels)
+        .service(list_peers)
+        .service(connect_peer)
+        .service(new_address)
+        .service(add_invoice)
+        .service(lookup_invoice)
+        .service(list_invoices)
+        .service(decode_payreq)
+        .service(send_payment_sync)
+        .service(router_send)
+        .service(open_channel)
+        .service(close_channel)
+        .service(list_payments)
+        .service(list_transactions);
+}
+
+fn auth_error(err: AuthError) -> HttpResponse {
+    let (status, message) = match err {
+        AuthError::Missing
+        | AuthError::Malformed
+        | AuthError::InvalidSignature
+        | AuthError::TooLarge => (actix_web::http::StatusCode::UNAUTHORIZED, err.to_string()),
+        AuthError::PermissionDenied | AuthError::UnknownCaveat(_) => {
+            (actix_web::http::StatusCode::FORBIDDEN, err.to_string())
+        }
+        AuthError::Io(_) | AuthError::Other(_) => (
+            actix_web::http::StatusCode::INTERNAL_SERVER_ERROR,
+            err.to_string(),
+        ),
+    };
+    HttpResponse::build(status).json(json::json!({
+        "code": status.as_u16(),
+        "message": message,
+        "details": []
+    }))
+}
+
+fn internal_error(err: impl std::fmt::Debug) -> HttpResponse {
+    log::error!(target: "lampo-lnd", "handler error: {:?}", err);
+    HttpResponse::InternalServerError().json(json::json!({
+        "code": 500,
+        "message": format!("{:?}", err),
+        "details": []
+    }))
+}
+
+fn proto_json<T: serde::Serialize>(msg: &T) -> HttpResponse {
+    match serde_json::to_value(msg) {
+        Ok(v) => HttpResponse::Ok().json(v),
+        Err(e) => internal_error(e),
+    }
+}
+
+#[get("/v1/getinfo")]
+async fn get_info(req: HttpRequest, state: web::Data<AppState>) -> HttpResponse {
+    if let Err(e) = authorize(&req, &state.bakery, INFO_READ) {
+        return auth_error(e);
+    }
+    let lampod = &state.lampod;
+    let (block_hash, height) = match lampod.onchain_manager().backend.get_best_block().await {
+        Ok(v) => v,
+        Err(e) => return internal_error(e),
+    };
+    let node_id = lampod
+        .channel_manager()
+        .manager()
+        .get_our_node_id()
+        .to_string();
+    let alias = lampod.conf().alias.clone().unwrap_or_default();
+    let network = convert::chain_network(&lampod.conf().network.to_string());
+    let mut uris = Vec::new();
+    if let Some(addr) = lampod.conf().announce_addr.clone() {
+        uris.push(format!("{}@{}:{}", node_id, addr, lampod.conf().port));
+    }
+
+    let info = lnrpc::GetInfoResponse {
+        version: "0.18.5-beta".to_string(),
+        commit_hash: String::new(),
+        identity_pubkey: node_id,
+        alias,
+        color: "#3399ff".to_string(),
+        num_pending_channels: 0,
+        num_active_channels: lampod.channel_manager().list_channels().channels.len() as u32,
+        num_inactive_channels: 0,
+        num_peers: lampod.peer_manager().manager().list_peers().len() as u32,
+        block_height: height.unwrap_or_default(),
+        block_hash: block_hash.to_string(),
+        best_header_timestamp: 0,
+        synced_to_chain: true,
+        synced_to_graph: true,
+        chains: vec![lnrpc::Chain {
+            network,
+            ..Default::default()
+        }],
+        uris,
+        features: Default::default(),
+        ..Default::default()
+    };
+    proto_json(&info)
+}
+
+#[get("/v1/balance/blockchain")]
+async fn wallet_balance(req: HttpRequest, state: web::Data<AppState>) -> HttpResponse {
+    if let Err(e) = authorize(&req, &state.bakery, ONCHAIN_READ) {
+        return auth_error(e);
+    }
+    match state.lampod.wallet_manager().get_onchain_balance().await {
+        Ok(confirmed) => {
+            let confirmed = confirmed as i64;
+            let resp = lnrpc::WalletBalanceResponse {
+                total_balance: confirmed,
+                confirmed_balance: confirmed,
+                unconfirmed_balance: 0,
+                locked_balance: 0,
+                reserved_balance_anchor_chan: 0,
+                account_balance: Default::default(),
+            };
+            proto_json(&resp)
+        }
+        Err(e) => internal_error(e),
+    }
+}
+
+#[get("/v1/balance/channels")]
+async fn channel_balance(req: HttpRequest, state: web::Data<AppState>) -> HttpResponse {
+    if let Err(e) = authorize(&req, &state.bakery, OFFCHAIN_READ) {
+        return auth_error(e);
+    }
+    let channels = state.lampod.channel_manager().list_channels();
+    let local: i64 = channels
+        .channels
+        .iter()
+        .map(|c| (c.available_balance_for_send_msat / 1000) as i64)
+        .sum();
+    let remote: i64 = channels
+        .channels
+        .iter()
+        .map(|c| (c.available_balance_for_recv_msat / 1000) as i64)
+        .sum();
+    let resp = lnrpc::ChannelBalanceResponse {
+        local_balance: Some(lnrpc::Amount {
+            sat: local as u64,
+            msat: (local as u64) * 1000,
+        }),
+        remote_balance: Some(lnrpc::Amount {
+            sat: remote as u64,
+            msat: (remote as u64) * 1000,
+        }),
+        unsettled_local_balance: Some(lnrpc::Amount::default()),
+        unsettled_remote_balance: Some(lnrpc::Amount::default()),
+        pending_open_local_balance: Some(lnrpc::Amount::default()),
+        pending_open_remote_balance: Some(lnrpc::Amount::default()),
+        custom_channel_data: Bytes::new(),
+        ..Default::default()
+    };
+    proto_json(&resp)
+}
+
+#[get("/v1/channels")]
+async fn list_channels(req: HttpRequest, state: web::Data<AppState>) -> HttpResponse {
+    if let Err(e) = authorize(&req, &state.bakery, OFFCHAIN_READ) {
+        return auth_error(e);
+    }
+    let list: Vec<lnrpc::Channel> = state
+        .lampod
+        .channel_manager()
+        .manager()
+        .list_channels()
+        .into_iter()
+        .map(|c| {
+            let channel_point = c
+                .funding_txo
+                .map(|o| format!("{}:{}", o.txid, o.index))
+                .unwrap_or_default();
+            lnrpc::Channel {
+                active: c.is_channel_ready,
+                remote_pubkey: c.counterparty.node_id.to_string(),
+                channel_point,
+                chan_id: c.short_channel_id.unwrap_or_default(),
+                capacity: c.channel_value_satoshis as i64,
+                local_balance: (c.outbound_capacity_msat / 1000) as i64,
+                remote_balance: (c.inbound_capacity_msat / 1000) as i64,
+                private: !c.is_announced,
+                ..Default::default()
+            }
+        })
+        .collect();
+    proto_json(&lnrpc::ListChannelsResponse { channels: list })
+}
+
+#[get("/v1/channels/pending")]
+async fn pending_channels(req: HttpRequest, state: web::Data<AppState>) -> HttpResponse {
+    if let Err(e) = authorize(&req, &state.bakery, OFFCHAIN_READ) {
+        return auth_error(e);
+    }
+    proto_json(&lnrpc::PendingChannelsResponse::default())
+}
+
+#[get("/v1/channels/closed")]
+async fn closed_channels(req: HttpRequest, state: web::Data<AppState>) -> HttpResponse {
+    if let Err(e) = authorize(&req, &state.bakery, OFFCHAIN_READ) {
+        return auth_error(e);
+    }
+    proto_json(&lnrpc::ClosedChannelsResponse::default())
+}
+
+#[get("/v1/peers")]
+async fn list_peers(req: HttpRequest, state: web::Data<AppState>) -> HttpResponse {
+    if let Err(e) = authorize(&req, &state.bakery, PEERS_READ) {
+        return auth_error(e);
+    }
+    let peers = state
+        .lampod
+        .peer_manager()
+        .manager()
+        .list_peers()
+        .into_iter()
+        .map(|p| lnrpc::Peer {
+            pub_key: p.counterparty_node_id.to_string(),
+            address: String::new(),
+            bytes_sent: 0,
+            bytes_recv: 0,
+            sat_sent: 0,
+            sat_recv: 0,
+            inbound: false,
+            ping_time: 0,
+            sync_type: 0,
+            features: Default::default(),
+            errors: Vec::new(),
+            flap_count: 0,
+            last_flap_ns: 0,
+            last_ping_payload: Bytes::new(),
+        })
+        .collect();
+    proto_json(&lnrpc::ListPeersResponse { peers })
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct ConnectPeerBody {
+    addr: Option<ConnectAddr>,
+    #[serde(default)]
+    #[allow(dead_code)]
+    perm: bool,
+    #[serde(default)]
+    #[allow(dead_code)]
+    timeout: u64,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct ConnectAddr {
+    pubkey: Option<String>,
+    host: Option<String>,
+}
+
+#[post("/v1/peers")]
+async fn connect_peer(
+    req: HttpRequest,
+    state: web::Data<AppState>,
+    body: web::Json<JsonValue>,
+) -> HttpResponse {
+    if let Err(e) = authorize(&req, &state.bakery, PEERS_WRITE) {
+        return auth_error(e);
+    }
+    let parsed: ConnectPeerBody = match serde_json::from_value(body.into_inner()) {
+        Ok(v) => v,
+        Err(e) => return internal_error(e),
+    };
+    let Some(addr) = parsed.addr else {
+        return internal_error("missing addr");
+    };
+    let (pubkey, host) = match (addr.pubkey, addr.host) {
+        (Some(p), Some(h)) => (p, h),
+        _ => return internal_error("addr.pubkey and addr.host are required"),
+    };
+    // host may be "ip:port" or "ip"
+    let (ip, port) = if let Some((h, p)) = host.rsplit_once(':') {
+        (h.to_string(), p.parse::<u64>().unwrap_or(9735))
+    } else {
+        (host, 9735)
+    };
+    let request = request::Connect {
+        node_id: pubkey,
+        addr: ip,
+        port,
+    };
+    match lampod::jsonrpc::peer_control::json_connect(
+        &state.lampod,
+        &json::to_value(request).unwrap_or_default(),
+    )
+    .await
+    {
+        Ok(_) => proto_json(&lnrpc::ConnectPeerResponse::default()),
+        Err(e) => internal_error(e),
+    }
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct NewAddressBody {
+    #[serde(default)]
+    #[allow(dead_code)]
+    r#type: i32,
+    #[serde(default)]
+    #[allow(dead_code)]
+    account: String,
+}
+
+#[post("/v1/newaddress")]
+async fn new_address(
+    req: HttpRequest,
+    state: web::Data<AppState>,
+    _body: web::Json<NewAddressBody>,
+) -> HttpResponse {
+    if let Err(e) = authorize(&req, &state.bakery, ADDRESS_WRITE) {
+        return auth_error(e);
+    }
+    match state.lampod.wallet_manager().get_onchain_address().await {
+        Ok(addr) => proto_json(&lnrpc::NewAddressResponse {
+            address: addr.address,
+        }),
+        Err(e) => internal_error(e),
+    }
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct AddInvoiceBody {
+    #[serde(default)]
+    memo: String,
+    #[serde(default)]
+    value: i64,
+    #[serde(default)]
+    value_msat: i64,
+    #[serde(default)]
+    expiry: i64,
+}
+
+#[post("/v1/invoices")]
+async fn add_invoice(
+    req: HttpRequest,
+    state: web::Data<AppState>,
+    body: web::Json<AddInvoiceBody>,
+) -> HttpResponse {
+    if let Err(e) = authorize(&req, &state.bakery, INVOICES_WRITE) {
+        return auth_error(e);
+    }
+    let amount_msat = if body.value_msat > 0 {
+        Some(body.value_msat as u64)
+    } else if body.value > 0 {
+        Some((body.value as u64) * 1000)
+    } else {
+        None
+    };
+    let expiry = if body.expiry > 0 {
+        body.expiry as u32
+    } else {
+        3600
+    };
+    let description = if body.memo.is_empty() {
+        "lampo invoice".to_string()
+    } else {
+        body.memo.clone()
+    };
+    let invoice =
+        match state
+            .lampod
+            .offchain_manager()
+            .generate_invoice(amount_msat, &description, expiry)
+        {
+            Ok(inv) => inv,
+            Err(e) => return internal_error(e),
+        };
+
+    let r_hash_hex = hex::encode(invoice.payment_hash().0);
+    let r_hash = Bytes::from(invoice.payment_hash().0.to_vec());
+
+    let lnd_invoice = lnrpc::Invoice {
+        memo: description,
+        r_preimage: Bytes::new(),
+        r_hash: r_hash.clone(),
+        value: amount_msat.map(|v| (v / 1000) as i64).unwrap_or(0),
+        value_msat: amount_msat.unwrap_or(0) as i64,
+        payment_request: invoice.to_string(),
+        expiry: expiry as i64,
+        state: lnrpc::invoice::InvoiceState::Open as i32,
+        ..Default::default()
+    };
+
+    state
+        .invoices
+        .write()
+        .await
+        .insert(r_hash_hex, lnd_invoice.clone());
+
+    proto_json(&lnrpc::AddInvoiceResponse {
+        r_hash,
+        payment_request: invoice.to_string(),
+        add_index: 0,
+        payment_addr: Bytes::new(),
+    })
+}
+
+#[get("/v1/invoice/{r_hash}")]
+async fn lookup_invoice(
+    req: HttpRequest,
+    state: web::Data<AppState>,
+    path: web::Path<String>,
+) -> HttpResponse {
+    if let Err(e) = authorize(&req, &state.bakery, INVOICES_READ) {
+        return auth_error(e);
+    }
+    let raw = path.into_inner();
+    let key = convert::normalize_r_hash(&raw);
+    let index = state.invoices.read().await;
+    let found = key
+        .as_ref()
+        .and_then(|k| index.get(k))
+        .or_else(|| index.get(&raw));
+    match found {
+        Some(inv) => proto_json(&inv),
+        None => HttpResponse::NotFound().json(json::json!({
+            "code": 5,
+            "message": "unable to locate invoice",
+            "details": []
+        })),
+    }
+}
+
+#[get("/v1/invoices")]
+async fn list_invoices(req: HttpRequest, state: web::Data<AppState>) -> HttpResponse {
+    if let Err(e) = authorize(&req, &state.bakery, INVOICES_READ) {
+        return auth_error(e);
+    }
+    let invoices = state.invoices.read().await.list();
+    proto_json(&lnrpc::ListInvoiceResponse {
+        invoices,
+        last_index_offset: 0,
+        first_index_offset: 0,
+    })
+}
+
+#[get("/v1/payreq/{payreq}")]
+async fn decode_payreq(
+    req: HttpRequest,
+    state: web::Data<AppState>,
+    path: web::Path<String>,
+) -> HttpResponse {
+    if let Err(e) = authorize(&req, &state.bakery, INFO_READ) {
+        return auth_error(e);
+    }
+    let payreq = path.into_inner();
+    let request = request::DecodeInvoice {
+        invoice_str: payreq,
+    };
+    match lampod::jsonrpc::offchain::json_decode(
+        &state.lampod,
+        &json::to_value(request).unwrap_or_default(),
+    )
+    .await
+    {
+        Ok(value) => {
+            // Best-effort map into PayReq.
+            let amount_msat = value
+                .get("amount_msat")
+                .and_then(|v| v.as_u64())
+                .unwrap_or(0);
+            let destination = value
+                .get("issuer_id")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string();
+            let description = value
+                .get("description")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string();
+            let expiry = value
+                .get("expiry_time")
+                .and_then(|v| v.as_u64())
+                .unwrap_or(0);
+            proto_json(&lnrpc::PayReq {
+                destination,
+                payment_hash: String::new(),
+                num_satoshis: (amount_msat / 1000) as i64,
+                timestamp: 0,
+                expiry: expiry as i64,
+                description,
+                description_hash: String::new(),
+                fallback_addr: String::new(),
+                cltv_expiry: 0,
+                route_hints: Vec::new(),
+                payment_addr: Bytes::new(),
+                num_msat: amount_msat as i64,
+                features: Default::default(),
+                blinded_paths: Vec::new(),
+            })
+        }
+        Err(e) => internal_error(e),
+    }
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct SendPaymentBody {
+    #[serde(default, alias = "payment_request")]
+    payment_request: String,
+    #[serde(default)]
+    amt: i64,
+    #[serde(default)]
+    amt_msat: i64,
+}
+
+async fn pay_invoice(
+    state: &AppState,
+    body: &SendPaymentBody,
+) -> Result<lnrpc::SendResponse, String> {
+    if body.payment_request.is_empty() {
+        return Err("payment_request is required".into());
+    }
+    let amount_msat = if body.amt_msat > 0 {
+        Some(body.amt_msat as u64)
+    } else if body.amt > 0 {
+        Some((body.amt as u64) * 1000)
+    } else {
+        None
+    };
+    let request = request::Pay {
+        invoice_str: body.payment_request.clone(),
+        amount: amount_msat,
+        bolt12: None,
+    };
+    let value = lampod::jsonrpc::offchain::json_pay(
+        &state.lampod,
+        &json::to_value(request).map_err(|e| e.to_string())?,
+    )
+    .await
+    .map_err(|e| e.to_string())?;
+
+    let state_str = value
+        .get("state")
+        .and_then(|v| v.as_str())
+        .unwrap_or("Failure");
+    let payment_hash = value
+        .get("payment_hash")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string();
+    let payment_preimage = value
+        .get("payment_preimage")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string();
+
+    if state_str != "Success" {
+        return Err(format!("payment failed with state {state_str}"));
+    }
+
+    Ok(lnrpc::SendResponse {
+        payment_error: String::new(),
+        payment_preimage: Bytes::from(hex::decode(payment_preimage).unwrap_or_default()),
+        payment_hash: Bytes::from(hex::decode(payment_hash).unwrap_or_default()),
+        payment_route: None,
+        ..Default::default()
+    })
+}
+
+#[post("/v1/channels/transactions")]
+async fn send_payment_sync(
+    req: HttpRequest,
+    state: web::Data<AppState>,
+    body: web::Json<SendPaymentBody>,
+) -> HttpResponse {
+    if let Err(e) = authorize(&req, &state.bakery, OFFCHAIN_WRITE) {
+        return auth_error(e);
+    }
+    match pay_invoice(&state, &body).await {
+        Ok(resp) => proto_json(&resp),
+        Err(e) => internal_error(e),
+    }
+}
+
+/// Zeus pays via `/v2/router/send` expecting NDJSON `{ "result": ... }` chunks.
+#[post("/v2/router/send")]
+async fn router_send(
+    req: HttpRequest,
+    state: web::Data<AppState>,
+    body: web::Json<SendPaymentBody>,
+) -> HttpResponse {
+    if let Err(e) = authorize(&req, &state.bakery, OFFCHAIN_WRITE) {
+        return auth_error(e);
+    }
+    match pay_invoice(&state, &body).await {
+        Ok(resp) => {
+            use base64::Engine;
+            let engine = base64::engine::general_purpose::STANDARD;
+            let status = json::json!({
+                "result": {
+                    "status": "SUCCEEDED",
+                    "paymentHash": engine.encode(&resp.payment_hash),
+                    "paymentPreimage": engine.encode(&resp.payment_preimage),
+                    "feeMsat": "0",
+                    "valueMsat": "0"
+                }
+            });
+            let line = format!("{}\n", status);
+            HttpResponse::Ok()
+                .content_type("application/json")
+                .body(line)
+        }
+        Err(e) => {
+            let status = json::json!({
+                "result": {
+                    "status": "FAILED",
+                    "failureReason": "FAILURE_REASON_NO_ROUTE",
+                    "paymentError": e
+                }
+            });
+            let line = format!("{}\n", status);
+            HttpResponse::Ok()
+                .content_type("application/json")
+                .body(line)
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct OpenChannelBody {
+    #[serde(default, alias = "node_pubkey_string")]
+    node_pubkey_string: String,
+    #[serde(default, alias = "node_pubkey")]
+    node_pubkey: String,
+    #[serde(default, alias = "local_funding_amount")]
+    local_funding_amount: i64,
+    #[serde(default)]
+    private: bool,
+}
+
+#[post("/v1/channels")]
+async fn open_channel(
+    req: HttpRequest,
+    state: web::Data<AppState>,
+    body: web::Json<OpenChannelBody>,
+) -> HttpResponse {
+    if let Err(e) = authorize(&req, &state.bakery, OFFCHAIN_WRITE) {
+        return auth_error(e);
+    }
+    let node_id = if !body.node_pubkey_string.is_empty() {
+        body.node_pubkey_string.clone()
+    } else {
+        body.node_pubkey.clone()
+    };
+    if node_id.is_empty() || body.local_funding_amount <= 0 {
+        return internal_error("node_pubkey_string and local_funding_amount are required");
+    }
+    let request = request::OpenChannel {
+        node_id,
+        amount: body.local_funding_amount as u64,
+        public: !body.private,
+        port: None,
+        addr: None,
+    };
+    match lampod::jsonrpc::open_channel::json_fundchannel(
+        &state.lampod,
+        &json::to_value(request).unwrap_or_default(),
+    )
+    .await
+    {
+        Ok(value) => {
+            let txid = value
+                .get("tx")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string();
+            proto_json(&lnrpc::ChannelPoint {
+                funding_txid: Some(lnrpc::channel_point::FundingTxid::FundingTxidStr(txid)),
+                output_index: 0,
+            })
+        }
+        Err(e) => internal_error(e),
+    }
+}
+
+#[delete("/v1/channels/{funding_txid}/{output_index}")]
+async fn close_channel(
+    req: HttpRequest,
+    state: web::Data<AppState>,
+    path: web::Path<(String, u32)>,
+) -> HttpResponse {
+    if let Err(e) = authorize(&req, &state.bakery, OFFCHAIN_WRITE) {
+        return auth_error(e);
+    }
+    let (funding_txid, output_index) = path.into_inner();
+    // Resolve channel by funding outpoint against LDK channel details.
+    let details = state.lampod.channel_manager().manager().list_channels();
+    let Some(channel) = details.into_iter().find(|c| {
+        c.funding_txo
+            .map(|o| o.txid.to_string() == funding_txid && o.index as u32 == output_index)
+            .unwrap_or(false)
+    }) else {
+        return HttpResponse::NotFound().json(json::json!({
+            "code": 5,
+            "message": "channel not found",
+            "details": []
+        }));
+    };
+
+    let request = request::CloseChannel {
+        node_id: channel.counterparty.node_id.to_string(),
+        channel_id: Some(channel.channel_id.to_string()),
+    };
+    match lampod::jsonrpc::channels::json_close(
+        &state.lampod,
+        &json::to_value(request).unwrap_or_default(),
+    )
+    .await
+    {
+        Ok(_) => HttpResponse::Ok().json(json::json!({})),
+        Err(e) => internal_error(e),
+    }
+}
+
+#[get("/v1/payments")]
+async fn list_payments(req: HttpRequest, state: web::Data<AppState>) -> HttpResponse {
+    if let Err(e) = authorize(&req, &state.bakery, OFFCHAIN_READ) {
+        return auth_error(e);
+    }
+    proto_json(&lnrpc::ListPaymentsResponse::default())
+}
+
+#[get("/v1/transactions")]
+async fn list_transactions(req: HttpRequest, state: web::Data<AppState>) -> HttpResponse {
+    if let Err(e) = authorize(&req, &state.bakery, ONCHAIN_READ) {
+        return auth_error(e);
+    }
+    proto_json(&lnrpc::TransactionDetails::default())
+}

--- a/lampo-lnd/src/routes/handlers.rs
+++ b/lampo-lnd/src/routes/handlers.rs
@@ -287,6 +287,29 @@ struct ConnectAddr {
     host: Option<String>,
 }
 
+fn parse_peer_host(host: String) -> Result<(String, u64), String> {
+    if let Ok(socket) = host.parse::<std::net::SocketAddr>() {
+        return Ok((socket.ip().to_string(), socket.port() as u64));
+    }
+    if host.starts_with('[') {
+        return Err("invalid bracketed peer address".into());
+    }
+    if host.matches(':').count() == 1 {
+        let (hostname, port) = host
+            .split_once(':')
+            .ok_or_else(|| "invalid peer address".to_string())?;
+        let port = port
+            .parse::<u16>()
+            .map_err(|_| "invalid peer port".to_string())?;
+        if hostname.is_empty() || port == 0 {
+            return Err("invalid peer address".into());
+        }
+        return Ok((hostname.to_string(), port as u64));
+    }
+    // A hostname/IPv4 address, or an unbracketed IPv6 address without a port.
+    Ok((host, 9735))
+}
+
 #[post("/v1/peers")]
 async fn connect_peer(
     req: HttpRequest,
@@ -307,11 +330,9 @@ async fn connect_peer(
         (Some(p), Some(h)) => (p, h),
         _ => return internal_error("addr.pubkey and addr.host are required"),
     };
-    // host may be "ip:port" or "ip"
-    let (ip, port) = if let Some((h, p)) = host.rsplit_once(':') {
-        (h.to_string(), p.parse::<u64>().unwrap_or(9735))
-    } else {
-        (host, 9735)
+    let (ip, port) = match parse_peer_host(host) {
+        Ok(addr) => addr,
+        Err(e) => return internal_error(e),
     };
     let request = request::Connect {
         node_id: pubkey,
@@ -548,10 +569,55 @@ struct SendPaymentBody {
     amt: i64,
     #[serde(default)]
     amt_msat: i64,
-    #[serde(default, alias = "fee_limit_sat")]
-    fee_limit_sat: i64,
-    #[serde(default, alias = "fee_limit_msat")]
-    fee_limit_msat: i64,
+    #[serde(
+        default,
+        alias = "fee_limit_sat",
+        deserialize_with = "deserialize_optional_i64"
+    )]
+    fee_limit_sat: Option<i64>,
+    #[serde(
+        default,
+        alias = "fee_limit_msat",
+        deserialize_with = "deserialize_optional_i64"
+    )]
+    fee_limit_msat: Option<i64>,
+    #[serde(default)]
+    fee_limit: Option<FeeLimitBody>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct FeeLimitBody {
+    #[serde(default, deserialize_with = "deserialize_optional_i64")]
+    fixed: Option<i64>,
+    #[serde(default, deserialize_with = "deserialize_optional_i64")]
+    fixed_msat: Option<i64>,
+    #[serde(default, deserialize_with = "deserialize_optional_i64")]
+    percent: Option<i64>,
+}
+
+fn deserialize_optional_i64<'de, D>(deserializer: D) -> Result<Option<i64>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    #[derive(Deserialize)]
+    #[serde(untagged)]
+    enum I64Value {
+        Number(i64),
+        String(String),
+    }
+
+    match Option::<I64Value>::deserialize(deserializer)? {
+        Some(I64Value::Number(value)) => Ok(Some(value)),
+        Some(I64Value::String(value)) => value.parse().map(Some).map_err(serde::de::Error::custom),
+        None => Ok(None),
+    }
+}
+
+#[derive(Clone, Copy)]
+enum PaymentEndpoint {
+    Sync,
+    Router,
 }
 
 struct PaymentOutcome {
@@ -560,19 +626,59 @@ struct PaymentOutcome {
     fee_msat: u64,
 }
 
-fn max_fee_msat(body: &SendPaymentBody) -> Result<u64, String> {
-    if body.fee_limit_sat < 0 || body.fee_limit_msat < 0 {
-        return Err("fee limits must not be negative".into());
+fn max_fee_msat(
+    body: &SendPaymentBody,
+    value_msat: u64,
+    endpoint: PaymentEndpoint,
+) -> Result<u64, String> {
+    if let Some(fee_limit) = &body.fee_limit {
+        if body.fee_limit_sat.is_some() || body.fee_limit_msat.is_some() {
+            return Err("flat and nested fee limits are mutually exclusive".into());
+        }
+        let limits = [
+            fee_limit.fixed.map(|value| (value, 1000_u64)),
+            fee_limit.fixed_msat.map(|value| (value, 1_u64)),
+            fee_limit.percent.map(|value| (value, 0_u64)),
+        ];
+        if limits.iter().filter(|limit| limit.is_some()).count() != 1 {
+            return Err("feeLimit must specify exactly one limit".into());
+        }
+        let (value, multiplier) = limits
+            .into_iter()
+            .flatten()
+            .next()
+            .ok_or_else(|| "feeLimit is empty".to_string())?;
+        if value < 0 {
+            return Err("fee limits must not be negative".into());
+        }
+        if multiplier == 0 {
+            return value_msat
+                .checked_mul(value as u64)
+                .map(|fee| fee / 100)
+                .ok_or_else(|| "feeLimit.percent is too large".to_string());
+        }
+        return (value as u64)
+            .checked_mul(multiplier)
+            .ok_or_else(|| "fixed fee limit is too large".to_string());
     }
-    if body.fee_limit_sat > 0 && body.fee_limit_msat > 0 {
+
+    if body.fee_limit_sat.is_some() && body.fee_limit_msat.is_some() {
         return Err("fee_limit_sat and fee_limit_msat are mutually exclusive".into());
     }
-    if body.fee_limit_msat > 0 {
-        Ok(body.fee_limit_msat as u64)
-    } else {
-        (body.fee_limit_sat as u64)
+    if let Some(value) = body.fee_limit_msat {
+        return u64::try_from(value).map_err(|_| "fee limits must not be negative".into());
+    }
+    if let Some(value) = body.fee_limit_sat {
+        return u64::try_from(value)
+            .map_err(|_| "fee limits must not be negative".to_string())?
             .checked_mul(1000)
-            .ok_or_else(|| "fee_limit_sat is too large".to_string())
+            .ok_or_else(|| "fee_limit_sat is too large".to_string());
+    }
+
+    match endpoint {
+        PaymentEndpoint::Router => Ok(0),
+        PaymentEndpoint::Sync if value_msat <= 1_000_000 => Ok(value_msat),
+        PaymentEndpoint::Sync => Ok(value_msat / 20),
     }
 }
 
@@ -596,7 +702,11 @@ fn route_value_and_fee(value: &JsonValue, fallback_value_msat: u64) -> (u64, u64
     )
 }
 
-async fn pay_invoice(state: &AppState, body: &SendPaymentBody) -> Result<PaymentOutcome, String> {
+async fn pay_invoice(
+    state: &AppState,
+    body: &SendPaymentBody,
+    endpoint: PaymentEndpoint,
+) -> Result<PaymentOutcome, String> {
     if body.payment_request.is_empty() {
         return Err("payment_request is required".into());
     }
@@ -607,7 +717,6 @@ async fn pay_invoice(state: &AppState, body: &SendPaymentBody) -> Result<Payment
     } else {
         None
     };
-    let max_fee_msat = max_fee_msat(body)?;
     let invoice_amount_msat = state
         .lampod
         .offchain_manager()
@@ -615,6 +724,7 @@ async fn pay_invoice(state: &AppState, body: &SendPaymentBody) -> Result<Payment
         .ok()
         .and_then(|invoice| invoice.amount_milli_satoshis());
     let value_msat = invoice_amount_msat.or(amount_msat).unwrap_or(0);
+    let max_fee_msat = max_fee_msat(body, value_msat, endpoint)?;
     let request = request::Pay {
         invoice_str: body.payment_request.clone(),
         amount: amount_msat,
@@ -677,7 +787,7 @@ async fn send_payment_sync(
     if let Err(e) = authorize(&req, &state.bakery, OFFCHAIN_WRITE) {
         return auth_error(e);
     }
-    match pay_invoice(&state, &body).await {
+    match pay_invoice(&state, &body, PaymentEndpoint::Sync).await {
         Ok(outcome) => proto_json(&outcome.response),
         Err(e) => proto_json(&lnrpc::SendResponse {
             payment_error: e,
@@ -696,7 +806,7 @@ async fn router_send(
     if let Err(e) = authorize(&req, &state.bakery, OFFCHAIN_WRITE) {
         return auth_error(e);
     }
-    match pay_invoice(&state, &body).await {
+    match pay_invoice(&state, &body, PaymentEndpoint::Router).await {
         Ok(outcome) => {
             use base64::Engine;
             let engine = base64::engine::general_purpose::STANDARD;
@@ -743,6 +853,25 @@ struct OpenChannelBody {
     private: bool,
 }
 
+fn open_channel_node_id(body: &OpenChannelBody) -> Result<String, String> {
+    if !body.node_pubkey_string.is_empty() {
+        return Ok(body.node_pubkey_string.clone());
+    }
+    if body.node_pubkey.is_empty() {
+        return Err("nodePubkey or nodePubkeyString is required".into());
+    }
+    use base64::Engine;
+    let bytes = base64::engine::general_purpose::STANDARD
+        .decode(&body.node_pubkey)
+        .map_err(|_| "nodePubkey must be base64 encoded".to_string())?;
+    if bytes.len() != 33 {
+        return Err("nodePubkey must encode a 33-byte public key".into());
+    }
+    lampo_common::secp256k1::PublicKey::from_slice(&bytes)
+        .map(|public_key| public_key.to_string())
+        .map_err(|_| "nodePubkey is not a valid compressed public key".into())
+}
+
 #[post("/v1/channels")]
 async fn open_channel(
     req: HttpRequest,
@@ -752,13 +881,12 @@ async fn open_channel(
     if let Err(e) = authorize(&req, &state.bakery, OFFCHAIN_WRITE) {
         return auth_error(e);
     }
-    let node_id = if !body.node_pubkey_string.is_empty() {
-        body.node_pubkey_string.clone()
-    } else {
-        body.node_pubkey.clone()
+    let node_id = match open_channel_node_id(&body) {
+        Ok(node_id) => node_id,
+        Err(e) => return internal_error(e),
     };
-    if node_id.is_empty() || body.local_funding_amount <= 0 {
-        return internal_error("node_pubkey_string and local_funding_amount are required");
+    if body.local_funding_amount <= 0 {
+        return internal_error("local_funding_amount is required");
     }
     let request = request::OpenChannel {
         node_id,
@@ -871,14 +999,65 @@ mod tests {
         }))
         .unwrap();
         assert_eq!(body.payment_request, "lnbc1...");
-        assert_eq!(max_fee_msat(&body).unwrap(), 1234);
+        assert_eq!(
+            max_fee_msat(&body, 100_000, PaymentEndpoint::Router).unwrap(),
+            1234
+        );
     }
 
     #[test]
-    fn zero_fee_limit_is_preserved() {
+    fn endpoint_fee_defaults_match_lnd() {
         let body: SendPaymentBody =
             serde_json::from_value(json::json!({ "paymentRequest": "lnbc1..." })).unwrap();
-        assert_eq!(max_fee_msat(&body).unwrap(), 0);
+        assert_eq!(
+            max_fee_msat(&body, 2_000_000, PaymentEndpoint::Router).unwrap(),
+            0
+        );
+        assert_eq!(
+            max_fee_msat(&body, 2_000_000, PaymentEndpoint::Sync).unwrap(),
+            100_000
+        );
+    }
+
+    #[test]
+    fn parses_nested_synchronous_fee_limit() {
+        let body: SendPaymentBody = serde_json::from_value(json::json!({
+            "paymentRequest": "lnbc1...",
+            "feeLimit": { "fixedMsat": "4321" }
+        }))
+        .unwrap();
+        assert_eq!(
+            max_fee_msat(&body, 100_000, PaymentEndpoint::Sync).unwrap(),
+            4321
+        );
+    }
+
+    #[test]
+    fn parses_peer_hostname_and_ipv6() {
+        assert_eq!(
+            parse_peer_host("node.example.com:19735".into()).unwrap(),
+            ("node.example.com".into(), 19735)
+        );
+        assert_eq!(
+            parse_peer_host("[::1]:9736".into()).unwrap(),
+            ("::1".into(), 9736)
+        );
+        assert_eq!(parse_peer_host("::1".into()).unwrap(), ("::1".into(), 9735));
+    }
+
+    #[test]
+    fn decodes_rest_node_pubkey() {
+        use base64::Engine;
+        use lampo_common::secp256k1::{PublicKey, Secp256k1, SecretKey};
+
+        let secret = SecretKey::from_slice(&[1; 32]).unwrap();
+        let public = PublicKey::from_secret_key(&Secp256k1::new(), &secret);
+        let body: OpenChannelBody = serde_json::from_value(json::json!({
+            "nodePubkey": base64::engine::general_purpose::STANDARD.encode(public.serialize()),
+            "localFundingAmount": 100_000
+        }))
+        .unwrap();
+        assert_eq!(open_channel_node_id(&body).unwrap(), public.to_string());
     }
 
     #[test]

--- a/lampo-lnd/src/routes/handlers.rs
+++ b/lampo-lnd/src/routes/handlers.rs
@@ -383,12 +383,19 @@ async fn new_address(
 struct AddInvoiceBody {
     #[serde(default)]
     memo: String,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_i64")]
     value: i64,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_i64")]
     value_msat: i64,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_i64")]
     expiry: i64,
+}
+
+fn invoice_expiry(expiry: i64) -> Result<u32, String> {
+    if expiry <= 0 {
+        return Ok(86_400);
+    }
+    u32::try_from(expiry).map_err(|_| "invoice expiry is too large".into())
 }
 
 #[post("/v1/invoices")]
@@ -407,10 +414,9 @@ async fn add_invoice(
     } else {
         None
     };
-    let expiry = if body.expiry > 0 {
-        body.expiry as u32
-    } else {
-        3600
+    let expiry = match invoice_expiry(body.expiry) {
+        Ok(expiry) => expiry,
+        Err(e) => return internal_error(e),
     };
     let description = if body.memo.is_empty() {
         "lampo invoice".to_string()
@@ -539,11 +545,12 @@ async fn decode_payreq(
                 .and_then(|v| v.as_str())
                 .unwrap_or("")
                 .to_string();
+            let timestamp = value.get("timestamp").and_then(|v| v.as_u64()).unwrap_or(0);
             proto_json(&lnrpc::PayReq {
                 destination,
                 payment_hash,
                 num_satoshis: (amount_msat / 1000) as i64,
-                timestamp: 0,
+                timestamp: timestamp as i64,
                 expiry: expiry as i64,
                 description,
                 description_hash: String::new(),
@@ -565,10 +572,16 @@ async fn decode_payreq(
 struct SendPaymentBody {
     #[serde(default, alias = "payment_request")]
     payment_request: String,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_i64")]
     amt: i64,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_i64")]
     amt_msat: i64,
+    #[serde(
+        default,
+        alias = "timeout_seconds",
+        deserialize_with = "deserialize_optional_i64"
+    )]
+    timeout_seconds: Option<i64>,
     #[serde(
         default,
         alias = "fee_limit_sat",
@@ -689,6 +702,22 @@ fn max_fee_msat(
     }
 }
 
+fn payment_timeout_secs(
+    body: &SendPaymentBody,
+    endpoint: PaymentEndpoint,
+) -> Result<Option<u64>, String> {
+    match body.timeout_seconds {
+        Some(timeout) if timeout < 0 => Err("timeoutSeconds must not be negative".into()),
+        Some(0) if matches!(endpoint, PaymentEndpoint::Router) => Ok(Some(60)),
+        Some(0) => Ok(None),
+        Some(timeout) => u64::try_from(timeout)
+            .map(Some)
+            .map_err(|_| "timeoutSeconds must not be negative".into()),
+        None if matches!(endpoint, PaymentEndpoint::Router) => Ok(Some(60)),
+        None => Ok(None),
+    }
+}
+
 fn route_value_and_fee(value: &JsonValue, fallback_value_msat: u64) -> (u64, u64) {
     let path_hop_fees = value
         .get("path")
@@ -738,6 +767,7 @@ async fn pay_invoice(
         max_fee_msat: Some(max_fee_msat),
         bolt12: None,
         timeout: Default::default(),
+        timeout_secs: payment_timeout_secs(body, endpoint)?,
     };
     let value = lampod::jsonrpc::offchain::json_pay(
         &state.lampod,
@@ -866,6 +896,12 @@ struct OpenChannelBody {
         deserialize_with = "deserialize_optional_i64"
     )]
     push_sat: Option<i64>,
+    #[serde(
+        default,
+        alias = "sat_per_vbyte",
+        deserialize_with = "deserialize_optional_i64"
+    )]
+    sat_per_vbyte: Option<i64>,
     #[serde(default)]
     private: bool,
 }
@@ -903,6 +939,16 @@ fn open_channel_push_msat(body: &OpenChannelBody) -> Result<Option<u64>, String>
         .ok_or_else(|| "pushSat is too large".to_string())
 }
 
+fn open_channel_fee_rate(body: &OpenChannelBody) -> Result<Option<u64>, String> {
+    match body.sat_per_vbyte {
+        Some(rate) if rate < 0 => Err("satPerVbyte must not be negative".into()),
+        Some(0) | None => Ok(None),
+        Some(rate) => u64::try_from(rate)
+            .map(Some)
+            .map_err(|_| "satPerVbyte is too large".into()),
+    }
+}
+
 #[post("/v1/channels")]
 async fn open_channel(
     req: HttpRequest,
@@ -923,6 +969,10 @@ async fn open_channel(
         Ok(push_msat) => push_msat,
         Err(e) => return internal_error(e),
     };
+    let sat_per_vbyte = match open_channel_fee_rate(&body) {
+        Ok(sat_per_vbyte) => sat_per_vbyte,
+        Err(e) => return internal_error(e),
+    };
     let expected_node_id = node_id.clone();
     let request = request::OpenChannel {
         node_id,
@@ -931,6 +981,7 @@ async fn open_channel(
         port: None,
         addr: None,
         push_msat,
+        sat_per_vbyte,
     };
     match lampod::jsonrpc::open_channel::json_fundchannel(
         &state.lampod,
@@ -1052,13 +1103,18 @@ mod tests {
     fn parses_zeus_fee_limit_and_payment_request() {
         let body: SendPaymentBody = serde_json::from_value(json::json!({
             "paymentRequest": "lnbc1...",
-            "feeLimitMsat": 1234
+            "feeLimitMsat": 1234,
+            "timeoutSeconds": "17"
         }))
         .unwrap();
         assert_eq!(body.payment_request, "lnbc1...");
         assert_eq!(
             max_fee_msat(&body, 100_000, PaymentEndpoint::Router).unwrap(),
             1234
+        );
+        assert_eq!(
+            payment_timeout_secs(&body, PaymentEndpoint::Router).unwrap(),
+            Some(17)
         );
     }
 
@@ -1074,6 +1130,23 @@ mod tests {
             max_fee_msat(&body, 2_000_000, PaymentEndpoint::Sync).unwrap(),
             100_000
         );
+        assert_eq!(
+            payment_timeout_secs(&body, PaymentEndpoint::Router).unwrap(),
+            Some(60)
+        );
+        assert_eq!(
+            payment_timeout_secs(&body, PaymentEndpoint::Sync).unwrap(),
+            None
+        );
+        assert_eq!(invoice_expiry(0).unwrap(), 86_400);
+
+        let invoice: AddInvoiceBody = serde_json::from_value(json::json!({
+            "value": "1000",
+            "expiry": "0"
+        }))
+        .unwrap();
+        assert_eq!(invoice.value, 1000);
+        assert_eq!(invoice_expiry(invoice.expiry).unwrap(), 86_400);
     }
 
     #[test]
@@ -1122,10 +1195,12 @@ mod tests {
         let body: OpenChannelBody = serde_json::from_value(json::json!({
             "nodePubkeyString": "02",
             "localFundingAmount": "100000",
-            "pushSat": "25000"
+            "pushSat": "25000",
+            "satPerVbyte": "12"
         }))
         .unwrap();
         assert_eq!(open_channel_push_msat(&body).unwrap(), Some(25_000_000));
+        assert_eq!(open_channel_fee_rate(&body).unwrap(), Some(12));
 
         let excessive: OpenChannelBody = serde_json::from_value(json::json!({
             "nodePubkeyString": "02",

--- a/lampo-lnd/src/routes/handlers.rs
+++ b/lampo-lnd/src/routes/handlers.rs
@@ -552,6 +552,7 @@ async fn pay_invoice(
         invoice_str: body.payment_request.clone(),
         amount: amount_msat,
         bolt12: None,
+        timeout: Default::default(),
     };
     let value = lampod::jsonrpc::offchain::json_pay(
         &state.lampod,
@@ -683,6 +684,7 @@ async fn open_channel(
         public: !body.private,
         port: None,
         addr: None,
+        push_msat: None,
     };
     match lampod::jsonrpc::open_channel::json_fundchannel(
         &state.lampod,

--- a/lampo-lnd/src/routes/handlers.rs
+++ b/lampo-lnd/src/routes/handlers.rs
@@ -646,6 +646,39 @@ struct PaymentOutcome {
     fee_msat: u64,
 }
 
+struct PaymentFailure {
+    message: String,
+    reason: &'static str,
+}
+
+impl From<String> for PaymentFailure {
+    fn from(message: String) -> Self {
+        let reason = classify_payment_failure(&message);
+        Self { message, reason }
+    }
+}
+
+fn classify_payment_failure(message: &str) -> &'static str {
+    let message = message.to_ascii_lowercase();
+    if message.contains("insufficient") {
+        "FAILURE_REASON_INSUFFICIENT_BALANCE"
+    } else if message.contains("abandon") || message.contains("cancel") {
+        "FAILURE_REASON_CANCELED"
+    } else if (message.contains("recipient") && message.contains("reject"))
+        || message.contains("invalid amount")
+        || message.contains("incorrect")
+        || message.contains("expired")
+    {
+        "FAILURE_REASON_INCORRECT_PAYMENT_DETAILS"
+    } else if message.contains("timeout") || message.contains("timed out") {
+        "FAILURE_REASON_TIMEOUT"
+    } else if message.contains("route") || message.contains("retries") {
+        "FAILURE_REASON_NO_ROUTE"
+    } else {
+        "FAILURE_REASON_ERROR"
+    }
+}
+
 fn max_fee_msat(
     body: &SendPaymentBody,
     value_msat: u64,
@@ -719,6 +752,12 @@ fn payment_timeout_secs(
 }
 
 fn route_value_and_fee(value: &JsonValue, fallback_value_msat: u64) -> (u64, u64) {
+    if let (Some(value_msat), Some(fee_msat)) = (
+        value.get("value_msat").and_then(JsonValue::as_u64),
+        value.get("fee_msat").and_then(JsonValue::as_u64),
+    ) {
+        return (value_msat, fee_msat);
+    }
     let path_hop_fees = value
         .get("path")
         .and_then(|v| v.as_array())
@@ -742,9 +781,11 @@ async fn pay_invoice(
     state: &AppState,
     body: &SendPaymentBody,
     endpoint: PaymentEndpoint,
-) -> Result<PaymentOutcome, String> {
+) -> Result<PaymentOutcome, PaymentFailure> {
     if body.payment_request.is_empty() {
-        return Err("payment_request is required".into());
+        return Err(PaymentFailure::from(
+            "payment_request is required".to_string(),
+        ));
     }
     let amount_msat = if body.amt_msat > 0 {
         Some(body.amt_msat as u64)
@@ -774,7 +815,7 @@ async fn pay_invoice(
         &json::to_value(request).map_err(|e| e.to_string())?,
     )
     .await
-    .map_err(|e| e.to_string())?;
+    .map_err(|e| PaymentFailure::from(e.to_string()))?;
 
     let state_str = value
         .get("state")
@@ -793,7 +834,11 @@ async fn pay_invoice(
     let (value_msat, fee_msat) = route_value_and_fee(&value, value_msat);
 
     if state_str != "Success" {
-        return Err(format!("payment failed with state {state_str}"));
+        let reason = value
+            .get("reason")
+            .and_then(JsonValue::as_str)
+            .unwrap_or("payment failed without a reason");
+        return Err(PaymentFailure::from(reason.to_string()));
     }
 
     Ok(PaymentOutcome {
@@ -827,7 +872,7 @@ async fn send_payment_sync(
     match pay_invoice(&state, &body, PaymentEndpoint::Sync).await {
         Ok(outcome) => proto_json(&outcome.response),
         Err(e) => proto_json(&lnrpc::SendResponse {
-            payment_error: e,
+            payment_error: e.message,
             ..Default::default()
         }),
     }
@@ -865,8 +910,8 @@ async fn router_send(
             let status = json::json!({
                 "result": {
                     "status": "FAILED",
-                    "failureReason": "FAILURE_REASON_NO_ROUTE",
-                    "paymentError": e
+                    "failureReason": e.reason,
+                    "paymentError": e.message
                 }
             });
             let line = format!("{}\n", status);
@@ -1223,5 +1268,35 @@ mod tests {
             ]
         });
         assert_eq!(route_value_and_fee(&result, 0), (100_000, 1250));
+    }
+
+    #[test]
+    fn uses_aggregated_mpp_totals() {
+        let result = json::json!({
+            "value_msat": 1_000_000,
+            "fee_msat": 2_500,
+            "path": [{ "hop_fee_msat": 400_000 }]
+        });
+        assert_eq!(route_value_and_fee(&result, 0), (1_000_000, 2_500));
+    }
+
+    #[test]
+    fn classifies_router_payment_failures() {
+        assert_eq!(
+            classify_payment_failure("insufficient local balance"),
+            "FAILURE_REASON_INSUFFICIENT_BALANCE"
+        );
+        assert_eq!(
+            classify_payment_failure("payment expired before completion"),
+            "FAILURE_REASON_INCORRECT_PAYMENT_DETAILS"
+        );
+        assert_eq!(
+            classify_payment_failure("payment was abandoned by the user"),
+            "FAILURE_REASON_CANCELED"
+        );
+        assert_eq!(
+            classify_payment_failure("no route found"),
+            "FAILURE_REASON_NO_ROUTE"
+        );
     }
 }

--- a/lampo-lnd/src/routes/mod.rs
+++ b/lampo-lnd/src/routes/mod.rs
@@ -1,0 +1,82 @@
+mod handlers;
+
+pub use handlers::configure;
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use actix_web::HttpRequest;
+use tokio::sync::RwLock;
+
+use crate::auth::{AuthError, MacaroonBakery, Permission};
+use crate::lnrpc;
+use lampod::LampoDaemon;
+
+/// In-memory invoice index so Zeus can poll `GET /v1/invoice/{r_hash}`.
+#[derive(Default)]
+pub struct InvoiceIndex {
+    by_hash_hex: HashMap<String, lnrpc::Invoice>,
+}
+
+impl InvoiceIndex {
+    pub fn insert(&mut self, r_hash_hex: String, invoice: lnrpc::Invoice) {
+        self.by_hash_hex.insert(r_hash_hex, invoice);
+    }
+
+    pub fn get(&self, r_hash_hex: &str) -> Option<lnrpc::Invoice> {
+        self.by_hash_hex.get(r_hash_hex).cloned()
+    }
+
+    pub fn list(&self) -> Vec<lnrpc::Invoice> {
+        self.by_hash_hex.values().cloned().collect()
+    }
+
+    pub fn mark_settled(
+        &mut self,
+        r_hash_hex: &str,
+        preimage: bytes::Bytes,
+        amt_paid_msat: i64,
+    ) -> bool {
+        let Some(inv) = self.by_hash_hex.get_mut(r_hash_hex) else {
+            return false;
+        };
+        inv.state = lnrpc::invoice::InvoiceState::Settled as i32;
+        inv.settled = true;
+        inv.r_preimage = preimage;
+        inv.amt_paid_msat = amt_paid_msat;
+        inv.amt_paid_sat = amt_paid_msat / 1000;
+        inv.amt_paid = amt_paid_msat / 1000;
+        true
+    }
+}
+
+pub struct AppState {
+    pub lampod: Arc<LampoDaemon>,
+    pub bakery: Arc<MacaroonBakery>,
+    pub invoices: Arc<RwLock<InvoiceIndex>>,
+}
+
+pub fn extract_macaroon_hex(req: &HttpRequest) -> Result<String, AuthError> {
+    // Zeus / LND REST use Grpc-Metadata-macaroon (case-insensitive).
+    for (name, value) in req.headers().iter() {
+        let key = name.as_str();
+        if key.eq_ignore_ascii_case("grpc-metadata-macaroon")
+            || key.eq_ignore_ascii_case("macaroon")
+        {
+            return value
+                .to_str()
+                .map(|s| s.to_string())
+                .map_err(|_| AuthError::Malformed);
+        }
+    }
+    Err(AuthError::Missing)
+}
+
+pub fn authorize(
+    req: &HttpRequest,
+    bakery: &MacaroonBakery,
+    required: Permission,
+) -> Result<(), AuthError> {
+    let hex = extract_macaroon_hex(req)?;
+    bakery.verify_hex(&hex, required)
+}

--- a/lampo-lnd/src/server.rs
+++ b/lampo-lnd/src/server.rs
@@ -1,0 +1,167 @@
+//! Actix HTTPS server for the LND-compatible REST API.
+use std::net::SocketAddr;
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::thread;
+use std::time::Duration;
+
+use actix_web::{web, App, HttpServer};
+use lampo_common::error;
+use lampo_common::handler::Handler;
+use lampod::LampoDaemon;
+use tokio::sync::RwLock;
+
+use crate::auth::MacaroonBakery;
+use crate::auth::RequireMacaroon;
+use crate::routes::{self, AppState, InvoiceIndex};
+use crate::tls::TlsMaterial;
+
+#[derive(Clone, Debug)]
+pub struct LndRestConfig {
+    pub listen_host: String,
+    pub listen_port: u16,
+    pub tls_dir: PathBuf,
+    pub macaroon_dir: PathBuf,
+}
+
+impl LndRestConfig {
+    pub fn socket_addr(&self) -> error::Result<SocketAddr> {
+        let raw = format!("{}:{}", self.listen_host, self.listen_port);
+        raw.parse()
+            .map_err(|e| error::anyhow!("invalid lnd rest listen address `{raw}`: {e}"))
+    }
+}
+
+/// Spawn the LND REST listener on a dedicated Actix system thread.
+///
+/// Actix's `HttpServer::run` future is `!Send`, so it cannot live on the
+/// multi-thread tokio runtime used by `lampod-cli`.
+pub fn spawn(lampod: Arc<LampoDaemon>, conf: LndRestConfig) -> error::Result<()> {
+    let admin_path = conf.macaroon_dir.join("admin.macaroon");
+    let addr = conf.socket_addr()?;
+    thread::Builder::new()
+        .name("lampo-lnd-rest".into())
+        .spawn(move || {
+            let system = actix_web::rt::System::new();
+            if let Err(err) = system.block_on(run(lampod, conf)) {
+                log::error!(target: "lampo-lnd", "LND REST server failed: {err}");
+            }
+        })
+        .map_err(|e| error::anyhow!("failed to spawn LND REST thread: {e}"))?;
+
+    // Wait until bakery material exists and the listener accepts TCP.
+    for _ in 0..100 {
+        if admin_path.exists() {
+            if std::net::TcpStream::connect_timeout(&addr, Duration::from_millis(50)).is_ok() {
+                return Ok(());
+            }
+        }
+        thread::sleep(Duration::from_millis(50));
+    }
+    error::bail!(
+        "timed out waiting for LND REST listener on {} (macaroon {})",
+        addr,
+        admin_path.display()
+    )
+}
+
+/// Bind and run the LND REST listener. Returns once the server stops.
+pub async fn run(lampod: Arc<LampoDaemon>, conf: LndRestConfig) -> error::Result<()> {
+    // rustls 0.23 requires an explicit process-level CryptoProvider when
+    // multiple backends could be linked. Prefer ring for portability.
+    let _ = rustls::crypto::ring::default_provider().install_default();
+
+    let addr = conf.socket_addr()?;
+    let hosts = vec![
+        conf.listen_host.clone(),
+        "localhost".to_string(),
+        "127.0.0.1".to_string(),
+    ];
+    let tls = TlsMaterial::load_or_create(&conf.tls_dir, &hosts)
+        .map_err(|e| error::anyhow!("tls init failed: {e}"))?;
+    let rustls_config = tls
+        .server_config()
+        .map_err(|e| error::anyhow!("tls config failed: {e}"))?;
+    let bakery = Arc::new(
+        MacaroonBakery::load_or_create(&conf.macaroon_dir)
+            .map_err(|e| error::anyhow!("macaroon bakery init failed: {e}"))?,
+    );
+
+    log::info!(
+        target: "lampo-lnd",
+        "LND REST listening on https://{} (tls={}, macaroons={})",
+        addr,
+        tls.cert_path.display(),
+        bakery.macaroon_dir().display()
+    );
+
+    let state = web::Data::new(AppState {
+        lampod: lampod.clone(),
+        bakery,
+        invoices: Arc::new(RwLock::new(InvoiceIndex::default())),
+    });
+
+    // Keep Zeus invoice polling accurate by marking in-memory invoices settled
+    // when LDK claims an incoming payment.
+    {
+        let invoices = state.invoices.clone();
+        let mut events = lampod.handler().events();
+        actix_web::rt::spawn(async move {
+            use lampo_common::event::Event;
+            use lampo_common::ldk;
+            while let Some(event) = events.recv().await {
+                let Event::RawLDK(ldk::events::Event::PaymentClaimed {
+                    payment_hash,
+                    amount_msat,
+                    purpose,
+                    ..
+                }) = event
+                else {
+                    continue;
+                };
+                let preimage = match purpose {
+                    ldk::events::PaymentPurpose::Bolt11InvoicePayment {
+                        payment_preimage, ..
+                    }
+                    | ldk::events::PaymentPurpose::Bolt12OfferPayment {
+                        payment_preimage, ..
+                    }
+                    | ldk::events::PaymentPurpose::Bolt12RefundPayment {
+                        payment_preimage, ..
+                    } => payment_preimage,
+                    ldk::events::PaymentPurpose::SpontaneousPayment(preimage) => Some(preimage),
+                };
+                let Some(preimage) = preimage else {
+                    continue;
+                };
+                let key = hex::encode(payment_hash.0);
+                let mut guard = invoices.write().await;
+                if guard.mark_settled(
+                    &key,
+                    bytes::Bytes::from(preimage.0.to_vec()),
+                    amount_msat as i64,
+                ) {
+                    log::debug!(
+                        target: "lampo-lnd",
+                        "marked invoice {key} settled for {amount_msat} msat"
+                    );
+                }
+            }
+        });
+    }
+
+    HttpServer::new(move || {
+        App::new()
+            .app_data(state.clone())
+            .app_data(web::JsonConfig::default().limit(1024 * 1024))
+            .wrap(RequireMacaroon)
+            .configure(routes::configure)
+    })
+    .bind_rustls_0_23(addr, rustls_config)
+    .map_err(|e| error::anyhow!("failed to bind LND REST on {addr}: {e}"))?
+    .run()
+    .await
+    .map_err(|e| error::anyhow!("LND REST server error: {e}"))?;
+
+    Ok(())
+}

--- a/lampo-lnd/src/server.rs
+++ b/lampo-lnd/src/server.rs
@@ -20,6 +20,7 @@ use crate::tls::TlsMaterial;
 pub struct LndRestConfig {
     pub listen_host: String,
     pub listen_port: u16,
+    pub tls_extra_sans: Vec<String>,
     pub tls_dir: PathBuf,
     pub macaroon_dir: PathBuf,
 }
@@ -92,11 +93,7 @@ fn build_server(
     } else {
         format!("{}:{}", conf.listen_host, conf.listen_port)
     };
-    let hosts = vec![
-        conf.listen_host.clone(),
-        "localhost".to_string(),
-        "127.0.0.1".to_string(),
-    ];
+    let hosts = certificate_hosts(&conf);
     let tls = TlsMaterial::load_or_create(&conf.tls_dir, &hosts)
         .map_err(|e| error::anyhow!("tls init failed: {e}"))?;
     let rustls_config = tls
@@ -183,4 +180,40 @@ fn build_server(
     .map_err(|e| error::anyhow!("failed to bind LND REST on {addr}: {e}"))?
     .run();
     Ok(server)
+}
+
+fn certificate_hosts(conf: &LndRestConfig) -> Vec<String> {
+    let mut hosts = vec![
+        conf.listen_host.clone(),
+        "localhost".to_string(),
+        "127.0.0.1".to_string(),
+        "::1".to_string(),
+    ];
+    for host in &conf.tls_extra_sans {
+        if !host.is_empty() && !hosts.contains(host) {
+            hosts.push(host.clone());
+        }
+    }
+    hosts
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn includes_remote_tls_names_with_wildcard_listener() {
+        let conf = LndRestConfig {
+            listen_host: "0.0.0.0".into(),
+            listen_port: 8080,
+            tls_extra_sans: vec!["node.local".into(), "192.168.1.10".into()],
+            tls_dir: PathBuf::new(),
+            macaroon_dir: PathBuf::new(),
+        };
+
+        let hosts = certificate_hosts(&conf);
+        assert!(hosts.contains(&"node.local".to_string()));
+        assert!(hosts.contains(&"192.168.1.10".to_string()));
+        assert!(hosts.contains(&"localhost".to_string()));
+    }
 }

--- a/lampo-lnd/src/server.rs
+++ b/lampo-lnd/src/server.rs
@@ -1,6 +1,6 @@
 //! Actix HTTPS server for the LND-compatible REST API.
-use std::net::SocketAddr;
 use std::path::PathBuf;
+use std::sync::mpsc;
 use std::sync::Arc;
 use std::thread;
 use std::time::Duration;
@@ -24,54 +24,74 @@ pub struct LndRestConfig {
     pub macaroon_dir: PathBuf,
 }
 
-impl LndRestConfig {
-    pub fn socket_addr(&self) -> error::Result<SocketAddr> {
-        let raw = format!("{}:{}", self.listen_host, self.listen_port);
-        raw.parse()
-            .map_err(|e| error::anyhow!("invalid lnd rest listen address `{raw}`: {e}"))
-    }
-}
-
 /// Spawn the LND REST listener on a dedicated Actix system thread.
 ///
 /// Actix's `HttpServer::run` future is `!Send`, so it cannot live on the
 /// multi-thread tokio runtime used by `lampod-cli`.
 pub fn spawn(lampod: Arc<LampoDaemon>, conf: LndRestConfig) -> error::Result<()> {
-    let admin_path = conf.macaroon_dir.join("admin.macaroon");
-    let addr = conf.socket_addr()?;
+    let (ready_tx, ready_rx) = mpsc::sync_channel(1);
     thread::Builder::new()
         .name("lampo-lnd-rest".into())
         .spawn(move || {
             let system = actix_web::rt::System::new();
-            if let Err(err) = system.block_on(run(lampod, conf)) {
+            if let Err(err) = system.block_on(run_with_ready(lampod, conf, Some(ready_tx))) {
                 log::error!(target: "lampo-lnd", "LND REST server failed: {err}");
             }
         })
         .map_err(|e| error::anyhow!("failed to spawn LND REST thread: {e}"))?;
 
-    // Wait until bakery material exists and the listener accepts TCP.
-    for _ in 0..100 {
-        if admin_path.exists() {
-            if std::net::TcpStream::connect_timeout(&addr, Duration::from_millis(50)).is_ok() {
-                return Ok(());
-            }
+    match ready_rx.recv_timeout(Duration::from_secs(5)) {
+        Ok(Ok(())) => Ok(()),
+        Ok(Err(err)) => Err(error::anyhow!(err)),
+        Err(mpsc::RecvTimeoutError::Timeout) => {
+            error::bail!("timed out waiting for LND REST listener startup")
         }
-        thread::sleep(Duration::from_millis(50));
+        Err(mpsc::RecvTimeoutError::Disconnected) => {
+            error::bail!("LND REST server exited before reporting startup")
+        }
     }
-    error::bail!(
-        "timed out waiting for LND REST listener on {} (macaroon {})",
-        addr,
-        admin_path.display()
-    )
 }
 
 /// Bind and run the LND REST listener. Returns once the server stops.
 pub async fn run(lampod: Arc<LampoDaemon>, conf: LndRestConfig) -> error::Result<()> {
+    run_with_ready(lampod, conf, None).await
+}
+
+async fn run_with_ready(
+    lampod: Arc<LampoDaemon>,
+    conf: LndRestConfig,
+    ready: Option<mpsc::SyncSender<Result<(), String>>>,
+) -> error::Result<()> {
+    let server = match build_server(lampod, conf) {
+        Ok(server) => server,
+        Err(err) => {
+            if let Some(ready) = ready {
+                let _ = ready.send(Err(err.to_string()));
+            }
+            return Err(err);
+        }
+    };
+    if let Some(ready) = ready {
+        let _ = ready.send(Ok(()));
+    }
+    server
+        .await
+        .map_err(|e| error::anyhow!("LND REST server error: {e}"))
+}
+
+fn build_server(
+    lampod: Arc<LampoDaemon>,
+    conf: LndRestConfig,
+) -> error::Result<actix_web::dev::Server> {
     // rustls 0.23 requires an explicit process-level CryptoProvider when
     // multiple backends could be linked. Prefer ring for portability.
     let _ = rustls::crypto::ring::default_provider().install_default();
 
-    let addr = conf.socket_addr()?;
+    let addr = if conf.listen_host.contains(':') {
+        format!("[{}]:{}", conf.listen_host, conf.listen_port)
+    } else {
+        format!("{}:{}", conf.listen_host, conf.listen_port)
+    };
     let hosts = vec![
         conf.listen_host.clone(),
         "localhost".to_string(),
@@ -150,18 +170,17 @@ pub async fn run(lampod: Arc<LampoDaemon>, conf: LndRestConfig) -> error::Result
         });
     }
 
-    HttpServer::new(move || {
+    let listen_host = conf.listen_host.clone();
+    let listen_port = conf.listen_port;
+    let server = HttpServer::new(move || {
         App::new()
             .app_data(state.clone())
             .app_data(web::JsonConfig::default().limit(1024 * 1024))
             .wrap(RequireMacaroon)
             .configure(routes::configure)
     })
-    .bind_rustls_0_23(addr, rustls_config)
+    .bind_rustls_0_23((listen_host.as_str(), listen_port), rustls_config)
     .map_err(|e| error::anyhow!("failed to bind LND REST on {addr}: {e}"))?
-    .run()
-    .await
-    .map_err(|e| error::anyhow!("LND REST server error: {e}"))?;
-
-    Ok(())
+    .run();
+    Ok(server)
 }

--- a/lampo-lnd/src/tls.rs
+++ b/lampo-lnd/src/tls.rs
@@ -1,0 +1,177 @@
+//! TLS certificate lifecycle for the LND-compatible REST listener.
+//!
+//! Certificates are generated once and reused across restarts so Zeus (and any
+//! cert pinning) keeps trusting the same identity.
+
+use std::fs::{self, OpenOptions};
+use std::io::{BufReader, Write};
+use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use rcgen::{CertificateParams, DistinguishedName, DnType, KeyPair, SanType};
+use rustls::pki_types::{CertificateDer, PrivateKeyDer, PrivatePkcs8KeyDer};
+use rustls::ServerConfig;
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum TlsError {
+    #[error("io error: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("tls error: {0}")]
+    Other(String),
+}
+
+#[derive(Clone, Debug)]
+pub struct TlsMaterial {
+    pub cert_path: PathBuf,
+    pub key_path: PathBuf,
+}
+
+impl TlsMaterial {
+    pub fn load_or_create(dir: impl AsRef<Path>, hostnames: &[String]) -> Result<Self, TlsError> {
+        let dir = dir.as_ref();
+        ensure_secure_dir(dir)?;
+        let cert_path = dir.join("tls.cert");
+        let key_path = dir.join("tls.key");
+
+        if cert_path.exists() || key_path.exists() {
+            if !(cert_path.exists() && key_path.exists()) {
+                return Err(TlsError::Other(
+                    "incomplete TLS material: both tls.cert and tls.key are required".into(),
+                ));
+            }
+            reject_symlink(&cert_path)?;
+            reject_symlink(&key_path)?;
+            return Ok(Self {
+                cert_path,
+                key_path,
+            });
+        }
+
+        let mut params =
+            CertificateParams::new(Vec::new()).map_err(|e| TlsError::Other(e.to_string()))?;
+        params.distinguished_name = DistinguishedName::new();
+        params
+            .distinguished_name
+            .push(DnType::CommonName, "lampo-lnd");
+
+        let mut sans = Vec::new();
+        for host in hostnames {
+            if let Ok(ip) = host.parse() {
+                sans.push(SanType::IpAddress(ip));
+            } else {
+                sans.push(SanType::DnsName(
+                    host.clone()
+                        .try_into()
+                        .map_err(|e| TlsError::Other(format!("{e}")))?,
+                ));
+            }
+        }
+        if sans.is_empty() {
+            sans.push(SanType::DnsName(
+                "localhost"
+                    .to_string()
+                    .try_into()
+                    .map_err(|e| TlsError::Other(format!("{e}")))?,
+            ));
+            sans.push(SanType::IpAddress(std::net::IpAddr::V4(
+                std::net::Ipv4Addr::LOCALHOST,
+            )));
+        }
+        params.subject_alt_names = sans;
+
+        let key_pair = KeyPair::generate().map_err(|e| TlsError::Other(e.to_string()))?;
+        let cert = params
+            .self_signed(&key_pair)
+            .map_err(|e| TlsError::Other(e.to_string()))?;
+
+        write_secret_file(&cert_path, cert.pem().as_bytes())?;
+        write_secret_file(&key_path, key_pair.serialize_pem().as_bytes())?;
+
+        Ok(Self {
+            cert_path,
+            key_path,
+        })
+    }
+
+    pub fn server_config(&self) -> Result<ServerConfig, TlsError> {
+        let cert_file = fs::File::open(&self.cert_path)?;
+        let mut cert_reader = BufReader::new(cert_file);
+        let certs: Vec<CertificateDer<'static>> = rustls_pemfile::certs(&mut cert_reader)
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|e| TlsError::Other(e.to_string()))?;
+
+        let key_file = fs::File::open(&self.key_path)?;
+        let mut key_reader = BufReader::new(key_file);
+        let key = rustls_pemfile::private_key(&mut key_reader)
+            .map_err(|e| TlsError::Other(e.to_string()))?
+            .ok_or_else(|| TlsError::Other("tls.key contained no private key".into()))?;
+
+        let key = match key {
+            PrivateKeyDer::Pkcs8(k) => {
+                PrivateKeyDer::Pkcs8(PrivatePkcs8KeyDer::from(k.secret_pkcs8_der().to_vec()))
+            }
+            other => other,
+        };
+
+        let mut config = ServerConfig::builder()
+            .with_no_client_auth()
+            .with_single_cert(certs, key)
+            .map_err(|e| TlsError::Other(e.to_string()))?;
+        config.alpn_protocols = vec![b"http/1.1".to_vec()];
+        Ok(config)
+    }
+
+    pub fn server_config_arc(&self) -> Result<Arc<ServerConfig>, TlsError> {
+        Ok(Arc::new(self.server_config()?))
+    }
+}
+
+fn ensure_secure_dir(path: &Path) -> Result<(), TlsError> {
+    if !path.exists() {
+        fs::create_dir_all(path)?;
+    }
+    let mut perms = fs::metadata(path)?.permissions();
+    perms.set_mode(0o700);
+    fs::set_permissions(path, perms)?;
+    Ok(())
+}
+
+fn reject_symlink(path: &Path) -> Result<(), TlsError> {
+    let meta = fs::symlink_metadata(path)?;
+    if meta.file_type().is_symlink() {
+        return Err(TlsError::Other(format!(
+            "refusing symlink TLS path {}",
+            path.display()
+        )));
+    }
+    Ok(())
+}
+
+fn write_secret_file(path: &Path, bytes: &[u8]) -> Result<(), TlsError> {
+    let mut file = OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .mode(0o600)
+        .open(path)?;
+    file.write_all(bytes)?;
+    file.sync_all()?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[test]
+    fn stable_across_restart() {
+        let dir = tempdir().unwrap();
+        let first = TlsMaterial::load_or_create(dir.path(), &["127.0.0.1".into()]).unwrap();
+        let cert1 = fs::read(&first.cert_path).unwrap();
+        let second = TlsMaterial::load_or_create(dir.path(), &["127.0.0.1".into()]).unwrap();
+        let cert2 = fs::read(&second.cert_path).unwrap();
+        assert_eq!(cert1, cert2);
+    }
+}

--- a/lampo-lnd/src/tls.rs
+++ b/lampo-lnd/src/tls.rs
@@ -34,6 +34,8 @@ impl TlsMaterial {
         ensure_secure_dir(dir)?;
         let cert_path = dir.join("tls.cert");
         let key_path = dir.join("tls.key");
+        let sans_path = dir.join("tls.sans");
+        let expected_sans = normalized_sans(hostnames);
 
         if cert_path.exists() || key_path.exists() {
             if !(cert_path.exists() && key_path.exists()) {
@@ -43,6 +45,26 @@ impl TlsMaterial {
             }
             reject_symlink(&cert_path)?;
             reject_symlink(&key_path)?;
+            if !sans_path.exists() {
+                return Err(TlsError::Other(format!(
+                    "existing TLS material has no SAN manifest; remove {}, {}, and {} \
+                     to regenerate it with the configured lnd-tls-san values",
+                    cert_path.display(),
+                    key_path.display(),
+                    sans_path.display()
+                )));
+            }
+            reject_symlink(&sans_path)?;
+            let actual_sans = fs::read_to_string(&sans_path)?;
+            if actual_sans != expected_sans {
+                return Err(TlsError::Other(format!(
+                    "configured TLS SANs changed; remove {}, {}, and {} to generate a new \
+                     certificate identity, then trust the new certificate in remote clients",
+                    cert_path.display(),
+                    key_path.display(),
+                    sans_path.display()
+                )));
+            }
             return Ok(Self {
                 cert_path,
                 key_path,
@@ -88,6 +110,7 @@ impl TlsMaterial {
 
         write_secret_file(&cert_path, cert.pem().as_bytes())?;
         write_secret_file(&key_path, key_pair.serialize_pem().as_bytes())?;
+        write_secret_file(&sans_path, expected_sans.as_bytes())?;
 
         Ok(Self {
             cert_path,
@@ -126,6 +149,17 @@ impl TlsMaterial {
     pub fn server_config_arc(&self) -> Result<Arc<ServerConfig>, TlsError> {
         Ok(Arc::new(self.server_config()?))
     }
+}
+
+fn normalized_sans(hostnames: &[String]) -> String {
+    let mut hostnames = hostnames
+        .iter()
+        .filter(|hostname| !hostname.is_empty())
+        .cloned()
+        .collect::<Vec<_>>();
+    hostnames.sort();
+    hostnames.dedup();
+    hostnames.join("\n")
 }
 
 fn ensure_secure_dir(path: &Path) -> Result<(), TlsError> {
@@ -173,5 +207,16 @@ mod tests {
         let second = TlsMaterial::load_or_create(dir.path(), &["127.0.0.1".into()]).unwrap();
         let cert2 = fs::read(&second.cert_path).unwrap();
         assert_eq!(cert1, cert2);
+    }
+
+    #[test]
+    fn rejects_stale_certificate_sans() {
+        let dir = tempdir().unwrap();
+        TlsMaterial::load_or_create(dir.path(), &["127.0.0.1".into()]).unwrap();
+
+        let err =
+            TlsMaterial::load_or_create(dir.path(), &["127.0.0.1".into(), "node.local".into()])
+                .unwrap_err();
+        assert!(err.to_string().contains("configured TLS SANs changed"));
     }
 }

--- a/lampo-lnd/src/wire_tests.rs
+++ b/lampo-lnd/src/wire_tests.rs
@@ -1,0 +1,63 @@
+#[cfg(test)]
+mod wire_tests {
+    use crate::convert;
+    use crate::lnrpc;
+    use serde::Deserialize;
+
+    #[test]
+    fn getinfo_uint64_serializes_as_string() {
+        let info = lnrpc::GetInfoResponse {
+            version: "0.18.5-beta".into(),
+            identity_pubkey: "02ab".into(),
+            block_height: 42,
+            synced_to_chain: true,
+            chains: vec![lnrpc::Chain {
+                network: "regtest".into(),
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+        let value = serde_json::to_value(&info).unwrap();
+        assert_eq!(value["version"], "0.18.5-beta");
+        assert_eq!(value["identityPubkey"], "02ab");
+        assert_eq!(value["blockHeight"], 42);
+        assert_eq!(value["chains"][0]["network"], "regtest");
+    }
+
+    #[test]
+    fn wallet_balance_int64_fields_present() {
+        let bal = lnrpc::WalletBalanceResponse {
+            total_balance: 1500,
+            confirmed_balance: 1000,
+            unconfirmed_balance: 500,
+            ..Default::default()
+        };
+        let value = serde_json::to_value(&bal).unwrap();
+        assert_eq!(value["confirmedBalance"], "1000");
+        assert_eq!(value["totalBalance"], "1500");
+    }
+
+    #[derive(Debug, Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    struct SendPaymentBody {
+        #[serde(default, alias = "payment_request")]
+        payment_request: String,
+    }
+
+    #[test]
+    fn accepts_zeus_camel_case_payment_request() {
+        let body: SendPaymentBody =
+            serde_json::from_str(r#"{"paymentRequest":"lnbc1..."}"#).unwrap();
+        assert_eq!(body.payment_request, "lnbc1...");
+    }
+
+    #[test]
+    fn normalize_r_hash_accepts_hex_and_base64() {
+        let hex = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+        assert_eq!(convert::normalize_r_hash(hex).as_deref(), Some(hex));
+        use base64::Engine;
+        let bytes = vec![0xaa; 32];
+        let b64 = base64::engine::general_purpose::STANDARD.encode(&bytes);
+        assert_eq!(convert::normalize_r_hash(&b64).as_deref(), Some(hex));
+    }
+}

--- a/lampo-testing/Cargo.toml
+++ b/lampo-testing/Cargo.toml
@@ -9,6 +9,7 @@ lampo-common = { path = "../lampo-common" }
 lampo-chain = { path = "../lampo-chain" }
 lampo-bdk-wallet = { path = "../lampo-bdk-wallet" }
 lampo-httpd = { path = "../lampo-httpd" }
+lampo-lnd = { path = "../lampo-lnd" }
 
 clightning-testing = { git = "https://github.com/laanwj/cln4rust.git"}
 log = "0.4.18"
@@ -16,3 +17,5 @@ tempfile = "3.21.0"
 port-selector = "0.1.6"
 anyhow = "1.0.102"
 tokio = { version = "1.50.0", features = ["process", "time", "fs", "rt-multi-thread"] }
+hex = "0.4"
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }

--- a/lampo-testing/src/lib.rs
+++ b/lampo-testing/src/lib.rs
@@ -145,7 +145,25 @@ impl LampoTesting {
         Self::with_conf(conf).await
     }
 
+    /// Same as [`Self::tmp`], but also starts the LND-compatible REST API.
+    ///
+    /// Prefer this only from LND REST tests: every node otherwise pays the
+    /// cost of an extra Actix HTTPS thread that is never torn down.
+    pub async fn tmp_with_lnd_rest() -> error::Result<Self> {
+        let mut conf = Conf::default();
+        conf.wallet = None;
+        let conf = Arc::new(conf);
+        Self::with_conf_inner(conf, true).await
+    }
+
     pub async fn with_conf(conf: Arc<Conf<'static>>) -> error::Result<Self> {
+        Self::with_conf_inner(conf, false).await
+    }
+
+    async fn with_conf_inner(
+        conf: Arc<Conf<'static>>,
+        enable_lnd_rest: bool,
+    ) -> error::Result<Self> {
         let conf_clone = conf.clone();
         let btc = tokio::task::spawn_blocking(move || {
             if let Ok(exec_path) = btc::exe_path() {
@@ -157,10 +175,14 @@ impl LampoTesting {
         })
         .await??;
         let btc = Arc::new(btc);
-        Self::new(btc).await
+        Self::new_inner(btc, enable_lnd_rest).await
     }
 
     pub async fn new(btc: Arc<BtcNode>) -> error::Result<Self> {
+        Self::new_inner(btc, false).await
+    }
+
+    async fn new_inner(btc: Arc<BtcNode>, enable_lnd_rest: bool) -> error::Result<Self> {
         let dir = tempfile::tempdir()?;
 
         // SAFETY: this should be safe because if the system has no
@@ -213,21 +235,38 @@ impl LampoTesting {
         run_httpd(lampo.clone()).await?;
         log::info!("httpd started");
 
-        let lnd_port = port::random_free_port().unwrap();
-        let (_, macaroon_hex) = run_lnd_rest(lampo.clone(), lnd_port).await?;
-        log::info!("lnd rest started on {lnd_port}");
+        let (lnd_port, macaroon_hex) = if enable_lnd_rest {
+            let lnd_port = port::random_free_port().unwrap();
+            let (_, macaroon_hex) = run_lnd_rest(lampo.clone(), lnd_port).await?;
+            log::info!("lnd rest started on {lnd_port}");
+            (lnd_port, macaroon_hex)
+        } else {
+            (0, String::new())
+        };
 
         // run lampo and take the handler over to run commands
         let handler = lampo.handler();
         tokio::spawn(lampo.listen());
 
-        // wait that lampo starts
-        while let Err(err) = handler
-            .call::<json::Value, response::GetInfo>("getinfo", json::json!({}))
-            .await
-        {
-            log::error!("error: `{}`", err);
-            tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+        // wait that lampo starts (bounded: an infinite wait hangs the whole CI job)
+        let mut ready = false;
+        for _ in 0..30 {
+            match handler
+                .call::<json::Value, response::GetInfo>("getinfo", json::json!({}))
+                .await
+            {
+                Ok(_) => {
+                    ready = true;
+                    break;
+                }
+                Err(err) => {
+                    log::error!("error: `{}`", err);
+                    tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+                }
+            }
+        }
+        if !ready {
+            error::bail!("lampo failed to become ready via getinfo within 30s");
         }
 
         let info: response::GetInfo = handler.call("getinfo", json::json!({})).await?;

--- a/lampo-testing/src/lib.rs
+++ b/lampo-testing/src/lib.rs
@@ -110,6 +110,7 @@ pub async fn run_lnd_rest(lampod: Arc<LampoDaemon>, port: u16) -> error::Result<
     let conf = LndRestConfig {
         listen_host: "127.0.0.1".to_string(),
         listen_port: port,
+        tls_extra_sans: Vec::new(),
         tls_dir: tls_dir.into(),
         macaroon_dir: macaroon_dir.into(),
     };

--- a/lampo-testing/src/lib.rs
+++ b/lampo-testing/src/lib.rs
@@ -27,6 +27,7 @@ use lampo_common::json;
 use lampo_common::model::request;
 use lampo_common::model::response;
 use lampo_httpd::handler::HttpdHandler;
+use lampo_lnd::LndRestConfig;
 use lampod::actions::handler::LampoHandler;
 use lampod::chain::WalletManager;
 use lampod::LampoDaemon;
@@ -101,6 +102,29 @@ pub async fn run_httpd(lampod: Arc<LampoDaemon>) -> error::Result<()> {
     Ok(())
 }
 
+pub async fn run_lnd_rest(lampod: Arc<LampoDaemon>, port: u16) -> error::Result<(u16, String)> {
+    let data = lampod.conf().path();
+    let tls_dir = format!("{data}/lnd-rest");
+    let macaroon_dir = format!("{data}/lnd-rest/macaroons");
+    let admin_path = format!("{macaroon_dir}/admin.macaroon");
+    let conf = LndRestConfig {
+        listen_host: "127.0.0.1".to_string(),
+        listen_port: port,
+        tls_dir: tls_dir.into(),
+        macaroon_dir: macaroon_dir.into(),
+    };
+    lampo_lnd::spawn(lampod, conf)?;
+
+    for _ in 0..100 {
+        if std::path::Path::new(&admin_path).exists() {
+            let bytes = tokio::fs::read(&admin_path).await?;
+            return Ok((port, hex::encode(bytes)));
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+    error::bail!("timed out waiting for LND REST admin.macaroon at {admin_path}")
+}
+
 pub struct LampoTesting {
     inner: Arc<LampoHandler>,
     root_path: Arc<TempDir>,
@@ -109,6 +133,8 @@ pub struct LampoTesting {
     pub mnemonic: String,
     pub btc: Arc<BtcNode>,
     pub info: response::GetInfo,
+    pub lnd_rest_port: u16,
+    pub lnd_admin_macaroon_hex: String,
 }
 
 impl LampoTesting {
@@ -187,6 +213,10 @@ impl LampoTesting {
         run_httpd(lampo.clone()).await?;
         log::info!("httpd started");
 
+        let lnd_port = port::random_free_port().unwrap();
+        let (_, macaroon_hex) = run_lnd_rest(lampo.clone(), lnd_port).await?;
+        log::info!("lnd rest started on {lnd_port}");
+
         // run lampo and take the handler over to run commands
         let handler = lampo.handler();
         tokio::spawn(lampo.listen());
@@ -210,6 +240,8 @@ impl LampoTesting {
             btc,
             root_path: Arc::new(dir),
             info,
+            lnd_rest_port: lnd_port,
+            lnd_admin_macaroon_hex: macaroon_hex,
         };
         node.fund_wallet(102).await?;
         Ok(node)

--- a/lampo-testing/src/lib.rs
+++ b/lampo-testing/src/lib.rs
@@ -377,6 +377,7 @@ impl LampoTesting {
                     port: None,
                     addr: None,
                     push_msat: None,
+                    sat_per_vbyte: None,
                 },
             )
             .await

--- a/lampo.example.conf
+++ b/lampo.example.conf
@@ -27,13 +27,13 @@ core-pass=lampo
 # The port where lampo will listen about p2p connection
 # port=39736
 
-# Enable the LND-compatible REST API for remote wallets like Zeus.
+# Serve the LND-compatible API instead of lampo-httpd for remote wallets like Zeus.
 # Writes tls.cert/tls.key and admin.macaroon under <datadir>/<network>/lnd-rest/.
-# IMPORTANT: keep api-host on loopback — lampo-httpd has no auth.
+# Uses api-host and api-port for its listener.
 # Macaroons have no expiry yet; rotate by deleting lnd-rest/macaroons/ carefully.
-# lnd-rest=true
-# lnd-rest-host=127.0.0.1
-# lnd-rest-port=8080
+# lnd=true
+# api-host=127.0.0.1
+# api-port=7979
 
 # Enable development sync mode (syncs every second instead of every 2 minutes)
 # Only use this for development/testing purposes

--- a/lampo.example.conf
+++ b/lampo.example.conf
@@ -27,6 +27,14 @@ core-pass=lampo
 # The port where lampo will listen about p2p connection
 # port=39736
 
+# Enable the LND-compatible REST API for remote wallets like Zeus.
+# Writes tls.cert/tls.key and admin.macaroon under <datadir>/<network>/lnd-rest/.
+# IMPORTANT: keep api-host on loopback — lampo-httpd has no auth.
+# Macaroons have no expiry yet; rotate by deleting lnd-rest/macaroons/ carefully.
+# lnd-rest=true
+# lnd-rest-host=127.0.0.1
+# lnd-rest-port=8080
+
 # Enable development sync mode (syncs every second instead of every 2 minutes)
 # Only use this for development/testing purposes
 # dev-sync=true

--- a/lampo.example.conf
+++ b/lampo.example.conf
@@ -34,6 +34,10 @@ core-pass=lampo
 # lnd=true
 # api-host=127.0.0.1
 # api-port=7979
+# Add the LAN DNS name or IP used by remote clients when api-host is a wildcard.
+# Repeat this setting for multiple certificate identities.
+# lnd-tls-san=lampo-node.local
+# lnd-tls-san=192.168.1.10
 
 # Enable development sync mode (syncs every second instead of every 2 minutes)
 # Only use this for development/testing purposes

--- a/lampo.example.conf
+++ b/lampo.example.conf
@@ -28,6 +28,7 @@ core-pass=lampo
 # port=39736
 
 # Serve the LND-compatible API instead of lampo-httpd for remote wallets like Zeus.
+# Requires lampod-cli to be built with `--features lnd`.
 # Writes tls.cert/tls.key and admin.macaroon under <datadir>/<network>/lnd-rest/.
 # Uses api-host and api-port for its listener.
 # Macaroons have no expiry yet; rotate by deleting lnd-rest/macaroons/ carefully.

--- a/lampod-cli/Cargo.toml
+++ b/lampod-cli/Cargo.toml
@@ -3,6 +3,9 @@ name = "lampod-cli"
 version = "0.1.0"
 edition = "2021"
 
+[features]
+default = []
+lnd = ["dep:lampo-lnd"]
 
 [dependencies]
 lampod = { path = "../lampod" }
@@ -10,7 +13,7 @@ lampo-common = { path = "../lampo-common" }
 lampo-chain = { path = "../lampo-chain" }
 lampo-bdk-wallet = { path = "../lampo-bdk-wallet" }
 lampo-httpd = { path = "../lampo-httpd" }
-lampo-lnd = { path = "../lampo-lnd" }
+lampo-lnd = { path = "../lampo-lnd", optional = true }
 tokio = { version = "1.50.0", features = ["rt", "macros", "time"] }
 clap = { version = "4.5", features = ["derive"] }
 filelock-rs = "0.1.0-beta.2"

--- a/lampod-cli/Cargo.toml
+++ b/lampod-cli/Cargo.toml
@@ -10,7 +10,8 @@ lampo-common = { path = "../lampo-common" }
 lampo-chain = { path = "../lampo-chain" }
 lampo-bdk-wallet = { path = "../lampo-bdk-wallet" }
 lampo-httpd = { path = "../lampo-httpd" }
-tokio = { version = "1.50.0", features = ["rt", "macros"] }
+lampo-lnd = { path = "../lampo-lnd" }
+tokio = { version = "1.50.0", features = ["rt", "macros", "time"] }
 clap = { version = "4.5", features = ["derive"] }
 filelock-rs = "0.1.0-beta.2"
 log = { version = "0.4", features = ["std"] }

--- a/lampod-cli/src/args.rs
+++ b/lampod-cli/src/args.rs
@@ -66,6 +66,18 @@ pub struct LampoCliArgs {
     #[arg(long = "api-port")]
     pub api_port: Option<u64>,
 
+    /// Enable the LND-compatible REST API (for Zeus)
+    #[arg(long = "lnd-rest")]
+    pub lnd_rest: bool,
+
+    /// LND REST listen host
+    #[arg(long = "lnd-rest-host")]
+    pub lnd_rest_host: Option<String>,
+
+    /// LND REST listen port (default 8080)
+    #[arg(long = "lnd-rest-port")]
+    pub lnd_rest_port: Option<u64>,
+
     /// Subcommand to run
     #[command(subcommand)]
     pub subcommand: Option<LampoCliSubcommand>,
@@ -118,6 +130,15 @@ impl TryInto<LampoConf> for LampoCliArgs {
         }
         if let Some(api_port) = self.api_port {
             conf.api_port = api_port;
+        }
+        if self.lnd_rest {
+            conf.lnd_rest = Some(true);
+        }
+        if let Some(host) = self.lnd_rest_host {
+            conf.lnd_rest_host = Some(host);
+        }
+        if let Some(port) = self.lnd_rest_port {
+            conf.lnd_rest_port = Some(port);
         }
         Ok(conf)
     }

--- a/lampod-cli/src/args.rs
+++ b/lampod-cli/src/args.rs
@@ -70,6 +70,10 @@ pub struct LampoCliArgs {
     #[arg(long = "lnd")]
     pub lnd: bool,
 
+    /// Add a DNS name or IP address to the LND REST TLS certificate
+    #[arg(long = "lnd-tls-san", value_delimiter = ',')]
+    pub lnd_tls_sans: Vec<String>,
+
     /// Subcommand to run
     #[command(subcommand)]
     pub subcommand: Option<LampoCliSubcommand>,
@@ -125,6 +129,9 @@ impl TryInto<LampoConf> for LampoCliArgs {
         }
         if self.lnd {
             conf.lnd = Some(true);
+        }
+        if !self.lnd_tls_sans.is_empty() {
+            conf.lnd_tls_sans = self.lnd_tls_sans;
         }
         Ok(conf)
     }

--- a/lampod-cli/src/args.rs
+++ b/lampod-cli/src/args.rs
@@ -66,17 +66,9 @@ pub struct LampoCliArgs {
     #[arg(long = "api-port")]
     pub api_port: Option<u64>,
 
-    /// Enable the LND-compatible REST API (for Zeus)
-    #[arg(long = "lnd-rest")]
-    pub lnd_rest: bool,
-
-    /// LND REST listen host
-    #[arg(long = "lnd-rest-host")]
-    pub lnd_rest_host: Option<String>,
-
-    /// LND REST listen port (default 8080)
-    #[arg(long = "lnd-rest-port")]
-    pub lnd_rest_port: Option<u64>,
+    /// Serve the LND-compatible API instead of lampo-httpd
+    #[arg(long = "lnd")]
+    pub lnd: bool,
 
     /// Subcommand to run
     #[command(subcommand)]
@@ -131,14 +123,8 @@ impl TryInto<LampoConf> for LampoCliArgs {
         if let Some(api_port) = self.api_port {
             conf.api_port = api_port;
         }
-        if self.lnd_rest {
-            conf.lnd_rest = Some(true);
-        }
-        if let Some(host) = self.lnd_rest_host {
-            conf.lnd_rest_host = Some(host);
-        }
-        if let Some(port) = self.lnd_rest_port {
-            conf.lnd_rest_port = Some(port);
+        if self.lnd {
+            conf.lnd = Some(true);
         }
         Ok(conf)
     }

--- a/lampod-cli/src/main.rs
+++ b/lampod-cli/src/main.rs
@@ -247,6 +247,7 @@ pub async fn run_lnd_rest_api(lampod: Arc<LampoDaemon>) -> error::Result<()> {
     let lnd_conf = LndRestConfig {
         listen_host: host.clone(),
         listen_port: port,
+        tls_extra_sans: conf.lnd_tls_sans.clone(),
         tls_dir: tls_dir.into(),
         macaroon_dir: macaroon_dir.clone().into(),
     };

--- a/lampod-cli/src/main.rs
+++ b/lampod-cli/src/main.rs
@@ -19,6 +19,7 @@ use lampo_common::conf::LampoConf;
 use lampo_common::error;
 use lampo_common::logger;
 use lampo_httpd::handler::HttpdHandler;
+#[cfg(feature = "lnd")]
 use lampo_lnd::{spawn as spawn_lnd_rest, LndRestConfig};
 use lampod::chain::WalletManager;
 use lampod::LampoDaemon;
@@ -194,7 +195,13 @@ async fn run(args: LampoCliArgs) -> error::Result<()> {
     let lampod = Arc::new(lampod);
 
     if lampo_conf.lnd.unwrap_or(false) {
+        #[cfg(feature = "lnd")]
         run_lnd_rest_api(lampod.clone()).await?;
+        #[cfg(not(feature = "lnd"))]
+        error::bail!(
+            "LND compatibility was requested but lampod-cli was built without it; \
+             rebuild with `--features lnd`"
+        );
     } else {
         run_httpd(lampod.clone()).await?;
         let handler = Arc::new(HttpdHandler::new(format!(
@@ -232,6 +239,7 @@ pub async fn run_httpd(lampod: Arc<LampoDaemon>) -> error::Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "lnd")]
 pub async fn run_lnd_rest_api(lampod: Arc<LampoDaemon>) -> error::Result<()> {
     let conf = lampod.conf();
     let host = conf
@@ -263,6 +271,7 @@ pub async fn run_lnd_rest_api(lampod: Arc<LampoDaemon>) -> error::Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "lnd")]
 fn lnd_api_port(port: u64) -> error::Result<u16> {
     let port =
         u16::try_from(port).map_err(|_| error::anyhow!("api-port must be between 1 and 65535"))?;
@@ -272,7 +281,7 @@ fn lnd_api_port(port: u64) -> error::Result<u16> {
     Ok(port)
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "lnd"))]
 mod tests {
     use super::lnd_api_port;
 

--- a/lampod-cli/src/main.rs
+++ b/lampod-cli/src/main.rs
@@ -193,14 +193,16 @@ async fn run(args: LampoCliArgs) -> error::Result<()> {
 
     let lampod = Arc::new(lampod);
 
-    run_httpd(lampod.clone()).await?;
-    run_lnd_rest_api(lampod.clone()).await?;
-
-    let handler = Arc::new(HttpdHandler::new(format!(
-        "{}:{}",
-        lampo_conf.api_host, lampo_conf.api_port
-    ))?);
-    lampod.add_external_handler(handler).await?;
+    if lampo_conf.lnd.unwrap_or(false) {
+        run_lnd_rest_api(lampod.clone()).await?;
+    } else {
+        run_httpd(lampod.clone()).await?;
+        let handler = Arc::new(HttpdHandler::new(format!(
+            "{}:{}",
+            lampo_conf.api_host, lampo_conf.api_port
+        ))?);
+        lampod.add_external_handler(handler).await?;
+    }
 
     // Signal the daemon to shut down gracefully on Ctrl+C.
     // This causes the LDK event processor to persist all state
@@ -232,31 +234,12 @@ pub async fn run_httpd(lampod: Arc<LampoDaemon>) -> error::Result<()> {
 
 pub async fn run_lnd_rest_api(lampod: Arc<LampoDaemon>) -> error::Result<()> {
     let conf = lampod.conf();
-    if !conf.lnd_rest.unwrap_or(false) {
-        log::info!(target: "lampod-cli", "LND REST API disabled (set lnd-rest=true to enable)");
-        return Ok(());
-    }
-
-    // Legacy lampo-httpd has no auth. Keep it loopback-only when exposing
-    // the Zeus/LND REST surface remotely.
-    let api_host = conf
+    let host = conf
         .api_host
         .trim_start_matches("http://")
-        .trim_start_matches("https://");
-    if api_host != "127.0.0.1" && api_host != "localhost" && api_host != "::1" {
-        log::warn!(
-            target: "lampod-cli",
-            "lnd-rest is enabled but api-host=`{}` is not loopback; \
-             lampo-httpd remains unauthenticated — bind it to 127.0.0.1",
-            conf.api_host
-        );
-    }
-
-    let host = conf
-        .lnd_rest_host
-        .clone()
-        .unwrap_or_else(|| "127.0.0.1".to_string());
-    let port = conf.lnd_rest_port.unwrap_or(8080) as u16;
+        .trim_start_matches("https://")
+        .to_string();
+    let port = lnd_api_port(conf.api_port)?;
     let data = conf.path();
     let tls_dir = format!("{data}/lnd-rest");
     let macaroon_dir = format!("{data}/lnd-rest/macaroons");
@@ -271,10 +254,31 @@ pub async fn run_lnd_rest_api(lampod: Arc<LampoDaemon>) -> error::Result<()> {
     spawn_lnd_rest(lampod, lnd_conf)?;
     log::info!(
         target: "lampod-cli",
-        "LND REST ready on https://{}:{} (macaroons under {})",
+        "LND API ready on https://{}:{} (macaroons under {})",
         host,
         port,
         macaroon_dir
     );
     Ok(())
+}
+
+fn lnd_api_port(port: u64) -> error::Result<u16> {
+    let port =
+        u16::try_from(port).map_err(|_| error::anyhow!("api-port must be between 1 and 65535"))?;
+    if port == 0 {
+        error::bail!("api-port must be between 1 and 65535");
+    }
+    Ok(port)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::lnd_api_port;
+
+    #[test]
+    fn lnd_api_port_rejects_zero_and_overflow() {
+        assert!(lnd_api_port(0).is_err());
+        assert!(lnd_api_port(u16::MAX as u64 + 1).is_err());
+        assert_eq!(lnd_api_port(8080).unwrap(), 8080);
+    }
 }

--- a/lampod-cli/src/main.rs
+++ b/lampod-cli/src/main.rs
@@ -19,6 +19,7 @@ use lampo_common::conf::LampoConf;
 use lampo_common::error;
 use lampo_common::logger;
 use lampo_httpd::handler::HttpdHandler;
+use lampo_lnd::{spawn as spawn_lnd_rest, LndRestConfig};
 use lampod::chain::WalletManager;
 use lampod::LampoDaemon;
 
@@ -193,6 +194,7 @@ async fn run(args: LampoCliArgs) -> error::Result<()> {
     let lampod = Arc::new(lampod);
 
     run_httpd(lampod.clone()).await?;
+    run_lnd_rest_api(lampod.clone()).await?;
 
     let handler = Arc::new(HttpdHandler::new(format!(
         "{}:{}",
@@ -225,5 +227,54 @@ pub async fn run_httpd(lampod: Arc<LampoDaemon>) -> error::Result<()> {
     }
     log::info!("preparing httpd api on addr `{url}`");
     tokio::spawn(lampo_httpd::run(lampod, http_hosting, url));
+    Ok(())
+}
+
+pub async fn run_lnd_rest_api(lampod: Arc<LampoDaemon>) -> error::Result<()> {
+    let conf = lampod.conf();
+    if !conf.lnd_rest.unwrap_or(false) {
+        log::info!(target: "lampod-cli", "LND REST API disabled (set lnd-rest=true to enable)");
+        return Ok(());
+    }
+
+    // Legacy lampo-httpd has no auth. Keep it loopback-only when exposing
+    // the Zeus/LND REST surface remotely.
+    let api_host = conf
+        .api_host
+        .trim_start_matches("http://")
+        .trim_start_matches("https://");
+    if api_host != "127.0.0.1" && api_host != "localhost" && api_host != "::1" {
+        log::warn!(
+            target: "lampod-cli",
+            "lnd-rest is enabled but api-host=`{}` is not loopback; \
+             lampo-httpd remains unauthenticated — bind it to 127.0.0.1",
+            conf.api_host
+        );
+    }
+
+    let host = conf
+        .lnd_rest_host
+        .clone()
+        .unwrap_or_else(|| "127.0.0.1".to_string());
+    let port = conf.lnd_rest_port.unwrap_or(8080) as u16;
+    let data = conf.path();
+    let tls_dir = format!("{data}/lnd-rest");
+    let macaroon_dir = format!("{data}/lnd-rest/macaroons");
+
+    let lnd_conf = LndRestConfig {
+        listen_host: host.clone(),
+        listen_port: port,
+        tls_dir: tls_dir.into(),
+        macaroon_dir: macaroon_dir.clone().into(),
+    };
+
+    spawn_lnd_rest(lampod, lnd_conf)?;
+    log::info!(
+        target: "lampod-cli",
+        "LND REST ready on https://{}:{} (macaroons under {})",
+        host,
+        port,
+        macaroon_dir
+    );
     Ok(())
 }

--- a/lampod/src/actions/handler.rs
+++ b/lampod/src/actions/handler.rs
@@ -271,20 +271,25 @@ impl Handler for LampoHandler {
                 }));
 
                 log::info!("propagate funding transaction for open a channel with `{counterparty_node_id}`");
-                // FIXME: estimate the fee rate with a callback
-                let fee = self
-                    .chain_manager
-                    .backend
-                    .fee_rate_estimation(6)
-                    .await
-                    .map_err(|err| {
-                        let msg = format!("Channel Opening Error: {err}");
-                        self.emit(Event::Lightning(LightningEvent::ChannelEvent {
-                            state: "error".to_owned(),
-                            message: msg,
-                        }));
-                        err
-                    })?;
+                let fee = match self
+                    .channel_manager
+                    .take_funding_fee_rate(&temporary_channel_id)?
+                {
+                    Some(sat_per_vbyte) => sat_per_vbyte,
+                    None => self
+                        .chain_manager
+                        .backend
+                        .fee_rate_estimation(6)
+                        .await
+                        .map_err(|err| {
+                            let msg = format!("Channel Opening Error: {err}");
+                            self.emit(Event::Lightning(LightningEvent::ChannelEvent {
+                                state: "error".to_owned(),
+                                message: msg,
+                            }));
+                            err
+                        })? as u64,
+                };
                 log::info!("fee estimated {:?} sats", fee);
 
                 let best_block = self.channel_manager.manager().current_best_block().height;
@@ -293,7 +298,7 @@ impl Handler for LampoHandler {
                     .create_transaction(
                         output_script,
                         Amount::from_sat(channel_value_satoshis),
-                        FeeRate::from_sat_per_vb_unchecked(fee as u64),
+                        FeeRate::from_sat_per_vb_unchecked(fee),
                         // FIXME: remove unwrap
                         Height::from_consensus(best_block).unwrap(),
                     )

--- a/lampod/src/jsonrpc/channels.rs
+++ b/lampod/src/jsonrpc/channels.rs
@@ -20,15 +20,15 @@ pub async fn json_close(ctx: &LampoDaemon, request: &json::Value) -> Result<json
     let mut request: request::CloseChannel = json::from_value(request.clone())?;
     let mut events = ctx.handler().events();
     // This gives all the channels with associated peer
-    let channels: response::Channels = ctx
-        .handler()
-        .call(
-            "channels",
-            json::json!({
-                "peer_id": request.node_id,
-            }),
-        )
-        .await?;
+    let channels = response::Channels {
+        channels: ctx
+            .channel_manager()
+            .list_channels()
+            .channels
+            .into_iter()
+            .filter(|channel| channel.peer_id == request.node_id)
+            .collect(),
+    };
 
     let res = if channels.channels.len() > 1 {
         // check the channel_id if it is not none, if it is return an error

--- a/lampod/src/jsonrpc/offchain.rs
+++ b/lampod/src/jsonrpc/offchain.rs
@@ -70,6 +70,7 @@ pub async fn json_decode(ctx: &LampoDaemon, request: &json::Value) -> Result<jso
         let bolt11_invoice = Bolt11InvoiceInfo {
             issuer_id: invoice.payee_pub_key().map(|id| id.to_string()),
             payment_hash: hex::encode(invoice.payment_hash().0),
+            timestamp: invoice.duration_since_epoch().as_secs(),
             amount_msat: invoice.amount_milli_satoshis(),
             network: invoice.network().to_string(),
             description: match invoice.description() {
@@ -126,7 +127,11 @@ pub async fn json_pay(ctx: &LampoDaemon, request: &json::Value) -> Result<json::
     // otherwise see this payment's result -- and now its preimage and payer
     // proof too. Only accept events carrying our own payment id.
     let payment_id = hex::encode(payment_id.0);
-    wait_for_payment_result(events, &payment_id, request.timeout.duration()).await
+    let timeout = request
+        .timeout_secs
+        .map(Duration::from_secs)
+        .unwrap_or_else(|| request.timeout.duration());
+    wait_for_payment_result(events, &payment_id, timeout).await
 }
 
 /// Hold the `PaymentReceipt` (preimage, payer proof) until the terminal

--- a/lampod/src/jsonrpc/offchain.rs
+++ b/lampod/src/jsonrpc/offchain.rs
@@ -69,6 +69,7 @@ pub async fn json_decode(ctx: &LampoDaemon, request: &json::Value) -> Result<jso
     {
         let bolt11_invoice = Bolt11InvoiceInfo {
             issuer_id: invoice.payee_pub_key().map(|id| id.to_string()),
+            payment_hash: hex::encode(invoice.payment_hash().0),
             amount_msat: invoice.amount_milli_satoshis(),
             network: invoice.network().to_string(),
             description: match invoice.description() {
@@ -79,7 +80,7 @@ pub async fn json_decode(ctx: &LampoDaemon, request: &json::Value) -> Result<jso
             },
             routes: Vec::new(),
             hints: Vec::new(),
-            expiry_time: Some(invoice.expiry_time().as_millis() as u64),
+            expiry_time: Some(invoice.expiry_time().as_secs()),
         };
 
         return Ok(json::to_value(&Decode::from(bolt11_invoice))?);
@@ -104,15 +105,22 @@ pub async fn json_pay(ctx: &LampoDaemon, request: &json::Value) -> Result<json::
     let payment_id = if let Ok(_) = offer::Offer::from_str(&request.invoice_str) {
         log::debug!("Paying offer with bolt12 invoice: {}", request.invoice_str);
         let payer_note = request.bolt12.and_then(|x| x.payer_note);
-        ctx.offchain_manager()
-            .pay_offer(&request.invoice_str, request.amount, payer_note)?
+        ctx.offchain_manager().pay_offer(
+            &request.invoice_str,
+            request.amount,
+            payer_note,
+            request.max_fee_msat,
+        )?
     } else {
         log::debug!(
             "Paying invoice with bolt11 invoice: {}",
             request.invoice_str
         );
-        ctx.offchain_manager()
-            .pay_invoice(&request.invoice_str, request.amount)?
+        ctx.offchain_manager().pay_invoice(
+            &request.invoice_str,
+            request.amount,
+            request.max_fee_msat,
+        )?
     };
     // The event bus broadcasts to every subscriber, so a concurrent `pay` would
     // otherwise see this payment's result -- and now its preimage and payer

--- a/lampod/src/jsonrpc/offchain.rs
+++ b/lampod/src/jsonrpc/offchain.rs
@@ -103,7 +103,21 @@ pub async fn json_pay(ctx: &LampoDaemon, request: &json::Value) -> Result<json::
     let request: Pay = json::from_value(request.clone())?;
     let mut events = ctx.handler().events();
 
-    let payment_id = if let Ok(_) = offer::Offer::from_str(&request.invoice_str) {
+    let parsed_offer = offer::Offer::from_str(&request.invoice_str);
+    let expected_value_msat = match &parsed_offer {
+        Ok(offer) => match offer.amount() {
+            Some(offer::Amount::Bitcoin { amount_msats }) => Some(amount_msats),
+            _ => request.amount,
+        },
+        Err(_) => ctx
+            .offchain_manager()
+            .decode_invoice(&request.invoice_str)
+            .ok()
+            .and_then(|invoice| invoice.amount_milli_satoshis())
+            .or(request.amount),
+    };
+
+    let payment_id = if parsed_offer.is_ok() {
         log::debug!("Paying offer with bolt12 invoice: {}", request.invoice_str);
         let payer_note = request.bolt12.and_then(|x| x.payer_note);
         ctx.offchain_manager().pay_offer(
@@ -133,7 +147,7 @@ pub async fn json_pay(ctx: &LampoDaemon, request: &json::Value) -> Result<json::
     // for the real terminal event so an in-flight payment is never reported as
     // failed merely because that deadline elapsed.
     let timeout = terminal_wait_timeout(request.timeout_secs, request.timeout.duration());
-    wait_for_payment_result(events, &payment_id, timeout).await
+    wait_for_payment_result(events, &payment_id, expected_value_msat, timeout).await
 }
 
 fn terminal_wait_timeout(
@@ -153,6 +167,7 @@ fn terminal_wait_timeout(
 async fn wait_for_payment_result(
     mut events: lampo_common::chan::UnboundedReceiver<Event>,
     payment_id: &str,
+    expected_value_msat: Option<u64>,
     timeout: Option<Duration>,
 ) -> Result<json::Value, Error> {
     // Regular JSON-RPC calls retain a single deadline for the whole wait.
@@ -163,6 +178,10 @@ async fn wait_for_payment_result(
     // The receipt lands on `PaymentReceipt` and the hop path on the terminal
     // `PaymentEvent`, so hold the receipt until the payment finishes.
     let mut receipt: Option<(String, Option<String>)> = None;
+    let mut successful_path = Vec::new();
+    let mut value_msat = 0_u64;
+    let mut fee_msat = 0_u64;
+    let mut successful_payment_hash = None;
 
     loop {
         log::warn!(target: "lampod::jsonrpc::offchain", "Waiting for payment event...");
@@ -203,16 +222,31 @@ async fn wait_for_payment_result(
                 payment_hash,
                 path,
                 state,
-                reason: _,
+                reason,
             }) if id == payment_id => {
+                if state == lampo_common::model::response::PaymentState::Success {
+                    let (path_value_msat, path_fee_msat) = path_value_and_fee(&path);
+                    value_msat = value_msat.saturating_add(path_value_msat);
+                    fee_msat = fee_msat.saturating_add(path_fee_msat);
+                    successful_path.extend(path);
+                    successful_payment_hash =
+                        successful_payment_hash.or_else(|| payment_hash.clone());
+
+                    if expected_value_msat.is_some_and(|expected| value_msat < expected) {
+                        continue;
+                    }
+                }
                 let (payment_preimage, payer_proof) = match receipt {
                     Some((preimage, proof)) => (Some(preimage), proof),
                     None => (None, None),
                 };
                 return Ok(json::to_value(PayResult {
                     state,
-                    path,
-                    payment_hash,
+                    path: successful_path,
+                    payment_hash: successful_payment_hash.or(payment_hash),
+                    value_msat,
+                    fee_msat,
+                    reason,
                     payment_preimage,
                     payer_proof,
                 })?);
@@ -233,7 +267,21 @@ pub async fn json_keysend(ctx: &LampoDaemon, request: &json::Value) -> Result<js
     // Same id semantics as `pay`: the hex payment hash identifies the
     // payment on the event bus.
     let payment_id = hex::encode(payment_id.0);
-    wait_for_payment_result(events, &payment_id, Some(request.timeout.duration())).await
+    wait_for_payment_result(
+        events,
+        &payment_id,
+        Some(request.amount_msat),
+        Some(request.timeout.duration()),
+    )
+    .await
+}
+
+fn path_value_and_fee(path: &[response::PaymentHop]) -> (u64, u64) {
+    let value_msat = path.last().map(|hop| hop.hop_fee_msat).unwrap_or(0);
+    let total_msat = path
+        .iter()
+        .fold(0_u64, |total, hop| total.saturating_add(hop.hop_fee_msat));
+    (value_msat, total_msat.saturating_sub(value_msat))
 }
 
 #[cfg(test)]
@@ -250,5 +298,19 @@ mod tests {
             terminal_wait_timeout(None, Duration::from_secs(120)),
             Some(Duration::from_secs(120))
         );
+    }
+
+    #[test]
+    fn aggregates_value_and_fees_per_mpp_path() {
+        let hop = |fee| response::PaymentHop {
+            node_id: String::new(),
+            short_channel_id: 0,
+            hop_fee_msat: fee,
+            cltv_expiry_delta: 0,
+            private_hop: false,
+        };
+
+        assert_eq!(path_value_and_fee(&[hop(20), hop(400)]), (400, 20));
+        assert_eq!(path_value_and_fee(&[hop(30), hop(600)]), (600, 30));
     }
 }

--- a/lampod/src/jsonrpc/offchain.rs
+++ b/lampod/src/jsonrpc/offchain.rs
@@ -121,17 +121,28 @@ pub async fn json_pay(ctx: &LampoDaemon, request: &json::Value) -> Result<json::
             &request.invoice_str,
             request.amount,
             request.max_fee_msat,
+            request.timeout_secs,
         )?
     };
     // The event bus broadcasts to every subscriber, so a concurrent `pay` would
     // otherwise see this payment's result -- and now its preimage and payer
     // proof too. Only accept events carrying our own payment id.
     let payment_id = hex::encode(payment_id.0);
-    let timeout = request
-        .timeout_secs
-        .map(Duration::from_secs)
-        .unwrap_or_else(|| request.timeout.duration());
+    // LND-compatible callers use `timeout_secs` as the retry deadline before
+    // an HTLC is launched. Once the payment API accepts an initial route, wait
+    // for the real terminal event so an in-flight payment is never reported as
+    // failed merely because that deadline elapsed.
+    let timeout = terminal_wait_timeout(request.timeout_secs, request.timeout.duration());
     wait_for_payment_result(events, &payment_id, timeout).await
+}
+
+fn terminal_wait_timeout(
+    compatible_retry_timeout_secs: Option<u64>,
+    default_timeout: Duration,
+) -> Option<Duration> {
+    compatible_retry_timeout_secs
+        .is_none()
+        .then_some(default_timeout)
 }
 
 /// Hold the `PaymentReceipt` (preimage, payer proof) until the terminal
@@ -142,14 +153,12 @@ pub async fn json_pay(ctx: &LampoDaemon, request: &json::Value) -> Result<json::
 async fn wait_for_payment_result(
     mut events: lampo_common::chan::UnboundedReceiver<Event>,
     payment_id: &str,
-    timeout: Duration,
+    timeout: Option<Duration>,
 ) -> Result<json::Value, Error> {
-    // Single deadline for the whole RPC wait. The event bus is broadcast, so
-    // unrelated events must not reset the timer — only the terminal
-    // `PaymentEvent` for `payment_id` completes the call (success or failure).
-    // If that event never arrives, stop waiting after `timeout` instead of
-    // blocking forever; the payment itself may still be retried in the background.
-    let deadline = Instant::now() + timeout;
+    // Regular JSON-RPC calls retain a single deadline for the whole wait.
+    // LND-compatible calls have no terminal deadline because their timeout only
+    // limits the period before launching an HTLC.
+    let deadline = timeout.map(|timeout| Instant::now() + timeout);
 
     // The receipt lands on `PaymentReceipt` and the hop path on the terminal
     // `PaymentEvent`, so hold the receipt until the payment finishes.
@@ -157,25 +166,29 @@ async fn wait_for_payment_result(
 
     loop {
         log::warn!(target: "lampod::jsonrpc::offchain", "Waiting for payment event...");
-        let event = tokio::time::timeout_at(deadline, events.recv())
-            .await
-            .map_err(|_| {
-                Error::Rpc(RpcError {
-                    code: -1,
-                    message: format!(
-                        "payment `{}` did not complete within {}s (no terminal Payment event; \
-                         payment status unknown — it may still be retried in the background)",
-                        payment_id,
-                        timeout.as_secs()
-                    ),
-                    data: None,
-                })
-            })?
-            .ok_or(Error::Rpc(RpcError {
-                code: -1,
-                message: format!("No event received, communication channel dropped"),
-                data: None,
-            }))?;
+        let event = if let Some(deadline) = deadline {
+            tokio::time::timeout_at(deadline, events.recv())
+                .await
+                .map_err(|_| {
+                    Error::Rpc(RpcError {
+                        code: -1,
+                        message: format!(
+                            "payment `{}` did not complete within {}s (no terminal Payment event; \
+                             payment status unknown — it may still be retried in the background)",
+                            payment_id,
+                            timeout.map(|value| value.as_secs()).unwrap_or_default()
+                        ),
+                        data: None,
+                    })
+                })?
+        } else {
+            events.recv().await
+        }
+        .ok_or(Error::Rpc(RpcError {
+            code: -1,
+            message: format!("No event received, communication channel dropped"),
+            data: None,
+        }))?;
 
         match event {
             Event::Lightning(LightningEvent::PaymentReceipt {
@@ -220,5 +233,22 @@ pub async fn json_keysend(ctx: &LampoDaemon, request: &json::Value) -> Result<js
     // Same id semantics as `pay`: the hex payment hash identifies the
     // payment on the event bus.
     let payment_id = hex::encode(payment_id.0);
-    wait_for_payment_result(events, &payment_id, request.timeout.duration()).await
+    wait_for_payment_result(events, &payment_id, Some(request.timeout.duration())).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn compatible_retry_deadline_does_not_end_terminal_wait() {
+        assert_eq!(
+            terminal_wait_timeout(Some(60), Duration::from_secs(120)),
+            None
+        );
+        assert_eq!(
+            terminal_wait_timeout(None, Duration::from_secs(120)),
+            Some(Duration::from_secs(120))
+        );
+    }
 }

--- a/lampod/src/jsonrpc/open_channel.rs
+++ b/lampod/src/jsonrpc/open_channel.rs
@@ -27,7 +27,7 @@ pub async fn json_fundchannel(
         log::trace!("we are not connected with the peer {}", request.node_id);
         let conn = request::Connect::try_from(request.clone())?;
         let conn = json::to_value(conn)?;
-        ctx.call("connect", conn).await?;
+        crate::jsonrpc::peer_control::json_connect(ctx, &conn).await?;
     }
 
     // FIXME: there are use case there need to be covered, like

--- a/lampod/src/ln/channel_manager.rs
+++ b/lampod/src/ln/channel_manager.rs
@@ -1,4 +1,5 @@
 //! Channel Manager Implementation
+use std::collections::HashMap;
 use std::fs::File;
 use std::io::BufReader;
 use std::path::Path;
@@ -35,7 +36,7 @@ use lampo_common::types::LampoChannel;
 use lampo_common::types::LampoGraph;
 use lampo_common::types::LampoRouter;
 use lampo_common::types::LampoScorer;
-use lampo_common::types::{LampoArcChannelManager, LampoChainMonitor};
+use lampo_common::types::{ChannelId, LampoArcChannelManager, LampoChainMonitor};
 
 use crate::actions::handler::LampoHandler;
 use crate::async_run;
@@ -51,6 +52,7 @@ pub struct LampoChannelManager {
     score: OnceLock<Arc<Mutex<LampoScorer>>>,
     handler: OnceLock<Arc<LampoHandler>>,
     router: OnceLock<Arc<LampoRouter>>,
+    funding_fee_rates: Mutex<HashMap<ChannelId, u64>>,
 
     pub(crate) onchain: Arc<LampoChainManager>,
     pub(crate) conf: LampoConf,
@@ -78,6 +80,7 @@ impl LampoChannelManager {
             graph: OnceLock::new(),
             score: OnceLock::new(),
             router: OnceLock::new(),
+            funding_fee_rates: Mutex::new(HashMap::new()),
         }
     }
 
@@ -253,7 +256,8 @@ impl LampoChannelManager {
         let mut config = self.conf.ldk_conf.clone();
         config.channel_handshake_config.announce_for_forwarding = open_channel.public;
         let push_msat = open_channel.push_msat.unwrap_or(0);
-        self.manager()
+        let temporary_channel_id = self
+            .manager()
             .create_channel(
                 open_channel.node_id()?,
                 open_channel.amount,
@@ -263,6 +267,12 @@ impl LampoChannelManager {
                 Some(config),
             )
             .map_err(|err| error::anyhow!("{:?}", err))?;
+        if let Some(sat_per_vbyte) = open_channel.sat_per_vbyte {
+            self.funding_fee_rates
+                .lock()
+                .map_err(|_| error::anyhow!("funding fee-rate lock is poisoned"))?
+                .insert(temporary_channel_id, sat_per_vbyte);
+        }
 
         // Wait for SendRawTransaction or FundingChannelFailed to be received
         let mut events = self.handler().events();
@@ -314,6 +324,17 @@ impl LampoChannelManager {
                 .map_err(|err| error::anyhow!("{:?}", err))?;
         }
         Ok(())
+    }
+
+    pub fn take_funding_fee_rate(
+        &self,
+        temporary_channel_id: &ChannelId,
+    ) -> error::Result<Option<u64>> {
+        Ok(self
+            .funding_fee_rates
+            .lock()
+            .map_err(|_| error::anyhow!("funding fee-rate lock is poisoned"))?
+            .remove(temporary_channel_id))
     }
 
     pub fn is_restarting(&self) -> error::Result<bool> {

--- a/lampod/src/ln/channel_manager.rs
+++ b/lampod/src/ln/channel_manager.rs
@@ -300,9 +300,19 @@ impl LampoChannelManager {
         let channel_id = channel.channel_id()?;
         let node_id = channel.counterpart_node_id()?;
 
-        self.manager()
-            .close_channel(&channel_id, &node_id)
-            .map_err(|err| error::anyhow!("{:?}", err))?;
+        if channel.force {
+            self.manager()
+                .force_close_broadcasting_latest_txn(
+                    &channel_id,
+                    &node_id,
+                    "Force close requested by RPC client".into(),
+                )
+                .map_err(|err| error::anyhow!("{:?}", err))?;
+        } else {
+            self.manager()
+                .close_channel(&channel_id, &node_id)
+                .map_err(|err| error::anyhow!("{:?}", err))?;
+        }
         Ok(())
     }
 

--- a/lampod/src/ln/offchain_manager.rs
+++ b/lampod/src/ln/offchain_manager.rs
@@ -148,6 +148,7 @@ impl OffchainManager {
         invoice_str: &str,
         amount_msat: Option<u64>,
         max_fee_msat: Option<u64>,
+        retry_timeout_secs: Option<u64>,
     ) -> error::Result<PaymentId> {
         // check if it is an invoice or an offer
         let invoice = self.decode_invoice(invoice_str)?;
@@ -167,7 +168,9 @@ impl OffchainManager {
                 payment_id,
                 amount_msat,
                 OptionalBolt11PaymentParams {
-                    retry_strategy: Retry::Attempts(10),
+                    retry_strategy: retry_timeout_secs
+                        .map(|seconds| Retry::Timeout(Duration::from_secs(seconds)))
+                        .unwrap_or(Retry::Attempts(10)),
                     route_params_config: ldk::routing::router::RouteParametersConfig {
                         max_total_routing_fee_msat: max_fee_msat,
                         ..Default::default()

--- a/lampod/src/ln/offchain_manager.rs
+++ b/lampod/src/ln/offchain_manager.rs
@@ -106,6 +106,7 @@ impl OffchainManager {
         offer_str: &str,
         amount_msat: Option<u64>,
         payer_note: Option<String>,
+        max_fee_msat: Option<u64>,
     ) -> error::Result<PaymentId> {
         // check if it is an invoice or an offer
         let offer_hash = Sha256::hash(offer_str.as_bytes());
@@ -131,6 +132,10 @@ impl OffchainManager {
                 OptionalOfferPaymentParams {
                     payer_note,
                     retry_strategy: Retry::Timeout(std::time::Duration::from_secs(1)),
+                    route_params_config: ldk::routing::router::RouteParametersConfig {
+                        max_total_routing_fee_msat: max_fee_msat,
+                        ..Default::default()
+                    },
                     ..Default::default()
                 },
             )
@@ -142,6 +147,7 @@ impl OffchainManager {
         &self,
         invoice_str: &str,
         amount_msat: Option<u64>,
+        max_fee_msat: Option<u64>,
     ) -> error::Result<PaymentId> {
         // check if it is an invoice or an offer
         let invoice = self.decode_invoice(invoice_str)?;
@@ -162,6 +168,10 @@ impl OffchainManager {
                 amount_msat,
                 OptionalBolt11PaymentParams {
                     retry_strategy: Retry::Attempts(10),
+                    route_params_config: ldk::routing::router::RouteParametersConfig {
+                        max_total_routing_fee_msat: max_fee_msat,
+                        ..Default::default()
+                    },
                     ..Default::default()
                 },
             )

--- a/tests/tests/Cargo.toml
+++ b/tests/tests/Cargo.toml
@@ -11,3 +11,4 @@ tokio-test-shutdown-timeout = "0.0.2"
 ntest = "0.9.0"
 serde_json = "1"
 log = "0.4"
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }

--- a/tests/tests/src/lampo_cln_tests.rs
+++ b/tests/tests/src/lampo_cln_tests.rs
@@ -76,6 +76,7 @@ pub async fn fund_a_simple_channel_from_lampo_to_cln() -> error::Result<()> {
                 public: true,
                 addr: Some("127.0.0.1".to_owned()),
                 push_msat: None,
+                sat_per_vbyte: None,
             },
         )
         .await?;

--- a/tests/tests/src/lampo_lnd_tests.rs
+++ b/tests/tests/src/lampo_lnd_tests.rs
@@ -1,0 +1,115 @@
+//! LND REST smoke tests (Zeus remote-node contract).
+//!
+//! Official `lncli` speaks gRPC only, so these tests exercise the REST
+//! surface with an HTTPS client the same way Zeus does.
+
+use lampo_common::error;
+use lampo_common::json;
+use lampo_testing::prelude::*;
+use lampo_testing::LampoTesting;
+
+use crate::init;
+
+async fn lnd_get(
+    node: &LampoTesting,
+    path: &str,
+    macaroon_hex: Option<&str>,
+) -> error::Result<(u16, json::Value)> {
+    let url = format!("https://127.0.0.1:{}{path}", node.lnd_rest_port);
+    let client = reqwest::Client::builder()
+        .danger_accept_invalid_certs(true)
+        .build()?;
+    let mut req = client.get(url);
+    if let Some(mac) = macaroon_hex {
+        req = req.header("Grpc-Metadata-macaroon", mac);
+    }
+    let resp = req.send().await?;
+    let status = resp.status().as_u16();
+    let body = resp.text().await?;
+    let value = serde_json::from_str(&body).unwrap_or(json::json!({ "raw": body }));
+    Ok((status, value))
+}
+
+#[tokio_test_shutdown_timeout::test(10)]
+pub async fn lnd_rest_getinfo_requires_macaroon() -> error::Result<()> {
+    init();
+    let node = LampoTesting::tmp().await?;
+
+    // Wait for the HTTPS listener to accept connections.
+    for _ in 0..40 {
+        match lnd_get(&node, "/v1/getinfo", None).await {
+            Ok((status, _)) if status == 401 => break,
+            Ok((status, _)) if status < 500 => break,
+            _ => tokio::time::sleep(std::time::Duration::from_millis(250)).await,
+        }
+    }
+
+    let (status, _) = lnd_get(&node, "/v1/getinfo", None).await?;
+    assert_eq!(status, 401, "missing macaroon must be unauthorized");
+    Ok(())
+}
+
+#[tokio_test_shutdown_timeout::test(10)]
+pub async fn lnd_rest_getinfo_with_admin_macaroon() -> error::Result<()> {
+    init();
+    let node = LampoTesting::tmp().await?;
+
+    let mut last = None;
+    for _ in 0..40 {
+        match lnd_get(&node, "/v1/getinfo", Some(&node.lnd_admin_macaroon_hex)).await {
+            Ok((200, body)) => {
+                last = Some(body);
+                break;
+            }
+            other => {
+                last = other.ok().map(|(_, b)| b);
+                tokio::time::sleep(std::time::Duration::from_millis(250)).await;
+            }
+        }
+    }
+
+    let body = last.expect("getinfo should succeed with admin macaroon");
+    assert_eq!(
+        body.get("identityPubkey")
+            .or_else(|| body.get("identity_pubkey"))
+            .and_then(|v| v.as_str()),
+        Some(node.info.node_id.as_str())
+    );
+    assert!(
+        body.get("version")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .contains("0.18"),
+        "version should look LND-like for Zeus feature gates: {body}"
+    );
+    Ok(())
+}
+
+#[tokio_test_shutdown_timeout::test(10)]
+pub async fn lnd_rest_wallet_balance_smoke() -> error::Result<()> {
+    init();
+    let node = LampoTesting::tmp().await?;
+
+    let mut ok = false;
+    for _ in 0..40 {
+        if let Ok((200, body)) = lnd_get(
+            &node,
+            "/v1/balance/blockchain",
+            Some(&node.lnd_admin_macaroon_hex),
+        )
+        .await
+        {
+            assert!(
+                body.get("confirmedBalance")
+                    .or_else(|| body.get("confirmed_balance"))
+                    .is_some(),
+                "unexpected balance body: {body}"
+            );
+            ok = true;
+            break;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(250)).await;
+    }
+    assert!(ok, "wallet balance endpoint should respond");
+    Ok(())
+}

--- a/tests/tests/src/lampo_lnd_tests.rs
+++ b/tests/tests/src/lampo_lnd_tests.rs
@@ -33,7 +33,7 @@ async fn lnd_get(
 #[tokio_test_shutdown_timeout::test(10)]
 pub async fn lnd_rest_getinfo_requires_macaroon() -> error::Result<()> {
     init();
-    let node = LampoTesting::tmp().await?;
+    let node = LampoTesting::tmp_with_lnd_rest().await?;
 
     // Wait for the HTTPS listener to accept connections.
     for _ in 0..40 {
@@ -52,7 +52,7 @@ pub async fn lnd_rest_getinfo_requires_macaroon() -> error::Result<()> {
 #[tokio_test_shutdown_timeout::test(10)]
 pub async fn lnd_rest_getinfo_with_admin_macaroon() -> error::Result<()> {
     init();
-    let node = LampoTesting::tmp().await?;
+    let node = LampoTesting::tmp_with_lnd_rest().await?;
 
     let mut last = None;
     for _ in 0..40 {
@@ -88,7 +88,7 @@ pub async fn lnd_rest_getinfo_with_admin_macaroon() -> error::Result<()> {
 #[tokio_test_shutdown_timeout::test(10)]
 pub async fn lnd_rest_wallet_balance_smoke() -> error::Result<()> {
     init();
-    let node = LampoTesting::tmp().await?;
+    let node = LampoTesting::tmp_with_lnd_rest().await?;
 
     let mut ok = false;
     for _ in 0..40 {

--- a/tests/tests/src/lampo_tests.rs
+++ b/tests/tests/src/lampo_tests.rs
@@ -72,6 +72,7 @@ pub async fn fund_a_simple_channel_from() -> error::Result<()> {
                 port: None,
                 addr: None,
                 push_msat: None,
+                sat_per_vbyte: None,
             },
         )
         .await
@@ -159,6 +160,7 @@ pub async fn fundchannel_honors_the_public_flag() -> error::Result<()> {
                     port: None,
                     addr: None,
                     push_msat: None,
+                    sat_per_vbyte: None,
                 },
             )
             .await
@@ -278,6 +280,7 @@ pub async fn pay_invoice_simple_case_lampo() -> error::Result<()> {
                 max_fee_msat: None,
                 bolt12: None,
                 timeout: Default::default(),
+                timeout_secs: None,
             },
         )
         .await?;
@@ -328,6 +331,7 @@ pub async fn pay_offer_simple_case_lampo() -> error::Result<()> {
                 max_fee_msat: None,
                 bolt12: None,
                 timeout: Default::default(),
+                timeout_secs: None,
             },
         )
         .await?;
@@ -394,6 +398,7 @@ pub async fn pay_offer_minimal_offer() -> error::Result<()> {
                 max_fee_msat: None,
                 bolt12: None,
                 timeout: Default::default(),
+                timeout_secs: None,
             },
         )
         .await?;
@@ -448,6 +453,7 @@ pub async fn decode_invoice() -> error::Result<()> {
 
     assert_eq!(decode.issuer_id.clone(), Some(node2.info.node_id.clone()));
     assert_eq!(decode.payment_hash.len(), 64);
+    assert!(decode.timestamp > 0);
     assert_eq!(decode.expiry_time, Some(10_000));
     log::info!(target: &node2.info.node_id, "decode offer `{:?}`", decode);
 
@@ -461,6 +467,7 @@ pub async fn decode_invoice() -> error::Result<()> {
                 max_fee_msat: None,
                 bolt12: None,
                 timeout: Default::default(),
+                timeout_secs: None,
             },
         )
         .await?;
@@ -533,6 +540,7 @@ pub async fn decode_offer_hex() -> error::Result<()> {
                 max_fee_msat: None,
                 bolt12: None,
                 timeout: Default::default(),
+                timeout_secs: None,
             },
         )
         .await?;

--- a/tests/tests/src/lampo_tests.rs
+++ b/tests/tests/src/lampo_tests.rs
@@ -275,6 +275,7 @@ pub async fn pay_invoice_simple_case_lampo() -> error::Result<()> {
             request::Pay {
                 invoice_str: invoice.bolt11,
                 amount: None,
+                max_fee_msat: None,
                 bolt12: None,
                 timeout: Default::default(),
             },
@@ -324,6 +325,7 @@ pub async fn pay_offer_simple_case_lampo() -> error::Result<()> {
             request::Pay {
                 invoice_str: offer.bolt12,
                 amount: None,
+                max_fee_msat: None,
                 bolt12: None,
                 timeout: Default::default(),
             },
@@ -389,6 +391,7 @@ pub async fn pay_offer_minimal_offer() -> error::Result<()> {
             request::Pay {
                 invoice_str: offer.bolt12,
                 amount: Some(100_000),
+                max_fee_msat: None,
                 bolt12: None,
                 timeout: Default::default(),
             },
@@ -444,6 +447,8 @@ pub async fn decode_invoice() -> error::Result<()> {
     };
 
     assert_eq!(decode.issuer_id.clone(), Some(node2.info.node_id.clone()));
+    assert_eq!(decode.payment_hash.len(), 64);
+    assert_eq!(decode.expiry_time, Some(10_000));
     log::info!(target: &node2.info.node_id, "decode offer `{:?}`", decode);
 
     let pay: response::PayResult = node1
@@ -453,6 +458,7 @@ pub async fn decode_invoice() -> error::Result<()> {
             request::Pay {
                 invoice_str: invoice.bolt11,
                 amount: None,
+                max_fee_msat: None,
                 bolt12: None,
                 timeout: Default::default(),
             },
@@ -524,6 +530,7 @@ pub async fn decode_offer_hex() -> error::Result<()> {
             request::Pay {
                 invoice_str: offer.bolt12,
                 amount: None,
+                max_fee_msat: None,
                 bolt12: None,
                 timeout: Default::default(),
             },

--- a/tests/tests/src/lib.rs
+++ b/tests/tests/src/lib.rs
@@ -1,6 +1,8 @@
 #[cfg(test)]
 pub mod lampo_cln_tests;
 #[cfg(test)]
+pub mod lampo_lnd_tests;
+#[cfg(test)]
 pub mod lampo_tests;
 #[cfg(test)]
 mod utils;

--- a/tools/lnd-rest-smoke.sh
+++ b/tools/lnd-rest-smoke.sh
@@ -9,12 +9,12 @@
 #   ./tools/lnd-rest-smoke.sh [host] [port] [macaroon_path]
 #
 # Defaults:
-#   host=127.0.0.1 port=8080
+#   host=127.0.0.1 port=7979
 #   macaroon_path=$LAMPO_DIR/<network>/lnd-rest/macaroons/admin.macaroon
 set -euo pipefail
 
 HOST="${1:-127.0.0.1}"
-PORT="${2:-8080}"
+PORT="${2:-7979}"
 MACAROON_PATH="${3:-}"
 
 if [[ -z "${MACAROON_PATH}" ]]; then

--- a/tools/lnd-rest-smoke.sh
+++ b/tools/lnd-rest-smoke.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# Smoke-test lampo's LND-compatible REST API the way Zeus does.
+#
+# Official `lncli` is gRPC-only and cannot validate a REST-only listener.
+# This script mirrors the LND docs curl examples:
+#   https://docs.lightning.engineering/lightning-network-tools/lnd/macaroons
+#
+# Usage:
+#   ./tools/lnd-rest-smoke.sh [host] [port] [macaroon_path]
+#
+# Defaults:
+#   host=127.0.0.1 port=8080
+#   macaroon_path=$LAMPO_DIR/<network>/lnd-rest/macaroons/admin.macaroon
+set -euo pipefail
+
+HOST="${1:-127.0.0.1}"
+PORT="${2:-8080}"
+MACAROON_PATH="${3:-}"
+
+if [[ -z "${MACAROON_PATH}" ]]; then
+  if [[ -z "${LAMPO_DIR:-}" ]]; then
+    echo "Provide macaroon path or set LAMPO_DIR" >&2
+    exit 1
+  fi
+  NETWORK="${LAMPO_NETWORK:-testnet}"
+  MACAROON_PATH="${LAMPO_DIR}/${NETWORK}/lnd-rest/macaroons/admin.macaroon"
+fi
+
+if [[ ! -f "${MACAROON_PATH}" ]]; then
+  echo "macaroon not found: ${MACAROON_PATH}" >&2
+  exit 1
+fi
+
+MACAROON_HEX="$(xxd -p -c 100000 "${MACAROON_PATH}" | tr -d '\n')"
+BASE="https://${HOST}:${PORT}"
+
+echo "==> GET ${BASE}/v1/getinfo"
+curl -sk \
+  --header "Grpc-Metadata-macaroon: ${MACAROON_HEX}" \
+  "${BASE}/v1/getinfo" | python3 -m json.tool
+
+echo
+echo "==> GET ${BASE}/v1/balance/blockchain"
+curl -sk \
+  --header "Grpc-Metadata-macaroon: ${MACAROON_HEX}" \
+  "${BASE}/v1/balance/blockchain" | python3 -m json.tool
+
+echo
+echo "==> GET ${BASE}/v1/channels"
+curl -sk \
+  --header "Grpc-Metadata-macaroon: ${MACAROON_HEX}" \
+  "${BASE}/v1/channels" | python3 -m json.tool
+
+echo
+echo "OK: LND REST smoke passed"


### PR DESCRIPTION
## Summary
- New `lampo-lnd` crate (Approach C): LND `v0.20` protos via `prost`/`pbjson`, TLS cert lifecycle, HMAC macaroon bakery with entity/action permissions, Actix REST routes Zeus needs for a remote LND node.
- Wired behind `lnd-rest=true` / `--lnd-rest` (default off). Materials under `<datadir>/<network>/lnd-rest/`.
- Does **not** take over [#474](https://github.com/vincenzopalazzo/lampo.rs/pull/474) (stale gRPC-only spike); Zeus remote is REST-only.
- Official `lncli` cannot smoke this surface (gRPC-only). Use `tools/lnd-rest-smoke.sh` or the new integration tests.

## Test plan
- [x] `cargo test -p lampo-lnd --lib` (bakery, TLS, pbjson wire, camelCase body)
- [x] `BITCOIND_EXE=... cargo test -p tests lnd_rest` (HTTPS getinfo auth + balance smoke)
- [ ] Manual: enable `lnd-rest=true`, run `./tools/lnd-rest-smoke.sh`, connect Zeus with host/port/hex admin macaroon
- [ ] Confirm legacy `lampo-httpd` stays on loopback when exposing LND REST

## Notes
- `getinfo.version` reports `0.18.5-beta` for Zeus feature gates.
- Invoice settle updates from LDK `PaymentClaimed` into an in-memory index (not durable yet).
- Plan/brainstorm: `docs/plans/2026-08-16-lnd-rest-api-zeus.md`, `docs/brainstorms/2026-08-16-lnd-rest-api-zeus.md`.

Made with [Cursor](https://cursor.com)