### PR TITLE
node: Sweep spendable outputs of closed channels

### DIFF
--- a/lampo-bdk-wallet/src/lib.rs
+++ b/lampo-bdk-wallet/src/lib.rs
@@ -27,8 +27,11 @@ use tokio_cron_scheduler::{Job, JobScheduler};
 use lampo_common::bitcoin::absolute::Height;
 use lampo_common::bitcoin::bip32::Xpriv;
 use lampo_common::bitcoin::blockdata::locktime::absolute::LockTime;
+use lampo_common::bitcoin::psbt::Psbt;
 use lampo_common::bitcoin::PrivateKey;
-use lampo_common::bitcoin::{Amount, Block, FeeRate, ScriptBuf, Transaction};
+use lampo_common::bitcoin::{
+    Amount, Block, FeeRate, OutPoint, ScriptBuf, Transaction, TxOut, Txid,
+};
 use lampo_common::chainsync::ChainSyncCoordinator;
 use lampo_common::conf::{LampoConf, Network};
 use lampo_common::keys::LampoKeys;
@@ -137,7 +140,8 @@ impl BDKWalletManager {
             None => LampoKeys::new(xprv.inner.secret_bytes()),
         };
 
-        let mut db = Connection::open_in_memory()?;
+        let path_db = format!("{}/bdk-wallet.db", conf.path());
+        let mut db = Connection::open(path_db)?;
 
         let xpriv = Xpriv::new_master(conf.network, &xprv.inner.secret_bytes())?;
 
@@ -283,13 +287,53 @@ impl WalletManager for BDKWalletManager {
     }
 
     async fn get_onchain_address(&self) -> error::Result<NewAddress> {
+        let script = self.next_wallet_script()?;
+        Ok(NewAddress {
+            address: lampo_common::bitcoin::Address::from_script(&script, self.network)?
+                .to_string(),
+        })
+    }
+
+    fn next_wallet_script(&self) -> error::Result<ScriptBuf> {
         let mut wallet = self.wallet.lock().unwrap();
         let mut wallet_db = self.wallet_db.lock().unwrap();
         let address = wallet.reveal_next_address(KeychainKind::External);
         wallet.persist(&mut wallet_db)?;
-        Ok(NewAddress {
-            address: address.address.to_string(),
-        })
+        Ok(address.address.script_pubkey())
+    }
+
+    fn is_mine(&self, script: &ScriptBuf) -> bool {
+        self.wallet.lock().unwrap().is_mine(script.clone())
+    }
+
+    fn confirmed_utxos(&self) -> error::Result<Vec<(OutPoint, TxOut)>> {
+        let wallet = self.wallet.lock().unwrap();
+        Ok(wallet
+            .list_unspent()
+            .filter(|utxo| utxo.chain_position.is_confirmed())
+            .map(|utxo| (utxo.outpoint, utxo.txout))
+            .collect())
+    }
+
+    fn get_transaction(&self, txid: Txid) -> error::Result<Option<Transaction>> {
+        Ok(self
+            .wallet
+            .lock()
+            .unwrap()
+            .tx_details(txid)
+            .map(|details| details.tx.as_ref().clone()))
+    }
+
+    fn sign_psbt(&self, mut psbt: Psbt) -> error::Result<Transaction> {
+        let wallet = self.wallet.lock().unwrap();
+        let mut sign_options = SignOptions::default();
+        sign_options.trust_witness_utxo = true;
+        wallet.sign(&mut psbt, sign_options)?;
+        match psbt.extract_tx() {
+            Ok(tx) => Ok(tx),
+            Err(lampo_common::bitcoin::psbt::ExtractTxError::MissingInputValue { tx }) => Ok(tx),
+            Err(err) => error::bail!("failed to extract signed bump transaction: {err}"),
+        }
     }
 
     // Return in satoshis

--- a/lampo-chain/src/lib.rs
+++ b/lampo-chain/src/lib.rs
@@ -498,14 +498,18 @@ impl Backend for LampoChainSync {
                     }
                 }
             }
-            if let Some((best_block, ref sweeper)) = sweeper_listener {
+            if let Some((_, ref sweeper)) = sweeper_listener {
+                // Re-read the sweeper's own checkpoint each attempt: a timed-out
+                // `synchronize_listeners` may already have advanced and persisted
+                // it, and replaying from the pre-loop locator would be out of order.
+                let best_block = sweeper.current_best_block();
                 log::info!(
                     target: "lampo-chain",
                     "Including output sweeper in chain sync from height {}",
                     best_block.height
                 );
                 chain_listeners.push((
-                    best_block.clone(),
+                    best_block,
                     sweeper.as_ref() as &(dyn chain::Listen + Send + Sync),
                 ));
             }

--- a/lampo-chain/src/lib.rs
+++ b/lampo-chain/src/lib.rs
@@ -18,7 +18,7 @@ use lampo_common::error;
 use lampo_common::json;
 use lampo_common::ldk::chain;
 use lampo_common::serde::Deserialize;
-use lampo_common::types::{LampoChainMonitor, LampoChannel};
+use lampo_common::types::{LampoChainMonitor, LampoChannel, LampoSweeper};
 use lampo_common::wallet::WalletManager;
 
 /// Adapts the on-chain wallet to LDK's [`chain::Listen`] so it can ride the
@@ -100,6 +100,41 @@ fn mark_initial_sync_complete(
     }
 }
 
+/// The set of ongoing chain listeners fed by the SPV client after the
+/// initial synchronization. The sweeper has to stay on this path: without
+/// block notifications it never sees a sweep confirm and tracked outputs
+/// stay pending forever.
+struct ChainListeners {
+    chain_monitor: Arc<LampoChainMonitor>,
+    channel_manager: Arc<LampoChannel>,
+    sweeper: Option<Arc<LampoSweeper>>,
+}
+
+impl chain::Listen for ChainListeners {
+    fn filtered_block_connected(
+        &self,
+        header: &lampo_common::bitcoin::block::Header,
+        txdata: &chain::transaction::TransactionData,
+        height: u32,
+    ) {
+        self.chain_monitor
+            .filtered_block_connected(header, txdata, height);
+        self.channel_manager
+            .filtered_block_connected(header, txdata, height);
+        if let Some(ref sweeper) = self.sweeper {
+            sweeper.filtered_block_connected(header, txdata, height);
+        }
+    }
+
+    fn blocks_disconnected(&self, fork_point: chain::BlockLocator) {
+        self.chain_monitor.blocks_disconnected(fork_point.clone());
+        self.channel_manager.blocks_disconnected(fork_point.clone());
+        if let Some(ref sweeper) = self.sweeper {
+            sweeper.blocks_disconnected(fork_point);
+        }
+    }
+}
+
 /// Welcome in another Facede pattern implementation
 pub struct LampoChainSync {
     config: Arc<LampoConf>,
@@ -109,6 +144,9 @@ pub struct LampoChainSync {
     handler: OnceLock<Arc<dyn lampo_common::handler::Handler>>,
     coordinator: OnceLock<Arc<ChainSyncCoordinator>>,
     wallet: OnceLock<Arc<dyn WalletManager>>,
+    /// The output sweeper, registered as an ongoing chain listener with the
+    /// best block its persisted state was last synced to.
+    sweeper: OnceLock<(chain::BlockLocator, Arc<LampoSweeper>)>,
 }
 
 impl LampoChainSync {
@@ -145,6 +183,7 @@ impl LampoChainSync {
             handler: OnceLock::new(),
             coordinator: OnceLock::new(),
             wallet: OnceLock::new(),
+            sweeper: OnceLock::new(),
         })
     }
 
@@ -176,6 +215,10 @@ impl LampoChainSync {
 
     fn wallet(&self) -> Option<Arc<dyn WalletManager>> {
         self.wallet.get().cloned()
+    }
+
+    fn sweeper(&self) -> Option<(chain::BlockLocator, Arc<LampoSweeper>)> {
+        self.sweeper.get().cloned()
     }
 }
 
@@ -358,9 +401,19 @@ impl Backend for LampoChainSync {
         }
     }
 
+    fn set_sweeper(&self, best_block: chain::BlockLocator, sweeper: Arc<LampoSweeper>) {
+        if self.sweeper.set((best_block, sweeper)).is_err() {
+            log::debug!(
+                target: "lampo-chain",
+                "output sweeper already set; keeping existing"
+            );
+        }
+    }
+
     async fn listen(self: Arc<Self>) -> lampo_common::error::Result<()> {
         let channel_manager = self.channel_manager();
         let chain_monitor = self.chain_monitor();
+        let sweeper_listener = self.sweeper();
 
         // Synchronize the channel manager and chain monitor from their
         // persisted best block up to the current chain tip. This is critical
@@ -445,6 +498,17 @@ impl Backend for LampoChainSync {
                     }
                 }
             }
+            if let Some((best_block, ref sweeper)) = sweeper_listener {
+                log::info!(
+                    target: "lampo-chain",
+                    "Including output sweeper in chain sync from height {}",
+                    best_block.height
+                );
+                chain_listeners.push((
+                    best_block.clone(),
+                    sweeper.as_ref() as &(dyn chain::Listen + Send + Sync),
+                ));
+            }
 
             // Bound each pass: a hung backend (the lightning-block-sync
             // `RpcClient` has no read timeout) must not stall the listener
@@ -501,7 +565,11 @@ impl Backend for LampoChainSync {
             );
         }
 
-        let chain_listener = (chain_monitor, channel_manager);
+        let chain_listener = ChainListeners {
+            chain_monitor,
+            channel_manager,
+            sweeper: sweeper_listener.map(|(_, sweeper)| sweeper),
+        };
         let chain_poller = poll::ChainPoller::new(self.as_ref(), self.config.network);
         let mut spv_client = SpvClient::new(synced_chain_tip, chain_poller, cache, &chain_listener);
         log::info!(target: "lampo-chain", "Start Backend ...");

--- a/lampo-common/src/backend.rs
+++ b/lampo-common/src/backend.rs
@@ -16,7 +16,8 @@ use serde::{Deserialize, Serialize};
 use crate::chainsync::ChainSyncCoordinator;
 use crate::error;
 use crate::handler::Handler;
-use crate::types::{LampoChainMonitor, LampoChannel};
+use crate::ldk::chain::BlockLocator;
+use crate::types::{LampoChainMonitor, LampoChannel, LampoSweeper};
 use crate::wallet::WalletManager;
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -130,6 +131,12 @@ pub trait Backend: Send + Sync {
     fn set_channel_manager(&self, _: Arc<LampoChannel>) {}
 
     fn set_chain_monitor(&self, _: Arc<LampoChainMonitor>) {}
+
+    /// Register the output sweeper as a chain listener, together with the
+    /// best block its persisted state was last synced to. Without this the
+    /// sweeper never learns that a sweep confirmed, and tracked outputs
+    /// stay pending across restarts.
+    fn set_sweeper(&self, _: BlockLocator, _: Arc<LampoSweeper>) {}
 
     /// Inject the backend-agnostic chain-sync coordinator so the backend can
     /// publish listener-sync progress. Default no-op.

--- a/lampo-common/src/keys.rs
+++ b/lampo-common/src/keys.rs
@@ -1,11 +1,17 @@
-use std::{sync::Arc, time::SystemTime};
+use std::sync::{Arc, OnceLock, Weak};
+use std::time::SystemTime;
 
 #[cfg(feature = "unsafe_channel_keys")]
 use bitcoin::secp256k1::SecretKey;
 use lightning::bolt11_invoice;
-use lightning::sign::{InMemorySigner, NodeSigner, OutputSpender, SignerProvider};
+use lightning::ln::script::ShutdownScript;
+use lightning::sign::{
+    ChangeDestinationSource, EntropySource, InMemorySigner, NodeSigner, OutputSpender,
+    SignerProvider,
+};
 
-use crate::ldk::sign::{EntropySource, KeysManager};
+use crate::ldk::sign::KeysManager;
+use crate::wallet::WalletManager;
 
 /// Lampo keys implementations
 pub struct LampoKeys {
@@ -59,6 +65,8 @@ impl LampoKeys {
 
 pub struct LampoKeysManager {
     pub(crate) inner: KeysManager,
+    /// Weak so the wallet can own this keys manager without a cycle.
+    wallet: OnceLock<Weak<dyn WalletManager>>,
 
     #[cfg(feature = "unsafe_channel_keys")]
     funding_key: Option<SecretKey>,
@@ -81,6 +89,7 @@ impl LampoKeysManager {
         let inner = KeysManager::new(seed, starting_time_secs, starting_time_nanos, false);
         Self {
             inner,
+            wallet: OnceLock::new(),
             #[cfg(feature = "unsafe_channel_keys")]
             funding_key: None,
             #[cfg(feature = "unsafe_channel_keys")]
@@ -115,6 +124,26 @@ impl LampoKeysManager {
             Some(SecretKey::from_str(&delayed_payment_base_secret).unwrap());
         self.htlc_base_secret = Some(SecretKey::from_str(&htlc_base_secret).unwrap());
         self.shachain_seed = Some(self.inner.get_secure_random_bytes())
+    }
+
+    pub fn set_wallet(&self, wallet: Arc<dyn WalletManager>) {
+        let _ = self.wallet.set(Arc::downgrade(&wallet));
+    }
+
+    fn wallet_script(&self) -> Result<bitcoin::ScriptBuf, ()> {
+        self.wallet
+            .get()
+            .and_then(|wallet| wallet.upgrade())
+            .ok_or(())?
+            .next_wallet_script()
+            .map_err(|err| {
+                log::error!(target: "lampo-keys", "wallet script: {err}");
+            })
+    }
+
+    fn destination_script(&self, channel_keys_id: [u8; 32]) -> Result<bitcoin::ScriptBuf, ()> {
+        self.wallet_script()
+            .or_else(|_| self.inner.get_destination_script(channel_keys_id))
     }
 }
 
@@ -237,10 +266,21 @@ impl SignerProvider for LampoKeysManager {
     }
 
     fn get_destination_script(&self, channel_keys_id: [u8; 32]) -> Result<bitcoin::ScriptBuf, ()> {
-        self.inner.get_destination_script(channel_keys_id)
+        self.destination_script(channel_keys_id)
     }
 
-    fn get_shutdown_scriptpubkey(&self) -> Result<lightning::ln::script::ShutdownScript, ()> {
-        self.inner.get_shutdown_scriptpubkey()
+    fn get_shutdown_scriptpubkey(&self) -> Result<ShutdownScript, ()> {
+        match self.wallet_script() {
+            Ok(script) => {
+                ShutdownScript::try_from(script).or_else(|_| self.inner.get_shutdown_scriptpubkey())
+            }
+            Err(()) => self.inner.get_shutdown_scriptpubkey(),
+        }
+    }
+}
+
+impl ChangeDestinationSource for LampoKeysManager {
+    async fn get_change_destination_script(&self) -> Result<bitcoin::ScriptBuf, ()> {
+        self.destination_script([0; 32])
     }
 }

--- a/lampo-common/src/types.rs
+++ b/lampo-common/src/types.rs
@@ -15,7 +15,9 @@ use crate::ldk::routing::scoring::{ProbabilisticScorer, ProbabilisticScoringFeeP
 use crate::ldk::sign::InMemorySigner;
 
 use crate::keys::LampoKeysManager;
+use crate::ldk::util::sweep::OutputSweeper;
 use crate::utils::logger::LampoLogger;
+use crate::wallet::LampoChangeDestination;
 
 pub type NodeId = PublicKey;
 pub type ChannelId = crate::ldk::ln::types::ChannelId;
@@ -43,6 +45,19 @@ pub type LampoArcChannelManager<M, L> = ChannelManager<
 >;
 
 pub type LampoChannel = LampoArcChannelManager<LampoChainMonitor, LampoLogger>;
+
+/// Tracks and sweeps spendable outputs of closed channels back into the
+/// on-chain wallet. Fed by `Event::SpendableOutputs`, driven by the
+/// background processor, and notified of blocks by the chain backend.
+pub type LampoSweeper = OutputSweeper<
+    Arc<dyn BroadcasterInterface + Send + Sync>,
+    Arc<LampoChangeDestination>,
+    Arc<dyn FeeEstimator + Send + Sync>,
+    Arc<dyn Filter + Send + Sync>,
+    Arc<FilesystemStore>,
+    Arc<LampoLogger>,
+    Arc<LampoKeysManager>,
+>;
 
 pub type LampoGraph = NetworkGraph<Arc<LampoLogger>>;
 pub type LampoScorer = ProbabilisticScorer<Arc<LampoGraph>, Arc<LampoLogger>>;

--- a/lampo-common/src/types.rs
+++ b/lampo-common/src/types.rs
@@ -17,7 +17,6 @@ use crate::ldk::sign::InMemorySigner;
 use crate::keys::LampoKeysManager;
 use crate::ldk::util::sweep::OutputSweeper;
 use crate::utils::logger::LampoLogger;
-use crate::wallet::LampoChangeDestination;
 
 pub type NodeId = PublicKey;
 pub type ChannelId = crate::ldk::ln::types::ChannelId;
@@ -51,7 +50,7 @@ pub type LampoChannel = LampoArcChannelManager<LampoChainMonitor, LampoLogger>;
 /// background processor, and notified of blocks by the chain backend.
 pub type LampoSweeper = OutputSweeper<
     Arc<dyn BroadcasterInterface + Send + Sync>,
-    Arc<LampoChangeDestination>,
+    Arc<LampoKeysManager>,
     Arc<dyn FeeEstimator + Send + Sync>,
     Arc<dyn Filter + Send + Sync>,
     Arc<FilesystemStore>,

--- a/lampo-common/src/wallet.rs
+++ b/lampo-common/src/wallet.rs
@@ -1,14 +1,16 @@
+use std::str::FromStr;
 use std::sync::Arc;
 
 use async_trait::async_trait;
 
 use crate::bitcoin::absolute::Height;
-use crate::bitcoin::{Amount, FeeRate};
+use crate::bitcoin::{Address, Amount, FeeRate, Network};
 use crate::bitcoin::{Block, BlockHash, ScriptBuf, Transaction};
 use crate::chainsync::ChainSyncCoordinator;
 use crate::conf::LampoConf;
 use crate::error;
 use crate::keys::LampoKeys;
+use crate::ldk::sign::ChangeDestinationSource;
 use crate::model::response::{NewAddress, Utxo};
 
 /// A lightweight reference to a block (height + hash). Pure `bitcoin` types,
@@ -89,4 +91,48 @@ pub trait WalletManager: Send + Sync {
     /// Run a task for wallet sync operation, this usually need to
     /// be run in a `tokio::spawn(wallet.listen())`.
     async fn listen(self: Arc<Self>) -> error::Result<()>;
+}
+
+/// [`ChangeDestinationSource`] backed by the node's on-chain wallet: swept
+/// channel outputs land on a fresh wallet address. Static outputs of a closed
+/// channel pay to scripts derived from the LDK keys manager, which this wallet
+/// does not track; only the sweeper can claim them back.
+pub struct LampoChangeDestination {
+    wallet: Arc<dyn WalletManager>,
+    network: Network,
+}
+
+impl LampoChangeDestination {
+    pub fn new(wallet: Arc<dyn WalletManager>, network: Network) -> Self {
+        Self { wallet, network }
+    }
+}
+
+impl ChangeDestinationSource for LampoChangeDestination {
+    async fn get_change_destination_script(&self) -> Result<ScriptBuf, ()> {
+        let addr = self.wallet.get_onchain_address().await.map_err(|err| {
+            log::error!(
+                target: "lampo-wallet",
+                "failed to get a change destination for the sweeper: {err}"
+            );
+        })?;
+        Address::from_str(&addr.address)
+            .map_err(|err| {
+                log::error!(
+                    target: "lampo-wallet",
+                    "sweeper change address `{}` is not a valid bitcoin address: {err}",
+                    addr.address
+                );
+            })?
+            .require_network(self.network)
+            .map_err(|err| {
+                log::error!(
+                    target: "lampo-wallet",
+                    "sweeper change address `{}` is not valid on {}: {err}",
+                    addr.address,
+                    self.network
+                );
+            })
+            .map(|addr| addr.script_pubkey())
+    }
 }

--- a/lampo-common/src/wallet.rs
+++ b/lampo-common/src/wallet.rs
@@ -1,16 +1,15 @@
-use std::str::FromStr;
 use std::sync::Arc;
 
 use async_trait::async_trait;
 
 use crate::bitcoin::absolute::Height;
-use crate::bitcoin::{Address, Amount, FeeRate, Network};
+use crate::bitcoin::psbt::Psbt;
+use crate::bitcoin::{Amount, FeeRate, OutPoint, TxOut, Txid};
 use crate::bitcoin::{Block, BlockHash, ScriptBuf, Transaction};
 use crate::chainsync::ChainSyncCoordinator;
 use crate::conf::LampoConf;
 use crate::error;
 use crate::keys::LampoKeys;
-use crate::ldk::sign::ChangeDestinationSource;
 use crate::model::response::{NewAddress, Utxo};
 
 /// A lightweight reference to a block (height + hash). Pure `bitcoin` types,
@@ -91,48 +90,30 @@ pub trait WalletManager: Send + Sync {
     /// Run a task for wallet sync operation, this usually need to
     /// be run in a `tokio::spawn(wallet.listen())`.
     async fn listen(self: Arc<Self>) -> error::Result<()>;
-}
 
-/// [`ChangeDestinationSource`] backed by the node's on-chain wallet: swept
-/// channel outputs land on a fresh wallet address. Static outputs of a closed
-/// channel pay to scripts derived from the LDK keys manager, which this wallet
-/// does not track; only the sweeper can claim them back.
-pub struct LampoChangeDestination {
-    wallet: Arc<dyn WalletManager>,
-    network: Network,
-}
-
-impl LampoChangeDestination {
-    pub fn new(wallet: Arc<dyn WalletManager>, network: Network) -> Self {
-        Self { wallet, network }
+    /// Next wallet-owned script. Used for LDK destination, shutdown, and
+    /// change so closed-channel funds land in this wallet.
+    fn next_wallet_script(&self) -> error::Result<ScriptBuf> {
+        error::bail!("wallet does not provide destination scripts")
     }
-}
 
-impl ChangeDestinationSource for LampoChangeDestination {
-    async fn get_change_destination_script(&self) -> Result<ScriptBuf, ()> {
-        let addr = self.wallet.get_onchain_address().await.map_err(|err| {
-            log::error!(
-                target: "lampo-wallet",
-                "failed to get a change destination for the sweeper: {err}"
-            );
-        })?;
-        Address::from_str(&addr.address)
-            .map_err(|err| {
-                log::error!(
-                    target: "lampo-wallet",
-                    "sweeper change address `{}` is not a valid bitcoin address: {err}",
-                    addr.address
-                );
-            })?
-            .require_network(self.network)
-            .map_err(|err| {
-                log::error!(
-                    target: "lampo-wallet",
-                    "sweeper change address `{}` is not valid on {}: {err}",
-                    addr.address,
-                    self.network
-                );
-            })
-            .map(|addr| addr.script_pubkey())
+    /// Whether `script` is a revealed address of this wallet.
+    fn is_mine(&self, _script: &ScriptBuf) -> bool {
+        false
+    }
+
+    /// Confirmed, spendable UTXOs this wallet can sign (anchor CPFP).
+    fn confirmed_utxos(&self) -> error::Result<Vec<(OutPoint, TxOut)>> {
+        Ok(Vec::new())
+    }
+
+    /// Full previous transaction for `txid`, if the wallet has it.
+    fn get_transaction(&self, _txid: Txid) -> error::Result<Option<Transaction>> {
+        Ok(None)
+    }
+
+    /// Sign every input in `psbt` that this wallet controls.
+    fn sign_psbt(&self, _psbt: Psbt) -> error::Result<Transaction> {
+        error::bail!("wallet does not sign PSBTs")
     }
 }

--- a/lampod/src/actions/handler.rs
+++ b/lampod/src/actions/handler.rs
@@ -3,10 +3,11 @@ use std::net::SocketAddr;
 use std::sync::Arc;
 
 use lampo_common::bitcoin::absolute::Height;
+use lampo_common::bitcoin::hashes::Hash;
+use lampo_common::bitcoin::{Amount, OutPoint, Transaction, WPubkeyHash};
 use tokio::sync::RwLock;
 
 use lampo_common::async_trait;
-use lampo_common::bitcoin::Amount;
 use lampo_common::chan;
 use lampo_common::error;
 use lampo_common::error::Ok;
@@ -17,11 +18,15 @@ use lampo_common::handler::ExternalHandler;
 use lampo_common::handler::Handler as EventHandler;
 use lampo_common::json;
 use lampo_common::jsonrpc::Request;
+use lampo_common::keys::LampoKeysManager;
 use lampo_common::ldk;
-use lampo_common::ldk::chain::chaininterface::{BroadcasterInterface, TransactionType};
-use lampo_common::ldk::sign::NodeSigner;
+use lampo_common::ldk::chain::chaininterface::BroadcasterInterface;
+use lampo_common::ldk::events::bump_transaction::BumpTransactionEventHandler;
+use lampo_common::ldk::sign::{NodeSigner, SpendableOutputDescriptor};
+use lampo_common::ldk::util::wallet_utils::{Utxo, Wallet, WalletSource};
 use lampo_common::model::response::PaymentHop;
 use lampo_common::model::response::PaymentState;
+use lampo_common::utils::logger::LampoLogger;
 
 use crate::chain::{FeeTarget, LampoChainManager, WalletManager};
 use crate::command::Command;
@@ -32,6 +37,50 @@ use crate::LampoDaemon;
 
 use super::Handler;
 
+/// Confirmed P2WPKH coins for LDK's bump handler (ldk-node `WalletSource`).
+struct BumpWallet(Arc<dyn WalletManager>);
+
+impl WalletSource for BumpWallet {
+    async fn list_confirmed_utxos(&self) -> Result<Vec<Utxo>, ()> {
+        let utxos = self.0.confirmed_utxos().map_err(|_| ())?;
+        std::result::Result::Ok(
+            utxos
+                .into_iter()
+                .filter_map(|(outpoint, output)| {
+                    if !output.script_pubkey.is_p2wpkh() {
+                        return None;
+                    }
+                    let wpkh =
+                        WPubkeyHash::from_slice(&output.script_pubkey.as_bytes()[2..]).ok()?;
+                    Some(Utxo::new_v0_p2wpkh(outpoint, output.value, &wpkh))
+                })
+                .collect(),
+        )
+    }
+
+    async fn get_prevtx(&self, outpoint: OutPoint) -> Result<Transaction, ()> {
+        self.0
+            .get_transaction(outpoint.txid)
+            .map_err(|_| ())?
+            .ok_or(())
+    }
+
+    async fn get_change_script(&self) -> Result<lampo_common::bitcoin::ScriptBuf, ()> {
+        self.0.next_wallet_script().map_err(|_| ())
+    }
+
+    async fn sign_psbt(&self, psbt: lampo_common::bitcoin::psbt::Psbt) -> Result<Transaction, ()> {
+        self.0.sign_psbt(psbt).map_err(|_| ())
+    }
+}
+
+type BumpHandler = BumpTransactionEventHandler<
+    Arc<dyn BroadcasterInterface + Send + Sync>,
+    Arc<Wallet<Arc<BumpWallet>, Arc<LampoLogger>>>,
+    Arc<LampoKeysManager>,
+    Arc<LampoLogger>,
+>;
+
 pub struct LampoHandler {
     channel_manager: Arc<LampoChannelManager>,
     peer_manager: Arc<LampoPeerManager>,
@@ -39,6 +88,7 @@ pub struct LampoHandler {
     wallet_manager: Arc<dyn WalletManager>,
     chain_manager: Arc<LampoChainManager>,
     persister: Arc<LampoPersistence>,
+    bump_tx_event_handler: BumpHandler,
     external_handlers: RwLock<Vec<Arc<dyn ExternalHandler>>>,
     #[allow(dead_code)]
     emitter: Emitter<Event>,
@@ -49,6 +99,16 @@ impl LampoHandler {
     pub(crate) fn new(lampod: &LampoDaemon) -> Self {
         let emitter = Emitter::default();
         let subscriber = emitter.subscriber();
+        let logger = lampod.logger();
+        let bump_tx_event_handler = BumpTransactionEventHandler::new(
+            lampod.onchain_manager().clone() as Arc<dyn BroadcasterInterface + Send + Sync>,
+            Arc::new(Wallet::new(
+                Arc::new(BumpWallet(lampod.wallet_manager())),
+                logger.clone(),
+            )),
+            lampod.wallet_manager().ldk_keys().keys_manager.clone(),
+            logger,
+        );
         Self {
             channel_manager: lampod.channel_manager(),
             peer_manager: lampod.peer_manager(),
@@ -56,6 +116,7 @@ impl LampoHandler {
             wallet_manager: lampod.wallet_manager(),
             chain_manager: lampod.onchain_manager(),
             persister: lampod.persister(),
+            bump_tx_event_handler,
             external_handlers: RwLock::new(Vec::new()),
             emitter,
             subscriber,
@@ -454,13 +515,29 @@ impl Handler for LampoHandler {
                     "tracking {} spendable output(s) from channel `{channel_id:?}` for sweeping",
                     outputs.len(),
                 );
-                // `exclude_static_outputs` must stay `false`: static outputs
-                // pay to scripts derived from the LDK keys manager, which the
-                // BDK on-chain wallet does not track. Only the sweeper can
-                // claim them.
+                // Skip static outputs the wallet already owns; keep delayed
+                // outputs and any leftover keys-manager statics for the sweeper.
+                let to_track = outputs
+                    .into_iter()
+                    .filter(|descriptor| match descriptor {
+                        SpendableOutputDescriptor::StaticOutput { output, .. } => {
+                            !self.wallet_manager.is_mine(&output.script_pubkey)
+                        }
+                        _ => true,
+                    })
+                    .collect::<Vec<_>>();
+                if to_track.is_empty() {
+                    return Ok(());
+                }
                 self.channel_manager
                     .sweeper()
-                    .track_spendable_outputs(outputs, channel_id, counterparty_node_id, false, None)
+                    .track_spendable_outputs(
+                        to_track,
+                        channel_id,
+                        counterparty_node_id,
+                        false,
+                        None,
+                    )
                     .await
                     .map_err(|_| {
                         error::anyhow!("failed to persist spendable outputs in the sweeper")
@@ -642,54 +719,8 @@ impl Handler for LampoHandler {
                 });
                 Ok(())
             }
-            ldk::events::Event::BumpTransaction(
-                ldk::events::bump_transaction::BumpTransactionEvent::ChannelClose {
-                    channel_id,
-                    counterparty_node_id,
-                    commitment_tx,
-                    pending_htlcs,
-                    ..
-                },
-            ) => {
-                // For anchor channels -- lampo's default channel type -- LDK
-                // does NOT broadcast the force-close commitment through the
-                // `BroadcasterInterface`. It hands the fully-signed holder
-                // commitment to the host inside this event and makes the host
-                // the sole broadcaster. The old catch-all `_` arm dropped it in
-                // a log line, so the channel balance stayed frozen on an
-                // unspent funding output with no recovery path. Broadcast it
-                // now so the funds can be swept once it confirms. A CPFP anchor
-                // child to fee-bump the (near zero-fee) commitment is still
-                // TODO, but the commitment must at least reach the mempool.
-                log::warn!(
-                    target: "lampo::handler",
-                    "channel `{channel_id}` with `{counterparty_node_id}` force-closed: \
-                     broadcasting local commitment tx `{}` ({} pending HTLC(s))",
-                    commitment_tx.compute_txid(),
-                    pending_htlcs.len(),
-                );
-                self.chain_manager.broadcast_transactions(&[(
-                    &commitment_tx,
-                    TransactionType::UnilateralClose {
-                        counterparty_node_id,
-                        channel_id,
-                    },
-                )]);
-                Ok(())
-            }
-            ldk::events::Event::BumpTransaction(
-                ldk::events::bump_transaction::BumpTransactionEvent::HTLCResolution { .. },
-            ) => {
-                // Zero-fee HTLC claims of anchor channels are likewise
-                // event-delivered and host-broadcast. Full anchor-fee handling
-                // is not implemented yet, so surface this loudly rather than
-                // silently dropping it: unresolved in-flight HTLCs can lose
-                // value once their CLTV deadlines pass.
-                log::error!(
-                    target: "lampo::handler",
-                    "unhandled BumpTransaction::HTLCResolution: in-flight HTLC claims need \
-                     manual broadcast to enforce CLTV deadlines"
-                );
+            ldk::events::Event::BumpTransaction(event) => {
+                self.bump_tx_event_handler.handle_event(&event).await;
                 Ok(())
             }
             _ => {

--- a/lampod/src/actions/handler.rs
+++ b/lampod/src/actions/handler.rs
@@ -444,6 +444,29 @@ impl Handler for LampoHandler {
                 // FIXME: make peristent these information
                 Ok(())
             }
+            ldk::events::Event::SpendableOutputs {
+                outputs,
+                channel_id,
+                counterparty_node_id,
+            } => {
+                log::info!(
+                    target: "lampo::handler",
+                    "tracking {} spendable output(s) from channel `{channel_id:?}` for sweeping",
+                    outputs.len(),
+                );
+                // `exclude_static_outputs` must stay `false`: static outputs
+                // pay to scripts derived from the LDK keys manager, which the
+                // BDK on-chain wallet does not track. Only the sweeper can
+                // claim them.
+                self.channel_manager
+                    .sweeper()
+                    .track_spendable_outputs(outputs, channel_id, counterparty_node_id, false, None)
+                    .await
+                    .map_err(|_| {
+                        error::anyhow!("failed to persist spendable outputs in the sweeper")
+                    })?;
+                Ok(())
+            }
             ldk::events::Event::PaymentSent {
                 payment_id,
                 payment_preimage,

--- a/lampod/src/chain/blockchain.rs
+++ b/lampod/src/chain/blockchain.rs
@@ -368,4 +368,12 @@ impl Backend for LampoChainManager {
     fn set_wallet_manager(&self, wallet: Arc<dyn WalletManager>) {
         self.backend.set_wallet_manager(wallet);
     }
+
+    fn set_sweeper(
+        &self,
+        best_block: lampo_common::ldk::chain::BlockLocator,
+        sweeper: Arc<lampo_common::types::LampoSweeper>,
+    ) {
+        self.backend.set_sweeper(best_block, sweeper);
+    }
 }

--- a/lampod/src/lib.rs
+++ b/lampod/src/lib.rs
@@ -81,6 +81,10 @@ impl LampoDaemon {
         // embedders) gets consistent sync-progress reporting with no per-caller
         // setup. The backend is wired separately in `init`.
         wallet_manager.set_coordinator(chain_sync.clone());
+        wallet_manager
+            .ldk_keys()
+            .keys_manager
+            .set_wallet(wallet_manager.clone());
         LampoDaemon {
             conf: config,
             logger: Arc::new(LampoLogger {}),
@@ -208,6 +212,10 @@ impl LampoDaemon {
 
     pub fn wallet_manager(&self) -> Arc<dyn WalletManager> {
         self.wallet_manager.clone()
+    }
+
+    pub fn logger(&self) -> Arc<LampoLogger> {
+        self.logger.clone()
     }
 
     pub fn init_event_handler(&mut self) -> error::Result<()> {

--- a/lampod/src/lib.rs
+++ b/lampod/src/lib.rs
@@ -29,7 +29,6 @@ use lampo_common::chainsync::ChainSyncCoordinator;
 use lampo_common::conf::LampoConf;
 use lampo_common::handler::ExternalHandler;
 use lampo_common::json;
-use lampo_common::keys::LampoKeysManager;
 use lampo_common::ldk::events::{Event, ReplayEvent};
 use lampo_common::ldk::io;
 use lampo_common::ldk::processor::{process_events_async, GossipSync, NO_LIQUIDITY_MANAGER};
@@ -48,34 +47,6 @@ use crate::utils::logger::LampoLogger;
 
 pub(crate) type P2PGossipSync =
     ldk::routing::gossip::P2PGossipSync<Arc<LampoGraph>, Arc<LampoChainManager>, Arc<LampoLogger>>;
-
-/// No-op [`ChangeDestinationSource`] used only to *name* the `OutputSweeper`
-/// type when passing `sweeper: None` to the background processor. Lampo does
-/// not run an output sweeper, so this is never constructed or called.
-///
-/// [`ChangeDestinationSource`]: lampo_common::ldk::sign::ChangeDestinationSource
-struct NoChangeDestinationSource;
-
-impl ldk::sign::ChangeDestinationSource for NoChangeDestinationSource {
-    fn get_change_destination_script<'a>(
-        &'a self,
-    ) -> impl std::future::Future<Output = Result<lampo_common::bitcoin::ScriptBuf, ()>> + Send + 'a
-    {
-        std::future::ready(Err(()))
-    }
-}
-
-/// Concrete `OutputSweeper` type matching lampo's chain-monitor wiring, used
-/// solely to type the `None` sweeper argument to [`process_events_async`].
-type LampoSweeper = ldk::util::sweep::OutputSweeper<
-    Arc<dyn ldk::chain::chaininterface::BroadcasterInterface + Send + Sync>,
-    Arc<NoChangeDestinationSource>,
-    Arc<dyn ldk::chain::chaininterface::FeeEstimator + Send + Sync>,
-    Arc<dyn ldk::chain::Filter + Send + Sync>,
-    Arc<LampoPersistence>,
-    Arc<LampoLogger>,
-    LampoKeysManager,
->;
 
 /// LampoDaemon is the main data structure that uses the facade
 /// pattern to hide the complexity of the LDK library. You can interact
@@ -267,6 +238,10 @@ impl LampoDaemon {
         client.set_chain_monitor(self.channel_manager().chain_monitor());
         client.set_coordinator(self.chain_sync());
         client.set_wallet_manager(self.wallet_manager());
+        client.set_sweeper(
+            self.channel_manager().sweeper_best_block(),
+            self.channel_manager().sweeper(),
+        );
         self.channel_manager().set_handler(self.handler());
         Ok(())
     }
@@ -328,7 +303,7 @@ impl LampoDaemon {
                 GossipSync::p2p(gossip_sync),
                 self.peer_manager().manager(),
                 NO_LIQUIDITY_MANAGER,
-                None::<Arc<LampoSweeper>>,
+                Some(self.channel_manager().sweeper()),
                 self.logger.clone(),
                 Some(self.channel_manager().scorer()),
                 |d| {
@@ -367,9 +342,18 @@ impl LampoDaemon {
         })
     }
 
-    // FIXME: what about replay event?
+    // Only `SpendableOutputs` is replayed on failure: dropping it would
+    // lose the descriptors needed to claim closed-channel funds on-chain.
+    // Other handlers can fail permanently (peer disconnected, wallet
+    // without funds); LDK keeps a failed event at the head of the queue,
+    // so replaying those would block every later event forever.
     async fn handler_ldk_events(&self, env: Event) -> Result<(), ReplayEvent> {
+        let replay_on_failure = matches!(env, Event::SpendableOutputs { .. });
         if let Err(err) = self.handler().handle(env).await {
+            if replay_on_failure {
+                log::error!(target: "lampod", "Error handling event, will replay it: {:?}", err);
+                return Err(ReplayEvent());
+            }
             log::error!(target: "lampod", "Error handling event: {:?}", err);
         }
         Ok(())

--- a/lampod/src/ln/channel_manager.rs
+++ b/lampod/src/ln/channel_manager.rs
@@ -43,7 +43,6 @@ use lampo_common::types::LampoRouter;
 use lampo_common::types::LampoScorer;
 use lampo_common::types::LampoSweeper;
 use lampo_common::types::{ChannelId, LampoArcChannelManager, LampoChainMonitor};
-use lampo_common::wallet::LampoChangeDestination;
 
 use crate::actions::handler::LampoHandler;
 use crate::async_run;
@@ -188,37 +187,60 @@ impl LampoChannelManager {
         Ok(())
     }
 
-    /// Build the [`LampoSweeper`], restoring its persisted state (tracked
-    /// spendable outputs and best block) when present.
-    fn init_sweeper(&self) -> error::Result<()> {
-        let broadcaster = self.onchain.clone() as Arc<dyn BroadcasterInterface + Send + Sync>;
-        let fee_estimator = self.onchain.clone() as Arc<dyn FeeEstimator + Send + Sync>;
-        let change_destination = Arc::new(LampoChangeDestination::new(
-            self.wallet_manager.clone(),
-            self.conf.network,
-        ));
-        let spender = self.wallet_manager.ldk_keys().keys_manager.clone();
+    /// Broadcaster, fee estimator, and keys manager shared by restore and
+    /// first-time sweeper construction. Spender and change destination are
+    /// the same keys manager, as in ldk-node.
+    fn sweeper_deps(
+        &self,
+    ) -> (
+        Arc<dyn BroadcasterInterface + Send + Sync>,
+        Arc<dyn FeeEstimator + Send + Sync>,
+        Arc<LampoKeysManager>,
+    ) {
+        (
+            self.onchain.clone(),
+            self.onchain.clone(),
+            self.wallet_manager.ldk_keys().keys_manager.clone(),
+        )
+    }
 
-        let state = KVStoreSync::read(
+    /// Restore a previously persisted [`LampoSweeper`], including its tracked
+    /// outputs and last synced block.
+    fn restore_sweeper(
+        &self,
+        bytes: Vec<u8>,
+        broadcaster: Arc<dyn BroadcasterInterface + Send + Sync>,
+        fee_estimator: Arc<dyn FeeEstimator + Send + Sync>,
+        keys_manager: Arc<LampoKeysManager>,
+    ) -> error::Result<(BlockLocator, LampoSweeper)> {
+        // ReadableArgs order: broadcaster, fee estimator, filter, spender,
+        // change destination, kv store, logger.
+        <(BlockLocator, LampoSweeper)>::read(
+            &mut std::io::Cursor::new(bytes),
+            (
+                broadcaster,
+                fee_estimator,
+                None,
+                keys_manager.clone(),
+                keys_manager,
+                self.persister.clone(),
+                self.logger.clone(),
+            ),
+        )
+        .map_err(|err| error::anyhow!("failed to read the sweeper state: {err}"))
+    }
+
+    /// Build the [`LampoSweeper`], restoring its persisted state when present.
+    fn init_sweeper(&self) -> error::Result<()> {
+        let (broadcaster, fee_estimator, keys_manager) = self.sweeper_deps();
+        let persisted = KVStoreSync::read(
             &*self.persister,
             OUTPUT_SWEEPER_PERSISTENCE_PRIMARY_NAMESPACE,
             OUTPUT_SWEEPER_PERSISTENCE_SECONDARY_NAMESPACE,
             OUTPUT_SWEEPER_PERSISTENCE_KEY,
         );
-        let (best_block, sweeper) = match state {
-            Ok(bytes) => <(BlockLocator, LampoSweeper)>::read(
-                &mut std::io::Cursor::new(bytes),
-                (
-                    broadcaster,
-                    fee_estimator,
-                    None,
-                    spender,
-                    change_destination,
-                    self.persister.clone(),
-                    self.logger.clone(),
-                ),
-            )
-            .map_err(|err| error::anyhow!("failed to read the sweeper state: {err}"))?,
+        let (best_block, sweeper) = match persisted {
+            Ok(bytes) => self.restore_sweeper(bytes, broadcaster, fee_estimator, keys_manager)?,
             Err(err) if err.kind() == lampo_common::ldk::io::ErrorKind::NotFound => {
                 let best_block = self.manager().current_best_block();
                 let sweeper = OutputSweeper::new(
@@ -226,8 +248,8 @@ impl LampoChannelManager {
                     broadcaster,
                     fee_estimator,
                     None,
-                    spender,
-                    change_destination,
+                    keys_manager.clone(),
+                    keys_manager,
                     self.persister.clone(),
                     self.logger.clone(),
                 );

--- a/lampod/src/ln/channel_manager.rs
+++ b/lampod/src/ln/channel_manager.rs
@@ -29,15 +29,21 @@ use lampo_common::ldk::routing::scoring::{
     ProbabilisticScorer, ProbabilisticScoringDecayParameters, ProbabilisticScoringFeeParameters,
 };
 use lampo_common::ldk::sign::{InMemorySigner, NodeSigner};
-use lampo_common::ldk::util::persist::read_channel_monitors;
+use lampo_common::ldk::util::persist::{
+    read_channel_monitors, KVStoreSync, OUTPUT_SWEEPER_PERSISTENCE_KEY,
+    OUTPUT_SWEEPER_PERSISTENCE_PRIMARY_NAMESPACE, OUTPUT_SWEEPER_PERSISTENCE_SECONDARY_NAMESPACE,
+};
 use lampo_common::ldk::util::ser::ReadableArgs;
+use lampo_common::ldk::util::sweep::OutputSweeper;
 use lampo_common::model::request;
 use lampo_common::model::response::{self, Channel, Channels};
 use lampo_common::types::LampoChannel;
 use lampo_common::types::LampoGraph;
 use lampo_common::types::LampoRouter;
 use lampo_common::types::LampoScorer;
+use lampo_common::types::LampoSweeper;
 use lampo_common::types::{ChannelId, LampoArcChannelManager, LampoChainMonitor};
+use lampo_common::wallet::LampoChangeDestination;
 
 use crate::actions::handler::LampoHandler;
 use crate::async_run;
@@ -72,6 +78,10 @@ pub struct LampoChannelManager {
     router: OnceLock<Arc<LampoRouter>>,
     /// Shared with the event handler; see [`FundingWaitState`].
     funding_wait_state: Mutex<HashMap<ChannelId, FundingWaitState>>,
+    /// Restored (or freshly created) output sweeper, paired with the best
+    /// block its persisted state was last synced to so the chain backend can
+    /// catch it up independently of the channel manager.
+    sweeper: OnceLock<(BlockLocator, Arc<LampoSweeper>)>,
 
     pub(crate) onchain: Arc<LampoChainManager>,
     pub(crate) conf: LampoConf,
@@ -100,6 +110,7 @@ impl LampoChannelManager {
             score: OnceLock::new(),
             router: OnceLock::new(),
             funding_wait_state: Mutex::new(HashMap::new()),
+            sweeper: OnceLock::new(),
         }
     }
 
@@ -173,7 +184,77 @@ impl LampoChannelManager {
         } else {
             self.start().await?;
         }
+        self.init_sweeper()?;
         Ok(())
+    }
+
+    /// Build the [`LampoSweeper`], restoring its persisted state (tracked
+    /// spendable outputs and best block) when present.
+    fn init_sweeper(&self) -> error::Result<()> {
+        let broadcaster = self.onchain.clone() as Arc<dyn BroadcasterInterface + Send + Sync>;
+        let fee_estimator = self.onchain.clone() as Arc<dyn FeeEstimator + Send + Sync>;
+        let change_destination = Arc::new(LampoChangeDestination::new(
+            self.wallet_manager.clone(),
+            self.conf.network,
+        ));
+        let spender = self.wallet_manager.ldk_keys().keys_manager.clone();
+
+        let state = KVStoreSync::read(
+            &*self.persister,
+            OUTPUT_SWEEPER_PERSISTENCE_PRIMARY_NAMESPACE,
+            OUTPUT_SWEEPER_PERSISTENCE_SECONDARY_NAMESPACE,
+            OUTPUT_SWEEPER_PERSISTENCE_KEY,
+        );
+        let (best_block, sweeper) = match state {
+            Ok(bytes) => <(BlockLocator, LampoSweeper)>::read(
+                &mut std::io::Cursor::new(bytes),
+                (
+                    broadcaster,
+                    fee_estimator,
+                    None,
+                    spender,
+                    change_destination,
+                    self.persister.clone(),
+                    self.logger.clone(),
+                ),
+            )
+            .map_err(|err| error::anyhow!("failed to read the sweeper state: {err}"))?,
+            Err(err) if err.kind() == lampo_common::ldk::io::ErrorKind::NotFound => {
+                let best_block = self.manager().current_best_block();
+                let sweeper = OutputSweeper::new(
+                    best_block.clone(),
+                    broadcaster,
+                    fee_estimator,
+                    None,
+                    spender,
+                    change_destination,
+                    self.persister.clone(),
+                    self.logger.clone(),
+                );
+                (best_block, sweeper)
+            }
+            Err(err) => error::bail!("failed to read the sweeper state: {err}"),
+        };
+        self.sweeper
+            .set((best_block, Arc::new(sweeper)))
+            .unwrap_or_else(|_| panic!("sweeper already initialized"));
+        Ok(())
+    }
+
+    pub fn sweeper(&self) -> Arc<LampoSweeper> {
+        self.sweeper
+            .get()
+            .expect("sweeper not initialized")
+            .1
+            .clone()
+    }
+
+    pub fn sweeper_best_block(&self) -> BlockLocator {
+        self.sweeper
+            .get()
+            .expect("sweeper not initialized")
+            .0
+            .clone()
     }
 
     fn build_channel_monitor(&self) -> LampoChainMonitor {

--- a/tests/tests/src/lampo_tests.rs
+++ b/tests/tests/src/lampo_tests.rs
@@ -547,13 +547,10 @@ pub async fn decode_offer_hex() -> error::Result<()> {
     Ok(())
 }
 
-/// After a channel closes, the funds return to a script derived from the
-/// LDK keys manager, which the on-chain BDK wallet does not track. The
-/// only way the node ever sees that money again is the output sweeper
-/// picking up `Event::SpendableOutputs` and sweeping it back into the
-/// wallet. Without the sweeper this test times out with the wallet
-/// balance stuck at its post-funding value: the closed channel's funds
-/// are lost. GHSA-pw22-mxxj-rvgh.
+/// After a channel closes, funds return to a wallet-owned destination
+/// script (and delayed outputs through the sweeper). Without that wiring
+/// this test times out with the wallet stuck at its post-funding value.
+/// GHSA-pw22-mxxj-rvgh.
 #[tokio_test_shutdown_timeout::test(10)]
 pub async fn sweep_funds_after_channel_close() -> error::Result<()> {
     init();

--- a/tests/tests/src/lampo_tests.rs
+++ b/tests/tests/src/lampo_tests.rs
@@ -546,3 +546,72 @@ pub async fn decode_offer_hex() -> error::Result<()> {
     log::info!(target: &node1.info.node_id, "Payment completed successfully: {:?}", pay);
     Ok(())
 }
+
+/// After a channel closes, the funds return to a script derived from the
+/// LDK keys manager, which the on-chain BDK wallet does not track. The
+/// only way the node ever sees that money again is the output sweeper
+/// picking up `Event::SpendableOutputs` and sweeping it back into the
+/// wallet. Without the sweeper this test times out with the wallet
+/// balance stuck at its post-funding value: the closed channel's funds
+/// are lost. GHSA-pw22-mxxj-rvgh.
+#[tokio_test_shutdown_timeout::test(10)]
+pub async fn sweep_funds_after_channel_close() -> error::Result<()> {
+    init();
+    let node1 = LampoTesting::tmp().await?;
+    let btc = node1.btc.clone();
+    let node2 = Arc::new(LampoTesting::new(btc.clone()).await?);
+
+    const CHANNEL_SAT: u64 = 1_000_000;
+    node1.fund_channel_with(node2.clone(), CHANNEL_SAT).await?;
+
+    // The sweep lands as a fresh wallet UTXO worth the channel balance
+    // minus close and sweep fees, i.e. somewhere in (CHANNEL_SAT / 2,
+    // CHANNEL_SAT). Nothing else in this test produces an output in that
+    // range: coinbases are ~50 BTC and the funding change is far larger.
+    let in_sweep_range = |utxo: &response::Utxo| {
+        let sat = utxo.amount_msat / 1000;
+        sat > CHANNEL_SAT / 2 && sat < CHANNEL_SAT
+    };
+    let funds: response::Utxos = node1.lampod().call("funds", json::json!({})).await?;
+    assert!(
+        !funds.transactions.iter().any(in_sweep_range),
+        "no sweep-sized utxo should exist before the close: {funds:?}"
+    );
+
+    let close: response::CloseChannel = node1
+        .lampod()
+        .call(
+            "close",
+            request::CloseChannel {
+                node_id: node2.info.node_id.clone(),
+                channel_id: None,
+            },
+        )
+        .await?;
+    log::info!(target: &node1.info.node_id, "channel closed: {close:?}");
+
+    // The closing transaction needs to confirm (plus LDK's anti-reorg
+    // delay of 6 blocks) before SpendableOutputs fires; the sweeper then
+    // broadcasts on the background processor's 30s timer and the sweep
+    // itself needs a confirmation. Keep mining and give it time.
+    async_wait!(
+        async {
+            node1.fund_wallet(2).await.unwrap();
+            tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+            let funds: response::Utxos =
+                node1.lampod().call("funds", json::json!({})).await.unwrap();
+            log::info!(
+                target: &node1.info.node_id,
+                "waiting for the sweep to land: {} utxos",
+                funds.transactions.len()
+            );
+            if funds.transactions.iter().any(in_sweep_range) {
+                Ok(())
+            } else {
+                Err(())
+            }
+        },
+        10
+    );
+    Ok(())
+}


### PR DESCRIPTION
## Summary

- Reproduces [GHSA-pw22-mxxj-rvgh](https://github.com/vincenzopalazzo/lampo.rs/security/advisories/GHSA-pw22-mxxj-rvgh): after a channel close, LDK emits `Event::SpendableOutputs` for scripts the BDK wallet does not track. Lampo ACKed that event in the catch-all and passed `sweeper: None` to `process_events_async`, so closed-channel funds never returned on-chain.
- `node: Sweep spendable outputs of closed channels` — wire LDK `OutputSweeper`, persist/restore across restarts, and drive it from chain sync (including facade `set_sweeper` forwarding).
- `node: Pay channel closes into the wallet` — match ldk-node: wallet-owned destination/shutdown scripts, `BumpTransaction` via `WalletSource` CPFP, durable BDK persist in private-key mode, and KeysManager fallback when `next_wallet_script` is missing.

## Test plan

- [x] `cargo test -p tests sweep_funds_after_channel_close` — funds a channel, closes it, mines through the anti-reorg delay, and waits until a sweep-sized UTXO appears in `funds`.
- [ ] CI integration suite after history cleanup